### PR TITLE
Add scheduler.schedule_after_task_execution and secrets.backend_kwargs Airflow config defaults

### DIFF
--- a/images/airflow/2.9.1/python/mwaa/config/airflow.py
+++ b/images/airflow/2.9.1/python/mwaa/config/airflow.py
@@ -1,5 +1,6 @@
 """Contain functions for building Airflow configuration."""
 
+import json
 from typing import Dict
 
 from mwaa.config.database import get_db_connection_string
@@ -96,8 +97,11 @@ def get_airflow_secrets_config() -> Dict[str, str]:
 
     :returns A dictionary containing the environment variables.
     """
+    connection_lookup_pattern = {
+        "connections_lookup_pattern": "^(?!aws_default$).*$"
+    }
     return {
-        "AIRFLOW__SECRETS__BACKEND_KWARGS": '{"connections_lookup_pattern":"^(?!aws_default$).*$"}"',
+        "AIRFLOW__SECRETS__BACKEND_KWARGS": json.dumps(connection_lookup_pattern),
     }
 
 


### PR DESCRIPTION
*Issue #, if available: #11*

*Description of changes:*

Adds two Airflow config defaults:
- `scheduler.schedule_after_task_execution:False` - we noticed performance issues when this was enabled so we disable this by default.
- `secrets.backend_kwargs: '{"connections_lookup_pattern":"^(?!aws_default$).*$"}"' `- provides default connections lookup pattern to improve performance.


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
