### PR TITLE
Multiple fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
-venv
+# Vim swap files
+*.swp
+
+# Virtual environments
 .venv
+venv
+
+# Python cache files
+__pycache__/
+*.py[cod]
+
+# Build directories
+build
+

--- a/images/airflow/2.9.2/bin/airflow-user/safe-pip-install
+++ b/images/airflow/2.9.2/bin/airflow-user/safe-pip-install
@@ -1,16 +1,8 @@
 #!/bin/bash
 
-# Define an array of required packages
-REQUIRED_PACKAGES=(
-    "apache-airflow-providers-amazon[aiobotocore]"
-    "apache-airflow[celery,statsd]==${AIRFLOW_VERSION}"
-    "celery[sqs]"
-    "boto3-stubs[logs]"
-    "boto3-stubs[sqs]"
-    psycopg2
-    pycurl
-    watchtower
-)
+# TODO Need to come up with a smaller list of constarints file including just
+# the critical dependencies that we don't allow the customer to override, e.g.
+# airflow, celery, kombu, and so on.
 
 # Install all required packages in one command
-pip3 install --constraint "${AIRFLOW_CONSTRAINTS_FILE}" "${REQUIRED_PACKAGES[@]}" "$@"
+pip3 install --constraint "${AIRFLOW_CONSTRAINTS_FILE}" "$@"

--- a/images/airflow/2.9.2/bootstrap/02-airflow/001-install-required-pip-packages.sh
+++ b/images/airflow/2.9.2/bootstrap/02-airflow/001-install-required-pip-packages.sh
@@ -4,6 +4,18 @@ set -e
 # shellcheck source=images/airflow/2.9.2/bootstrap/common.sh
 source /bootstrap/common.sh
 
+# Define an array of required packages
+REQUIRED_PACKAGES=(
+    "apache-airflow-providers-amazon[aiobotocore]"
+    "apache-airflow[celery,statsd]==${AIRFLOW_VERSION}"
+    "celery[sqs]"
+    "boto3-stubs[logs]"
+    "boto3-stubs[sqs]"
+    psycopg2
+    pycurl
+    watchtower
+)
+
 # safe-pip-install always install all required packages, along with whatever
 # the user provides, hence we don't need to provide anything here.
-safe-pip-install
+safe-pip-install "${REQUIRED_PACKAGES[@]}" 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

- Add a grace period based on the contaitner start time to the `SidecarHealthCondition` condition to avoid reporting confusing error logs.
- Change `safe-pip-install` to only install the given packages, rather than always install all required packages in addition to what is given. We used to do the latter to disallow installing any pip packages that might break the Airflow packages, but this is a bit too restricting, and also result in increasing the time it takes to do `pip install`, in addition to unnecessary logs. So, we will just instead craft a list of fundamental constraints that we enforce.
- Add a new configuration variable, `MWAA__CORE__STARTUP_SCRIPT_PATH`, for specifying the path to look for start-up scripts instead of hard-coding it.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
