### PR TITLE
Fix auto-scaling service metrics

### DIFF
--- a/images/airflow/2.9.2/python/mwaa/celery/task_monitor.py
+++ b/images/airflow/2.9.2/python/mwaa/celery/task_monitor.py
@@ -20,6 +20,9 @@ import boto3
 import botocore
 import psutil
 
+# Our imports
+from mwaa.utils.statsd import get_statsd
+
 EOF_TOKEN = "EOF_TOKEN"
 
 # The SQS channel needs to maintain data regarding the SQS messages that it is currently
@@ -299,9 +302,7 @@ class WorkerTaskMonitor:
         self.abandoned_celery_tasks_from_last_check: List[CeleryTask] = []
         self.undead_process_ids_from_last_check = []
 
-        from airflow.stats import Stats
-
-        self.stats = Stats
+        self.stats = get_statsd()
 
     def is_worker_idle(self):
         """
@@ -453,15 +454,15 @@ class WorkerTaskMonitor:
         self.abandoned_celery_tasks_from_last_check = potentially_abandoned_celery_tasks
 
         # Report behavioural metrics.
-        self.stats.incr(
+        self.stats.incr(  # type: ignore
             f"mwaa.task_monitor.clean_celery_message_error_no_queue",
             clean_celery_message_error_no_queue,
         )
-        self.stats.incr(
+        self.stats.incr(  # type: ignore
             f"mwaa.task_monitor.clean_celery_message_success",
             clean_celery_message_success,
         )
-        self.stats.incr(
+        self.stats.incr(  # type: ignore
             f"mwaa.task_monitor.clean_celery_message_error_sqs_op",
             clean_celery_message_error_sqs_op,
         )
@@ -494,15 +495,15 @@ class WorkerTaskMonitor:
         self.undead_process_ids_from_last_check = potentially_undead_process_ids
 
         # Report behavioural metrics.
-        self.stats.incr(
+        self.stats.incr(  # type: ignore
             f"mwaa.task_monitor.clean_undead_process_graceful_success",
             clean_undead_process_graceful_success,
         )
-        self.stats.incr(
+        self.stats.incr(  # type: ignore
             f"mwaa.task_monitor.clean_undead_process_forceful_success",
             clean_undead_process_forceful_success,
         )
-        self.stats.incr(
+        self.stats.incr(  # type: ignore
             f"mwaa.task_monitor.clean_undead_process_forceful_failure",
             clean_undead_process_forceful_failure,
         )

--- a/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
@@ -29,6 +29,7 @@ import watchtower
 
 # Our imports
 from mwaa.logging.utils import parse_arn, throttle
+from python.mwaa.utils.statsd import get_statsd
 
 
 LOG_GROUP_INIT_WAIT_SECONDS = 900
@@ -101,10 +102,7 @@ class BaseLogHandler(logging.Handler):
         # TODO Find a nice and unambiguous solution to the craziness of super() and MRO.
         logging.Handler.__init__(self)
 
-        # Airflow Stats object.
-        from airflow.stats import Stats
-
-        self.stats = Stats
+        self.stats = get_statsd()
 
     def create_watchtower_handler(
         self,

--- a/images/airflow/2.9.2/python/mwaa/utils/statsd.py
+++ b/images/airflow/2.9.2/python/mwaa/utils/statsd.py
@@ -1,0 +1,42 @@
+"""
+Utility functions related to StatsD.
+"""
+
+# Python imports
+from functools import cache
+
+# 3rd-party imports
+from statsd import StatsClient  # type: ignore
+from airflow.metrics.statsd_logger import SafeStatsdLogger
+
+
+@cache
+def get_statsd():
+    """
+    Retrieves a StatsD client for publishing metrics.
+
+    Important Note: Typically, one would want to use the `Stats` object from the
+    `airflow.stats` module. However, this requires the necessary Airflow configuration
+    to have been initialized, which is not always the case. One example is the metrics
+    published by the code in our entrypoint.py. The reason is that we define the
+    necessary Airflow configuration via environment variables and then pass them to
+    child processes, e.g. scheduler, worker, etc., but the parent process itself (the
+    entrypoint.py) doesn't have those enviromnent variables.
+
+    This is more of a temporary workaround, since ideally we should patch the
+    environment variables of the parent process as well. This, however, is a bit
+    challenging since the process of patching the enviromnent variables should happen
+    before any Airflow module is imported, which is a bit tricky considering that
+    even pretty much all modules in our code ends up importing Airflow, directly or
+    indirectly, hence some substantial refactoring is required. This, however, isn't
+    impossible, and hence a GitHub issue is created to track it:
+
+    https://github.com/aws/amazon-mwaa-docker-images/issues/99
+    """
+    statsd_client = StatsClient(
+        host="localhost",
+        port=8125,
+        prefix="airflow",
+    )
+
+    return SafeStatsdLogger(statsd_client)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Most of our auto-scaling service metrics were not being emitted due to the direct use of Airflow's StatsD object in a context where the necessary Airflow configurations are not yet set (the entrypoint.py, i.e. the top level container process.) Hence, metrics were simply being ignored. To solve this issue, I made a change to directly create a StatsD object with the right configuration.

*Testing:*

Confirmed metrics are being emitted:

![image](https://github.com/aws/amazon-mwaa-docker-images/assets/442447/e15d1ba7-33fc-440b-9ab3-4f42953b8bd7)

Notice that the second graph is empty because there were no running tasks (also, this graph was working anyway, so not related to the issue mentioned in this PR.)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
