### PR TITLE
fix: checking for empty string log_group_arn 

### DIFF
--- a/images/airflow/2.9.1/python/mwaa/logging/config.py
+++ b/images/airflow/2.9.1/python/mwaa/logging/config.py
@@ -70,7 +70,7 @@ def _get_mwaa_logging_env_vars(source: str):
 
 def _configure_task_logging():
     log_group_arn, log_level, logging_enabled = _get_mwaa_logging_env_vars("task")
-    if log_group_arn is not None:
+    if log_group_arn:
         # Setup CloudWatch logging.
         LOGGING_CONFIG["handlers"]["task"] = {
             "class": _qualified_name(cloudwatch_handlers.TaskLogHandler),
@@ -92,7 +92,7 @@ def _configure_dag_processing_logging():
     log_group_arn, log_level, logging_enabled = _get_mwaa_logging_env_vars(
         "dagprocessor"
     )
-    if log_group_arn is not None:
+    if log_group_arn:
         # Setup CloudWatch logging for DAG Processor Manager.
         LOGGING_CONFIG["handlers"]["processor_manager"] = {
             "class": _qualified_name(cloudwatch_handlers.DagProcessorManagerLogHandler),
@@ -132,7 +132,7 @@ def _configure_subprocesses_logging(
 ):
     logger_name = MWAA_LOGGERS[subprocess_name.lower()]
     handler_name = logger_name.replace(".", "_")
-    if log_group_arn is not None:
+    if log_group_arn:
         LOGGING_CONFIG["handlers"][handler_name] = {
             "class": _qualified_name(cloudwatch_handlers.SubprocessLogHandler),
             "formatter": "airflow",


### PR DESCRIPTION
*Issue #, if available:*
When the `MWAA__LOGGING__AIRFLOW_*_LOG_GROUP_ARN` are set to empty strings, the logging configs are unable to parse them. This results in the following error:

```shell
mwaa-280-webserver  | CloudWatch logging is disabled for SubprocessLogHandler
mwaa-280-webserver  | Traceback (most recent call last):
mwaa-280-webserver  |   File "/python/mwaa/logging/utils.py", line 19, in parse_arn
mwaa-280-webserver  |     log_group = split_arn[6]
mwaa-280-webserver  |                 ~~~~~~~~~^^^
mwaa-280-webserver  | IndexError: list index out of range
mwaa-280-webserver  |
mwaa-280-webserver  | The above exception was the direct cause of the following exception:
mwaa-280-webserver  |
mwaa-280-webserver  | Traceback (most recent call last):
mwaa-280-webserver  |   File "/usr/local/lib/python3.11/logging/config.py", line 573, in configure
mwaa-280-webserver  |     handler = self.configure_handler(handlers[name])
mwaa-280-webserver  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mwaa-280-webserver  |   File "/usr/local/lib/python3.11/logging/config.py", line 757, in configure_handler
mwaa-280-webserver  |     result = factory(**kwargs)
mwaa-280-webserver  |              ^^^^^^^^^^^^^^^^^
mwaa-280-webserver  |   File "/python/mwaa/logging/cloudwatch_handlers.py", line 428, in __init__
mwaa-280-webserver  |     super().__init__(log_group_arn, kms_key_arn, enabled)
mwaa-280-webserver  |   File "/python/mwaa/logging/cloudwatch_handlers.py", line 59, in __init__
mwaa-280-webserver  |     self.log_group_name, self.region_name = parse_arn(log_group_arn)
mwaa-280-webserver  |                                             ^^^^^^^^^^^^^^^^^^^^^^^^
mwaa-280-webserver  |   File "/python/mwaa/logging/utils.py", line 24, in parse_arn
mwaa-280-webserver  |     raise RuntimeError(f"Invalid log group ARN: {log_group_arn}") from ex
mwaa-280-webserver  | RuntimeError: Invalid log group ARN:
```

*Description of changes:*
This PR changes the null check for the arn to `if log_group_arn`, so that if `log_group_arn = ""`, it will not pass the check and we will not set up logging.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
