### PR TITLE
Fix task logs spilling into scheduler logs

### DIFF
--- a/images/airflow/2.9.2/python/mwaa/logging/config.py
+++ b/images/airflow/2.9.2/python/mwaa/logging/config.py
@@ -100,6 +100,7 @@ def _configure_task_logging():
         LOGGING_CONFIG["loggers"]["airflow.task"].update(
             {
                 "level": log_level,
+                "propagate": False,
             }
         )
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

In our logging configuration, we were not setting the propagation flag to False for the `airflow.task` logger, resulting in some task logs going to the scheduler as well (and probably workers, but I didn't verify) because the go to the 'root' handler, which prints to console, and the latter gets captured by the scheduler.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
