### PR TITLE
Port the license checking code + Improving Docker build time

### DIFF
--- a/images/airflow/2.9.2/Dockerfile.base.j2
+++ b/images/airflow/2.9.2/Dockerfile.base.j2
@@ -27,16 +27,17 @@ ARG MARIADB_RPM_SHARED_CHECKSUM=ed82ad5bc5b35cb2719a9471a71c6cdb
 ENV AIRFLOW_CONSTRAINTS_FILE=${AIRFLOW_USER_LOCAL_ETC_PATH}/airflow_constraints.txt
 ENV MWAA_ESSENTIAL_CONSTRAINTS_FILE=${AIRFLOW_USER_LOCAL_ETC_PATH}/mwaa_essential_constraints.txt
 
-# Copy bootstrapping files.
-COPY ./bootstrap /bootstrap
-RUN chmod -R +x /bootstrap
+# Copy files common to all bootstrapping files.
+COPY ./bootstrap/common.sh /bootstrap/common.sh
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for root user, first pass bootstrapping steps.
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 {% for filepath in bootstrapping_scripts_root_firstpass %}
-RUN {{ filepath }}
+COPY ./{{ filepath }} /{{ filepath }}
+RUN chmod +x /{{ filepath }} && /{{ filepath }}
+
 {% endfor %}
 
 #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -63,7 +64,11 @@ USER airflow
 ENV PATH=${PATH_AIRFLOW_USER} 
 
 {% for filepath in bootstrapping_scripts_airflow %}
-RUN {{ filepath }}
+USER root
+COPY ./{{ filepath }} /{{ filepath }}
+RUN chmod +x /{{ filepath }}
+USER airflow
+RUN /{{ filepath }}
 {% endfor %}
 
 # Revert the PATH and user.
@@ -86,7 +91,8 @@ USER root
 # the folder to be fully setup first.
 
 {% for filepath in bootstrapping_scripts_root_secondpass %}
-RUN {{ filepath }}
+COPY ./{{ filepath }} /{{ filepath }}
+RUN chmod +x /{{ filepath }} && /{{ filepath }}
 {% endfor %}
 
 #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/images/airflow/2.9.2/Dockerfile.derivatives.j2
+++ b/images/airflow/2.9.2/Dockerfile.derivatives.j2
@@ -2,10 +2,6 @@ FROM amazon-mwaa-docker-images/airflow:2.9.2-base
 
 {% if bootstrapping_scripts_dev %}
 
-# Copy bootstrapping files.
-COPY ./bootstrap-dev /bootstrap-dev
-RUN chmod -R +x /bootstrap-dev
-
 {#
 Those steps are only exectued for development images. Those are images that
 contain additional packages that help with debugging, e.g. editors, etc., but
@@ -17,7 +13,8 @@ are not supposed to be in production.
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 {% for filepath in bootstrapping_scripts_dev %}
-RUN {{ filepath }}
+COPY ./{{ filepath }} /{{ filepath }}
+RUN chmod +x /{{ filepath }} && /{{ filepath }}
 {% endfor %}
 
 #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/images/airflow/2.9.2/Dockerfiles/Dockerfile
+++ b/images/airflow/2.9.2/Dockerfiles/Dockerfile
@@ -3,8 +3,6 @@
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on 2024-06-12 23:08:41.023084
-#
 
 FROM amazon-mwaa-docker-images/airflow:2.9.2-base
 

--- a/images/airflow/2.9.2/Dockerfiles/Dockerfile-dev
+++ b/images/airflow/2.9.2/Dockerfiles/Dockerfile-dev
@@ -3,20 +3,15 @@
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on 2024-06-12 23:08:41.014600
-#
 
 FROM amazon-mwaa-docker-images/airflow:2.9.2-base
-
-# Copy bootstrapping files.
-COPY ./bootstrap-dev /bootstrap-dev
-RUN chmod -R +x /bootstrap-dev
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-RUN /bootstrap-dev/001-devonly-install-dev-tools.sh
+COPY ./bootstrap-dev/001-devonly-install-dev-tools.sh /bootstrap-dev/001-devonly-install-dev-tools.sh
+RUN chmod +x /bootstrap-dev/001-devonly-install-dev-tools.sh && /bootstrap-dev/001-devonly-install-dev-tools.sh
 
 #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 # END marker for dev bootstrapping steps.

--- a/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer
+++ b/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer
@@ -3,8 +3,6 @@
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on 2024-06-12 23:08:41.025856
-#
 
 FROM amazon-mwaa-docker-images/airflow:2.9.2-base
 

--- a/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer-dev
+++ b/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer-dev
@@ -3,20 +3,15 @@
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on 2024-06-12 23:08:41.017508
-#
 
 FROM amazon-mwaa-docker-images/airflow:2.9.2-base
-
-# Copy bootstrapping files.
-COPY ./bootstrap-dev /bootstrap-dev
-RUN chmod -R +x /bootstrap-dev
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-RUN /bootstrap-dev/001-devonly-install-dev-tools.sh
+COPY ./bootstrap-dev/001-devonly-install-dev-tools.sh /bootstrap-dev/001-devonly-install-dev-tools.sh
+RUN chmod +x /bootstrap-dev/001-devonly-install-dev-tools.sh && /bootstrap-dev/001-devonly-install-dev-tools.sh
 
 #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 # END marker for dev bootstrapping steps.

--- a/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer-privileged
+++ b/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer-privileged
@@ -3,8 +3,6 @@
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on 2024-06-12 23:08:41.028567
-#
 
 FROM amazon-mwaa-docker-images/airflow:2.9.2-base
 

--- a/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer-privileged-dev
+++ b/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer-privileged-dev
@@ -3,20 +3,15 @@
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on 2024-06-12 23:08:41.020330
-#
 
 FROM amazon-mwaa-docker-images/airflow:2.9.2-base
-
-# Copy bootstrapping files.
-COPY ./bootstrap-dev /bootstrap-dev
-RUN chmod -R +x /bootstrap-dev
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-RUN /bootstrap-dev/001-devonly-install-dev-tools.sh
+COPY ./bootstrap-dev/001-devonly-install-dev-tools.sh /bootstrap-dev/001-devonly-install-dev-tools.sh
+RUN chmod +x /bootstrap-dev/001-devonly-install-dev-tools.sh && /bootstrap-dev/001-devonly-install-dev-tools.sh
 
 #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 # END marker for dev bootstrapping steps.

--- a/images/airflow/2.9.2/Dockerfiles/Dockerfile.base
+++ b/images/airflow/2.9.2/Dockerfiles/Dockerfile.base
@@ -3,8 +3,6 @@
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on 2024-06-18 01:40:14.378983
-#
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
@@ -35,25 +33,30 @@ ARG MARIADB_RPM_SHARED_CHECKSUM=ed82ad5bc5b35cb2719a9471a71c6cdb
 ENV AIRFLOW_CONSTRAINTS_FILE=${AIRFLOW_USER_LOCAL_ETC_PATH}/airflow_constraints.txt
 ENV MWAA_ESSENTIAL_CONSTRAINTS_FILE=${AIRFLOW_USER_LOCAL_ETC_PATH}/mwaa_essential_constraints.txt
 
-# Copy bootstrapping files.
-COPY ./bootstrap /bootstrap
-RUN chmod -R +x /bootstrap
+# Copy files common to all bootstrapping files.
+COPY ./bootstrap/common.sh /bootstrap/common.sh
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for root user, first pass bootstrapping steps.
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-RUN /bootstrap/01-root-firstpass/001-init.sh
+COPY ./bootstrap/01-root-firstpass/001-init.sh /bootstrap/01-root-firstpass/001-init.sh
+RUN chmod +x /bootstrap/01-root-firstpass/001-init.sh && /bootstrap/01-root-firstpass/001-init.sh
 
-RUN /bootstrap/01-root-firstpass/002-install-python.sh
+COPY ./bootstrap/01-root-firstpass/002-install-python.sh /bootstrap/01-root-firstpass/002-install-python.sh
+RUN chmod +x /bootstrap/01-root-firstpass/002-install-python.sh && /bootstrap/01-root-firstpass/002-install-python.sh
 
-RUN /bootstrap/01-root-firstpass/003-install-mariadb.sh
+COPY ./bootstrap/01-root-firstpass/003-install-mariadb.sh /bootstrap/01-root-firstpass/003-install-mariadb.sh
+RUN chmod +x /bootstrap/01-root-firstpass/003-install-mariadb.sh && /bootstrap/01-root-firstpass/003-install-mariadb.sh
 
-RUN /bootstrap/01-root-firstpass/004-create-airflow-user.sh
+COPY ./bootstrap/01-root-firstpass/004-create-airflow-user.sh /bootstrap/01-root-firstpass/004-create-airflow-user.sh
+RUN chmod +x /bootstrap/01-root-firstpass/004-create-airflow-user.sh && /bootstrap/01-root-firstpass/004-create-airflow-user.sh
 
-RUN /bootstrap/01-root-firstpass/005-install-aws-cli.sh
+COPY ./bootstrap/01-root-firstpass/005-install-aws-cli.sh /bootstrap/01-root-firstpass/005-install-aws-cli.sh
+RUN chmod +x /bootstrap/01-root-firstpass/005-install-aws-cli.sh && /bootstrap/01-root-firstpass/005-install-aws-cli.sh
 
-RUN /bootstrap/01-root-firstpass/100-install-needed-dnf-packages.sh
+COPY ./bootstrap/01-root-firstpass/100-install-needed-dnf-packages.sh /bootstrap/01-root-firstpass/100-install-needed-dnf-packages.sh
+RUN chmod +x /bootstrap/01-root-firstpass/100-install-needed-dnf-packages.sh && /bootstrap/01-root-firstpass/100-install-needed-dnf-packages.sh
 
 #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 # END marker for root user, first pass bootstrapping steps.
@@ -78,7 +81,17 @@ RUN chown -R airflow: ${AIRFLOW_USER_LOCAL_PATH}
 USER airflow
 ENV PATH=${PATH_AIRFLOW_USER} 
 
+USER root
+COPY ./bootstrap/02-airflow/001-install-required-pip-packages.sh /bootstrap/02-airflow/001-install-required-pip-packages.sh
+RUN chmod +x /bootstrap/02-airflow/001-install-required-pip-packages.sh
+USER airflow
 RUN /bootstrap/02-airflow/001-install-required-pip-packages.sh
+
+USER root
+COPY ./bootstrap/02-airflow/999-licensecheck.py /bootstrap/02-airflow/999-licensecheck.py
+RUN chmod +x /bootstrap/02-airflow/999-licensecheck.py
+USER airflow
+RUN /bootstrap/02-airflow/999-licensecheck.py
 
 # Revert the PATH and user.
 ENV PATH=${PATH_DEFAULT}
@@ -97,11 +110,14 @@ USER root
 # giving ownership of the Airflow home user to the 'airflow' user requires the
 # the folder to be fully setup first.
 
-RUN /bootstrap/03-root-secondpass/001-create-mwaa-dir.sh
+COPY ./bootstrap/03-root-secondpass/001-create-mwaa-dir.sh /bootstrap/03-root-secondpass/001-create-mwaa-dir.sh
+RUN chmod +x /bootstrap/03-root-secondpass/001-create-mwaa-dir.sh && /bootstrap/03-root-secondpass/001-create-mwaa-dir.sh
 
-RUN /bootstrap/03-root-secondpass/002-make-airflow-sudoer.sh
+COPY ./bootstrap/03-root-secondpass/002-make-airflow-sudoer.sh /bootstrap/03-root-secondpass/002-make-airflow-sudoer.sh
+RUN chmod +x /bootstrap/03-root-secondpass/002-make-airflow-sudoer.sh && /bootstrap/03-root-secondpass/002-make-airflow-sudoer.sh
 
-RUN /bootstrap/03-root-secondpass/100-chown-airflow-folder.sh
+COPY ./bootstrap/03-root-secondpass/100-chown-airflow-folder.sh /bootstrap/03-root-secondpass/100-chown-airflow-folder.sh
+RUN chmod +x /bootstrap/03-root-secondpass/100-chown-airflow-folder.sh && /bootstrap/03-root-secondpass/100-chown-airflow-folder.sh
 
 #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 # END marker for root user, second pass bootstrapping steps.

--- a/images/airflow/2.9.2/bootstrap/02-airflow/999-licensecheck.py
+++ b/images/airflow/2.9.2/bootstrap/02-airflow/999-licensecheck.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+This module ensures that we are only using acceptable licenses in our repository.
+"""
+
+from collections import defaultdict
+from typing import DefaultDict, List
+import importlib.metadata as importlib_metadata
+
+# Amazon Pre-Approved Licenses
+ACCEPTABLE_LICENSES = [
+    "AFL",
+    "ASL",
+    "Academic Free License",
+    "Amazon",
+    "Apache",
+    "AppleJavaExtensions",
+    "Artistic",
+    "BSD",
+    "Boost",
+    "CC0",
+    "Carnegie",
+    "Creative Commons",
+    "Curl",
+    "Eiffel Forum",
+    "Free Type",
+    "HPND",
+    "ISC",
+    "ImageMagick",
+    "Indiana University",
+    "JPEG",
+    "JSON",
+    "JTidy",
+    "JiBX",
+    "Jython",
+    "Libtiff",
+    "MIT",
+    "MSIS",
+    "MX4J",
+    "Microsoft Public",
+    "NCSA",
+    "OFL",
+    "Open Font",
+    "OpenLDAP",
+    "OpenSSL",
+    "PDDL",
+    "PDWiki",
+    "PHP",
+    "PIL",
+    "PSL",
+    "PostgreSQL",
+    "Public Domain",
+    "Python Imaging Library",
+    "Python Software Foundation",
+    "Ruby",
+    "SLF4J",
+    "Scala",
+    "University of Illinois",
+    "Unlicense",
+    "VIM",
+    "W3C",
+    "WTFPL",
+    "WordNet",
+    "ZPL",
+    "Zlib",
+    "Zope Public",
+    "libpng",
+]
+
+# Amazon Policy doesn't allow the use of these licenses.
+PROHIBITED_LICENSES = [
+    "AGPLv3",
+    "Affero General Public",
+    "Apple Public",
+    "BUSL",
+    "Business Source License",
+    "CC-NC",
+    "CDLA",
+    "CPAL",
+    "CRAPL",
+    "Comminuty Data License Agreement",
+    "Common Public Attribution",
+    "Commons Clause",
+    "Community Research and Academic Programming",
+    "Confluent",
+    "EUPL",
+    "Elastic",
+    "Enna",
+    "European Union Public",
+    "GNU General Public License v3",
+    "GNU Lesser General Public License v3",
+    "GPLv3",
+    "HFOIL",
+    "HPL",
+    "Host Public",
+    "Hugging Face",
+    "LGPLv3",
+    "NASA Open Source",
+    "NOSA",
+    "ODbL",
+    "Open Data Commons Open Database",
+    "Parity",
+    "Prosperity",
+    "RealNetworks Public",
+    "Redis",
+    "Server Side Public",
+    "UC Berkeley",
+    "University of Wisconsin",
+]
+
+# These can be used as well, under certain conditions, so we use a different list to
+# keep the distinction visibile.
+EXEMPTED_LICENSES = [
+    "Mozilla Public",
+    "MPL",
+]
+
+# These packages, although having licenses that Amazon doesn't approve, are specifically
+# exempted because the use case is approved.
+EXEMPTED_PACKAGES = [
+    "chardet",
+    "paramiko",
+    "pendulum",
+    "psycopg2",
+    "psycopg2-binary",
+]
+
+
+def extract_license_info(pkg_metadata: importlib_metadata.PackageMetadata) -> str:
+    """
+    Accepts an importlib MetaData object and extract license information
+    from both License field and the Classifiers fields.
+    """
+    license: str = str(pkg_metadata.get("License", ""))  # type: ignore
+    # Also check all Classifiers for License information
+    for classifier in pkg_metadata.get_all("Classifier", []):  # type: ignore
+        if "License" in classifier:
+            license += f" - {classifier}"
+    return license
+
+
+def main():
+    """
+    Script entrypoint.
+    """
+    license_check_failed = False
+    results: DefaultDict[str, List[str]] = defaultdict(list)
+
+    for dist in importlib_metadata.distributions():
+        pkg_name = dist.metadata["Name"]
+        pkg_license = extract_license_info(dist.metadata)
+        if pkg_name in EXEMPTED_PACKAGES:
+            print(f"Package {pkg_name} has license {pkg_license} but is exempted.")
+            continue
+        if any(x in pkg_license for x in ACCEPTABLE_LICENSES):
+            results[pkg_license].append(pkg_name)
+            continue
+        if any(x in pkg_license for x in EXEMPTED_LICENSES):
+            results[pkg_license].append(pkg_name)
+            continue
+        if any(x in pkg_license for x in PROHIBITED_LICENSES):
+            license_check_failed = True
+            print(
+                f"ERROR: The package {pkg_name} has prohibited license {pkg_license}."
+            )
+            continue
+        license_check_failed = True
+        print(
+            f"ERROR: Package {pkg_name} has a non-pre-approved License: {pkg_license}. "
+            "If you think the use case is justified here, please reach out to AppSec "
+            "or Open Source teams to obtain an approval, and update one or more of the "
+            "lists above accordingly."
+        )
+
+    for item in results:
+        print(f"The following packages has approved {item} license:")
+        print(results[item])
+
+    if license_check_failed:
+        exit(2)
+
+
+if __name__ == "__main__":
+    main()
+else:
+    print("This module cannot be imported.")
+    exit(1)

--- a/images/airflow/generate-dockerfiles.py
+++ b/images/airflow/generate-dockerfiles.py
@@ -90,8 +90,6 @@ def generate_dockerfile(
 # the Jinja2-templated Dockerfile.j2 file, so you need to change that file
 # instead.
 #
-# This file was generated on {datetime.now()}
-#
     """.strip()
         )
         f.write(os.linesep)
@@ -116,21 +114,21 @@ def generate_base_dockerfile(image_root_dir: Path) -> None:
     data = {
         "bootstrapping_scripts_root_firstpass": sorted(
             [
-                os.path.join("/bootstrap/01-root-firstpass", file.name)
+                os.path.join("bootstrap/01-root-firstpass", file.name)
                 for file in (image_root_dir / "bootstrap/01-root-firstpass").iterdir()
                 if file.is_file()
             ]
         ),
         "bootstrapping_scripts_airflow": sorted(
             [
-                os.path.join("/bootstrap/02-airflow", file.name)
+                os.path.join("bootstrap/02-airflow", file.name)
                 for file in (image_root_dir / "bootstrap/02-airflow").iterdir()
                 if file.is_file()
             ]
         ),
         "bootstrapping_scripts_root_secondpass": sorted(
             [
-                os.path.join("/bootstrap/03-root-secondpass", file.name)
+                os.path.join("bootstrap/03-root-secondpass", file.name)
                 for file in (image_root_dir / "bootstrap/03-root-secondpass").iterdir()
                 if file.is_file()
             ]
@@ -174,7 +172,7 @@ def generate_derivative_dockerfiles(
         "bootstrapping_scripts_dev": (
             sorted(
                 [
-                    os.path.join("/bootstrap-dev", file.name)
+                    os.path.join("bootstrap-dev", file.name)
                     for file in (image_root_dir / "bootstrap-dev").iterdir()
                     if file.is_file()
                 ]


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Add a bootstrapping step to make sure we are the approved licenses in the packages we use.

While at this, I also improved the Dockerfiles to avoid unnecessary rebuilds. Previously, I was copying the entire bootstrap folder before bootstrapping, which resulted in Docker having to repeat the copying step, and everything also after it, resulting in redoing bootstrapping even, if a single line changed in any bootstrap file.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
