### PR TITLE
Minor log fixes

### DIFF
--- a/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
@@ -171,6 +171,17 @@ class BaseLogHandler(logging.Handler):
             record - The log record to emit.
         """
         if self.handler:
+            # This is a potentially noisy warning that we started seeing because we
+            # are still not using pattern matching for metrics allow/block-listing.
+            # As a temporary work-around, we are dropping these messages at the handler
+            # level. We should, however, fix this issue by setting to True the
+            # `metrics_use_pattern_match` flag.
+            # More context: https://github.com/aws/amazon-mwaa-docker-images/issues/98
+            if (
+                "RemovedInAirflow3Warning: The basic metric validator will be deprecated"
+                in record.getMessage()
+            ):
+                return
             try:
                 self.handler.emit(record)  # type: ignore
                 self.sniff_errors(record)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

- Swallow the StatsD deprecation warning, since it is becoming very noisy for our setup:
```
RemovedInAirflow3Warning: The basic metric validator will be deprecated
in the future in favor of pattern-matching.  You can try this now by
setting config option metrics_use_pattern_match to True.
```
- Use Python-style logging instead of prints in task_monitor.py

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
