### PR TITLE
Make auto scaling metrics report zero

### DIFF
--- a/images/airflow/2.9.2/python/mwaa/celery/task_monitor.py
+++ b/images/airflow/2.9.2/python/mwaa/celery/task_monitor.py
@@ -235,6 +235,9 @@ def _cleanup_undead_process(process_id: int):
     Cleanup the undead process.
 
     :param process_id: The ID of the process.
+
+    :returns A tuple containing the number of process graceful successes, forceful
+    successes, and failures, respectively.
     """
     print(f"Cleaning up undead process with ID: {process_id}")
 
@@ -530,6 +533,15 @@ class WorkerTaskMonitor:
             )
 
         # Report behavioural metrics.
-        Stats.incr(f"mwaa.task_monitor.clean_celery_message_error_no_queue", 1)
-        Stats.incr(f"mwaa.task_monitor.clean_celery_message_success", 1)
-        Stats.incr(f"mwaa.task_monitor.clean_celery_message_error_sqs_op", 1)
+        Stats.incr(
+            f"mwaa.task_monitor.clean_celery_message_error_no_queue",
+            clean_celery_message_error_no_queue,
+        )
+        Stats.incr(
+            f"mwaa.task_monitor.clean_celery_message_success",
+            clean_celery_message_success,
+        )
+        Stats.incr(
+            f"mwaa.task_monitor.clean_celery_message_error_sqs_op",
+            clean_celery_message_error_sqs_op,
+        )


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Currently, our code doesn't publish a metric in case there is nothing to report, instead of reporting 0. This commit changes it such that we always report a value. This helps us confirm that the auto scaling code is working, just there is nothing to do, as opposed to seeing no metric, which makes it difficult to know when there is an issue with our logic.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
