### PR TITLE
Ensure start-up script finishes in 5 minutes

### DIFF
--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -81,7 +81,10 @@ AVAILABLE_COMMANDS = [
     "spy",
 ]
 MWAA_DOCS_REQUIREMENTS_GUIDE = "https://docs.aws.amazon.com/mwaa/latest/userguide/working-dags-dependencies.html#working-dags-dependencies-test-create"
-STARTUP_SCRIPT_MAX_EXECUTION_TIME = timedelta(minutes=5)
+STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL = timedelta(seconds=5)
+STARTUP_SCRIPT_MAX_EXECUTION_TIME = (
+    timedelta(minutes=5) - STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL
+)
 USER_REQUIREMENTS_MAX_INSTALL_TIME = timedelta(minutes=9)
 
 # Save the start time of the container. This is used later to with the sidecar
@@ -279,6 +282,7 @@ def execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]:
                 TimeoutCondition(STARTUP_SCRIPT_MAX_EXECUTION_TIME),
             ],
             friendly_name=f"{cmd}_startup",
+            sigterm_patience_interval=STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL,
         )
         startup_script_process.start()
         end_time = time.time()


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

To make sure that the start-up script execution finishes in 5 minutes, I updated the Subprocess class to support passing in the maximum interval of wait between sending a SIGTERM and a SIGKILL. This way we can avoid having to add 90 seconds of additional wait time for the start up script.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
