### PR TITLE
 Optional integration with IAM via MWAA IAM plugin

### DIFF
--- a/images/airflow/2.9.1/docker-compose.yaml
+++ b/images/airflow/2.9.1/docker-compose.yaml
@@ -16,6 +16,7 @@ x-airflow-common: &airflow-common
     # Use this environment variable if you have custom requirements you want to install when the
     # container is up.
     MWAA__CORE__REQUIREMENTS_PATH: ${MWAA__CORE__REQUIREMENTS_PATH}
+    MWAA__CORE__AUTH_TYPE: "simple"
     # Use this enviornment variable to enable encryption with KMS.
     MWAA__CORE__KMS_KEY_ARN: ${MWAA__CORE__KMS_KEY_ARN}
 

--- a/images/airflow/2.9.1/python/mwaa/config/airflow.py
+++ b/images/airflow/2.9.1/python/mwaa/config/airflow.py
@@ -90,6 +90,17 @@ def get_airflow_scheduler_config() -> Dict[str, str]:
     }
 
 
+def get_airflow_webserver_config() -> Dict[str, str]:
+    """
+    Retrieve the environment variables for Airflow's "webserver" configuration section.
+
+    :returns A dictionary containing the environment variables.
+    """
+    return {
+        "AIRFLOW__WEBSERVER__CONFIG_FILE": "/python/mwaa/webserver/webserver_config.py",
+    }
+
+
 def get_airflow_config() -> Dict[str, str]:
     """
     Retrieve the environment variables required to set Airflow configurations.
@@ -103,4 +114,5 @@ def get_airflow_config() -> Dict[str, str]:
         **get_airflow_logging_config(),
         **get_airflow_metrics_config(),
         **get_airflow_scheduler_config(),
+        **get_airflow_webserver_config(),
     }

--- a/images/airflow/2.9.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.1/python/mwaa/entrypoint.py
@@ -340,7 +340,12 @@ async def main() -> None:
     logger.debug(f"Environment variables: {environ}")
 
     await airflow_db_init(environ)
-    await create_airflow_user(environ)
+    if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "simple":
+        # In "simple" auth mode, we create an admin user "airflow" with password
+        # "airflow". We use this to make the Docker Compose setup easy to use without
+        # having to create a user manually. Needless to say, this shouldn't be used in
+        # production environments.
+        await create_airflow_user(environ)
     create_queue()
     await install_user_requirements(command, environ)
 

--- a/images/airflow/2.9.1/python/mwaa/webserver/webserver_config.py
+++ b/images/airflow/2.9.1/python/mwaa/webserver/webserver_config.py
@@ -1,0 +1,27 @@
+"""Configuration for the Airflow webserver."""
+
+import os
+
+from airflow.configuration import conf
+
+# The SQLAlchemy connection string.
+SQLALCHEMY_DATABASE_URI = conf.get_mandatory_value("database", "SQL_ALCHEMY_CONN")
+
+# Flask-WTF flag for CSRF
+CSRF_ENABLED = True
+
+# Flask-WTF flag for CSRF
+WTF_CSRF_ENABLED = True
+
+if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "iam":
+    # The auth type is IAM. This is a MWAA-specific type, which relies on a plugin
+    # defined in MWAA's sidecar.
+    from aws_mwaa.iam import IamSecurityManager
+    from flask_appbuilder.security.manager import AUTH_REMOTE_USER
+
+    AUTH_TYPE = AUTH_REMOTE_USER
+    SECURITY_MANAGER_CLASS = IamSecurityManager
+else:
+    from flask_appbuilder.security.manager import AUTH_DB
+
+    AUTH_TYPE = AUTH_DB


### PR DESCRIPTION
*Issue #, if available:* #39

*Description of changes:*

The changes in this PR enable optional integration with IAM via MWAA IAM plugin (not open source). With this change, the user can specify two auth type:

- `simple`: In this type, an admin user with user name/password airflow/airflow, respectively, is created. This is used for development and testing purposes so the user can access the web server.
- `iam`: In this type, IAM integration is supported via MWAA IAM plugin, which as an internal code. This type will only be used by a MWAA environment.

In the future, we will probably make changes to the IAM integration such that any user can use IAM integration.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
