### PR TITLE
Make DB condition informational + Log sniffing

### DIFF
--- a/images/airflow/2.9.2/python/mwaa/config/airflow.py
+++ b/images/airflow/2.9.2/python/mwaa/config/airflow.py
@@ -1,6 +1,7 @@
 """Contain functions for building Airflow configuration."""
 
 # Python imports
+from functools import cache
 from typing import Dict
 import json
 import logging
@@ -115,6 +116,7 @@ def _get_essential_airflow_logging_config() -> Dict[str, str]:
     }
 
 
+@cache
 def _get_mwaa_cloudwatch_integration_config() -> Dict[str, str]:
     """
     Retrieve the environment variables required to enable CloudWatch Metrics integration.
@@ -127,7 +129,10 @@ def _get_mwaa_cloudwatch_integration_config() -> Dict[str, str]:
     )
     if not enabled:
         # MWAA CloudWatch Metrics integration isn't enabled.
+        logging.info("MWAA CloudWatch Metrics integration is NOT enabled.")
         return {}
+
+    logging.info("MWAA CloudWatch Metrics integration is enabled.")
 
     metrics_section = conf.getsection("metrics")
     if metrics_section is None:

--- a/images/airflow/2.9.2/python/mwaa/utils/cmd.py
+++ b/images/airflow/2.9.2/python/mwaa/utils/cmd.py
@@ -61,7 +61,12 @@ async def run_command(
     if not stdout_logging_method:
         stdout_logging_method = logging.getLogger(__name__).info
     if not stderr_logging_method:
-        stderr_logging_method = logging.getLogger(__name__).error
+        # Use the "info" method for stderr as well as shell scripts frequently use
+        # stderr even for informational output (e.g. in case the stdout should be
+        # allowed to be piped to another process, hence non-pipeable info is sent to
+        # stderr), and in such cases using the "error" method can be misleading if
+        # "[ERROR]" appears in logs when in fact there are no errors.
+        stderr_logging_method = logging.getLogger(__name__).info
 
     # Start the subprocess
     process: asyncio.subprocess.Process = await asyncio.create_subprocess_shell(

--- a/images/airflow/2.9.2/python/mwaa/utils/plogs.py
+++ b/images/airflow/2.9.2/python/mwaa/utils/plogs.py
@@ -1,0 +1,48 @@
+"""
+A module containing utility functions for processable logs.
+
+Processable logs are JSON-formatted, structured logs that contain useful information
+about the behaviour of the containers. They can be used to automate certain actions
+based on certain events. Their main use is within MWAA to monitor the health of
+enviornmetns. They get ingested by Fargate (the infrastructure we deploy our enviroments
+on) which allow us to
+"""
+
+import json
+import os
+import time
+
+
+def generate_plog(
+    logs_processor_name: str,
+    log_message: str,
+):
+    """
+    Generate a processable log.
+
+    A processable log is structured log that carrys certain useful information about
+    the behaviour of the container and is processed by the MWAA service.
+
+    :param logs_processor_name: The name of the logs processor responsible we want to
+      process this log. These names are defined by the MWAA service and is not public.
+    :param log_message: The message we want to send.
+
+    :returns The generated processable log.
+    """
+    airflow_version = os.environ.get("AIRFLOW_VERSION", "Unknown")
+    customer_account_id = os.environ.get("CUSTOMER_ACCOUNT_ID", "Unknown")
+    environment_name = os.environ.get("AIRFLOW_ENV_NAME", "Unknown")
+
+    return json.dumps(
+        {
+            "signature": "mwaa_plog_v1",
+            "logsProcessorName": logs_processor_name,
+            "dataPlaneCell": "Unknown",
+            "airflowVersion": airflow_version,
+            "airflowImage": "Unknown",
+            "customerAccountId": customer_account_id,
+            "environmentName": environment_name,
+            "timestamp": int(time.time()),
+            "message": log_message,
+        }
+    )


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* 

Previously, `AirflowDbReachableCondition` would result in a container restart if there is a problem reaching the database. While this is the desired result eventually, I am changing it for now to be informational only, i.e. report connection problem, for two reasons:

1. This is the current behaviour in our internal images, so we want to reduce how much we deviate from it.
2. More importantly, a restart would need to be a bit more intelligent to avoid unnecessary restarts, which results in a considerable wait time while the container is being replaced.

The re-introduction of restarts will be tracked in Issue #75.

Along with this PR, I also re-introduced the generation of processable logs to capture the DB health metrics in the MWAA service.

Finally, the PR also includes the porting of the log sniffing logic to detect common Airflow problems.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
