### PR TITLE
Add apache-airflow-providers-postgres to list of required pip packages

### DIFF
--- a/images/airflow/2.9.2/bootstrap/02-airflow/001-install-required-pip-packages.sh
+++ b/images/airflow/2.9.2/bootstrap/02-airflow/001-install-required-pip-packages.sh
@@ -8,6 +8,7 @@ source /bootstrap/common.sh
 REQUIRED_PACKAGES=(
     "apache-airflow-providers-amazon[aiobotocore]"
     "apache-airflow[celery,statsd]==${AIRFLOW_VERSION}"
+    "apache-airflow-providers-postgres"
     "celery[sqs]"
     "boto3-stubs[logs]"
     "boto3-stubs[sqs]"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding apache-airflow-providers-postgres helps customers connect with postgres databases for running queries without going through installation themselves. This is an existing installation for earlier MWAA Airflow versions already. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
