### PR TITLE
Add virtualenv to list of required pip packages

### DIFF
--- a/images/airflow/2.9.2/bootstrap/02-airflow/001-install-required-pip-packages.sh
+++ b/images/airflow/2.9.2/bootstrap/02-airflow/001-install-required-pip-packages.sh
@@ -15,6 +15,7 @@ REQUIRED_PACKAGES=(
     psycopg2
     pycurl
     watchtower
+    virtualenv
 )
 
 # safe-pip-install always install all required packages, along with whatever


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The PythonVirtualenvOperator is used to run Python functions in a virtual environment, which requires the virtualenv package to be installed. This is an existing installation for earlier MWAA Airflow versions already.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
