### PR TITLE
feat: Add webserver config to optionally disable WTF CSRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ To experiment with the image using a vanilla Docker setup, follow these steps:
 python3 create_venvs.py
 ```
 
-3. Build the Airflow v2.9.2 Docker image using:
+3. Build the `fake-statsd-server` image:
+```
+cd <amazon-mwaa-docker-images path>/images/fake-statsd-server
+./build.sh
+```
+
+4. Build the Airflow v2.9.2 Docker image using:
 
 ```
 cd <amazon-mwaa-docker-images path>/images/airflow/2.9.2

--- a/images/airflow/2.9.2/python/mwaa/webserver/webserver_config.py
+++ b/images/airflow/2.9.2/python/mwaa/webserver/webserver_config.py
@@ -11,7 +11,7 @@ SQLALCHEMY_DATABASE_URI = conf.get_mandatory_value("database", "SQL_ALCHEMY_CONN
 CSRF_ENABLED = True
 
 # Flask-WTF flag for CSRF
-WTF_CSRF_ENABLED = True
+WTF_CSRF_ENABLED = False if os.environ.get("MWAA__WEBSERVER__WTF_CSRF_ENABLED", "").lower() == "false" else True
 
 if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "mwaa-iam":
     # The auth type is IAM. This is a MWAA-specific type, which relies on a plugin


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-mwaa-docker-images/issues/86

*Description of changes:*
This PR adds an environment variable to allow disabling CSRF. CSRF will be enabled by default unless `MWAA__WEBSERVER__WTF_CSRF_ENABLED` is explicitly set to `False`.

I verified the changes by running the container locally with the environment variable set to `False`, `True`, and not setting it at all. In the first case, I was able to get the response from `http://localhost:8080/dag_stats`, and in the latter two cases, I received the 400 `The CSRF token is missing` error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
