### PR TITLE
Script for pushing images to ECR

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 ## Overview
 
-This repository contains the Docker Images that [Amazon MWAA](https://aws.amazon.com/managed-workflows-for-apache-airflow/)
-will use in future versions of Airflow. Eventually, we will deprecate [aws-mwaa-local-runner](https://github.com/aws/aws-mwaa-local-runner)
-in favour of this package. However, at this point, this repository is still under development.
+This repository contains the Docker Images that [Amazon
+MWAA](https://aws.amazon.com/managed-workflows-for-apache-airflow/) will use in future versions of
+Airflow. Eventually, we will deprecate
+[aws-mwaa-local-runner](https://github.com/aws/aws-mwaa-local-runner) in favour of this package.
+However, at this point, this repository is still under development.
 
 ## Using the Airflow Image
 
@@ -13,20 +15,34 @@ Currently, Airflow v2.9.0 is supported. Future versions in parity with Amazon MW
 To experiment with the image using a vanilla Docker setup, follow these steps:
 
 0. Ensure you have:
-    - Python 3.11 or later.
-    - Docker and Docker Compose.
+   - Python 3.11 or later.
+   - Docker and Docker Compose.
 1. Clone this repository.
-2. This repository makes use of Python virtual environments. To create them, from the root of the package, execute the following command:
+2. This repository makes use of Python virtual environments. To create them, from the root of the
+   package, execute the following command:
+
 ```
 python3 create_venvs.py
 ```
+
 3. Build the Airflow v2.9.0 Docker image using:
+
 ```
-cd <amazon-mwaa-docker-images path>/images/airflow/2.9.0 
+cd <amazon-mwaa-docker-images path>/images/airflow/2.9.0
 ./run.sh
 ```
 
 Airflow should be up and running now. You can access the web server on your localhost on port 8080.
+
+Optionally, if you also want to publish the image to ECR, you can execute the following command:
+
+```
+./push_to_ecr.sh
+```
+
+Notice that this command requires you to have valid AWS credentials in your `~/.aws/credentials`
+file or environment variables, and that the credentials you use have the necessary permissions to
+create an ECR repository and push a Docker image.
 
 ## Security
 

--- a/images/airflow/2.9.0/Dockerfile.base.j2
+++ b/images/airflow/2.9.0/Dockerfile.base.j2
@@ -92,6 +92,7 @@ RUN rm -rf /bootstrap
 # is created by the `001-create-mwaa-dir.sh` script.
 VOLUME ["${MWAA_HOME}"]
 
+# Expose the web server port
 # TODO We should only expose this port if the command is 'webserver'.
 EXPOSE 8080
 

--- a/images/airflow/2.9.0/Dockerfile.derivatives.j2
+++ b/images/airflow/2.9.0/Dockerfile.derivatives.j2
@@ -1,4 +1,4 @@
-FROM amazon-mwaa/airflow:2.9.0-base
+FROM amazon-mwaa-docker-images/airflow:2.9.0-base
 
 {% if bootstrapping_scripts_dev %}
 

--- a/images/airflow/2.9.0/Dockerfiles/Dockerfile
+++ b/images/airflow/2.9.0/Dockerfiles/Dockerfile
@@ -3,10 +3,10 @@
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on 2024-04-19 02:30:48.359587
+# This file was generated on 2024-04-25 22:57:09.614456
 #
 
-FROM amazon-mwaa/airflow:2.9.0-base
+FROM amazon-mwaa-docker-images/airflow:2.9.0-base
 
 USER airflow
 

--- a/images/airflow/2.9.0/Dockerfiles/Dockerfile-dev
+++ b/images/airflow/2.9.0/Dockerfiles/Dockerfile-dev
@@ -3,10 +3,10 @@
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on 2024-04-19 02:30:48.351336
+# This file was generated on 2024-04-25 22:57:09.605710
 #
 
-FROM amazon-mwaa/airflow:2.9.0-base
+FROM amazon-mwaa-docker-images/airflow:2.9.0-base
 
 # Copy bootstrapping files.
 COPY ./bootstrap-dev /bootstrap-dev

--- a/images/airflow/2.9.0/Dockerfiles/Dockerfile-explorer
+++ b/images/airflow/2.9.0/Dockerfiles/Dockerfile-explorer
@@ -3,10 +3,10 @@
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on 2024-04-19 02:30:48.362267
+# This file was generated on 2024-04-25 22:57:09.617236
 #
 
-FROM amazon-mwaa/airflow:2.9.0-base
+FROM amazon-mwaa-docker-images/airflow:2.9.0-base
 
 USER airflow
 

--- a/images/airflow/2.9.0/Dockerfiles/Dockerfile-explorer-dev
+++ b/images/airflow/2.9.0/Dockerfiles/Dockerfile-explorer-dev
@@ -3,10 +3,10 @@
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on 2024-04-19 02:30:48.354110
+# This file was generated on 2024-04-25 22:57:09.608674
 #
 
-FROM amazon-mwaa/airflow:2.9.0-base
+FROM amazon-mwaa-docker-images/airflow:2.9.0-base
 
 # Copy bootstrapping files.
 COPY ./bootstrap-dev /bootstrap-dev

--- a/images/airflow/2.9.0/Dockerfiles/Dockerfile-explorer-privileged
+++ b/images/airflow/2.9.0/Dockerfiles/Dockerfile-explorer-privileged
@@ -3,10 +3,10 @@
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on 2024-04-19 02:30:48.364902
+# This file was generated on 2024-04-25 22:57:09.620060
 #
 
-FROM amazon-mwaa/airflow:2.9.0-base
+FROM amazon-mwaa-docker-images/airflow:2.9.0-base
 
 USER root
 

--- a/images/airflow/2.9.0/Dockerfiles/Dockerfile-explorer-privileged-dev
+++ b/images/airflow/2.9.0/Dockerfiles/Dockerfile-explorer-privileged-dev
@@ -3,10 +3,10 @@
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on 2024-04-19 02:30:48.356865
+# This file was generated on 2024-04-25 22:57:09.611579
 #
 
-FROM amazon-mwaa/airflow:2.9.0-base
+FROM amazon-mwaa-docker-images/airflow:2.9.0-base
 
 # Copy bootstrapping files.
 COPY ./bootstrap-dev /bootstrap-dev

--- a/images/airflow/2.9.0/Dockerfiles/Dockerfile.base
+++ b/images/airflow/2.9.0/Dockerfiles/Dockerfile.base
@@ -3,7 +3,7 @@
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on 2024-04-19 02:30:48.348008
+# This file was generated on 2024-04-25 22:57:09.602276
 #
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
@@ -104,6 +104,7 @@ RUN rm -rf /bootstrap
 # is created by the `001-create-mwaa-dir.sh` script.
 VOLUME ["${MWAA_HOME}"]
 
+# Expose the web server port
 # TODO We should only expose this port if the command is 'webserver'.
 EXPOSE 8080
 

--- a/images/airflow/2.9.0/build.sh
+++ b/images/airflow/2.9.0/build.sh
@@ -8,13 +8,13 @@ python3 ../generate-dockerfiles.py
 deactivate
 
 # Build the base image.
-docker build -f ./Dockerfiles/Dockerfile.base -t amazon-mwaa/airflow:2.9.0-base ./
+docker build -f ./Dockerfiles/Dockerfile.base -t amazon-mwaa-docker-images/airflow:2.9.0-base ./
 
 # Build the derivatives.
 for dev in "True" "False"; do
     for build_type in "standard" "explorer" "explorer-privileged"; do
         dockerfile_name="Dockerfile"
-        tag_name="amazon-mwaa/airflow:2.9.0"
+        tag_name="amazon-mwaa-docker-images/airflow:2.9.0"
 
         if [[ "$build_type" != "standard" ]]; then
             dockerfile_name="${dockerfile_name}-${build_type}"

--- a/images/airflow/2.9.0/docker-compose.yaml
+++ b/images/airflow/2.9.0/docker-compose.yaml
@@ -1,14 +1,16 @@
 version: "3.8"
 
 x-airflow-common: &airflow-common
-  image: amazon-mwaa/airflow:2.9.0
+  image: amazon-mwaa-docker-images/airflow:2.9.0
   restart: always
   environment:
+    # AWS credentials
     AWS_ACCESS_KEY_ID: "FAKE_AWS_ACCESS_KEY_ID"
     AWS_SECRET_ACCESS_KEY: "FAKE_AWS_SECRET_ACCESS_KEY"
     AWS_SESSION_TOKEN: "FAKE_AWS_SESSION_TOKEN"
     AWS_REGION: "us-west-2"
     AWS_DEFAULT_REGION: "us-west-2"
+
     # Core configuration
     MWAA__CORE__REQUIREMENTS_PATH: "/usr/local/airflow/requirements/requirements.txt"
 

--- a/images/airflow/2.9.0/push_to_ecr.sh
+++ b/images/airflow/2.9.0/push_to_ecr.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+# Build the Docker image
+./build.sh
+
+# Constants
+AWS_REGION=us-west-2
+REPO_NAME=amazon-mwaa-docker-images
+
+# Create the ECR repository if it doesn't already exist.
+if ! aws ecr describe-repositories --repository-names ${REPO_NAME} --region ${AWS_REGION} > /dev/null 2>&1 ; then
+    echo "Repository does not exist. Creating repository..."
+    aws ecr create-repository --repository-name ${REPO_NAME} --region ${AWS_REGION}
+    echo "Repository created."
+else
+    echo "Repository ${REPO_NAME} already exists."
+fi
+
+# Construct the ECR URI.
+account_id=$(aws sts get-caller-identity --query Account --output text)
+ecr_uri="${account_id}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}"
+
+# Authenticate Docker to the ECR registry
+aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${ecr_uri}"
+
+for dev in "True" "False"; do
+    for build_type in "standard" "explorer" "explorer-privileged"; do
+        tag_name="amazon-mwaa-docker-images/airflow:2.9.0"
+        target_tag_name="${ecr_uri}:airflow-2.9.0"
+
+        if [[ "$build_type" != "standard" ]]; then
+            tag_name="${tag_name}-${build_type}"
+            target_tag_name="${target_tag_name}-${build_type}"
+        fi
+
+        if [[ "$dev" == "True" ]]; then
+            tag_name="${tag_name}-dev"
+            target_tag_name="${target_tag_name}-dev"
+        fi
+
+        docker image tag "${tag_name}" "${target_tag_name}"
+        docker push "${target_tag_name}"
+        echo "Docker image ${target_tag_name} has been pushed to ECR"
+    done
+done


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

To help with development on AWS, I created a script for pushing the images to ECR. This can be used internally by Amazon MWAA developers to test the images on Amazon MWAA, but also externally by users who want to deploy the image on ECR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
