### PR TITLE
Reduce CONSECUTIVE_IDLENESS_CHECK_THRESHOLD to 2

### DIFF
--- a/images/airflow/2.9.2/python/mwaa/celery/task_monitor.py
+++ b/images/airflow/2.9.2/python/mwaa/celery/task_monitor.py
@@ -61,9 +61,9 @@ IDLENESS_CHECK_WARMUP_WAIT_PERIOD = timedelta(minutes=3)
 CLEANUP_ABANDONED_RESOURCES_WARMUP_WAIT_PERIOD = timedelta(minutes=3)
 # Allow at least 1 second between any two consecutive idleness checks.
 IDLENESS_CHECK_DELAY_PERIOD = timedelta(seconds=1)
-# The worker should be idle for at least 15 consecutive idleness check before being
+# The worker should be idle for at least 2 consecutive idleness check before being
 # declared idle.
-CONSECUTIVE_IDLENESS_CHECK_THRESHOLD = 15
+CONSECUTIVE_IDLENESS_CHECK_THRESHOLD = 2
 # Allow at least 1 minute between any two consecutive abandoned resource cleanups.
 CLEANUP_ABANDONED_RESOURCES_DELAY_PERIOD = timedelta(minutes=1)
 # If in the improbable case of the worker picking up new tasks after having paused its


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Reducing `CONSECUTIVE_IDLENESS_CHECK_THRESHOLD` from 15 to 2 to avoid lengthy wait before shutting down an idle worker. This setting, when applied to the internal code, resulted in ~ 15 seconds of delay, but the new open source image are designed differently and our checks are executed once 1 minute, so 15 consecutive checks means 15 minutes, which is considerable time. So, reducing this to 2 to keep the idleness wait to roughly 2 minutes.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
