### PR TITLE
Add hybrid scheduler/worker container

### DIFF
--- a/images/airflow/2.9.2/docker-compose-hybrid.yaml
+++ b/images/airflow/2.9.2/docker-compose-hybrid.yaml
@@ -1,0 +1,128 @@
+version: "3.8"
+
+x-airflow-common: &airflow-common
+  image: amazon-mwaa-docker-images/airflow:2.9.2-dev
+  restart: always
+  environment:
+    # AWS credentials
+    AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+    AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+    AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
+    AWS_REGION: "us-west-2"
+    AWS_DEFAULT_REGION: "us-west-2"
+
+    # > MWAA Configurations
+    # >> Core Configuration
+    # Use this environment variable if you have custom requirements you want to install when the
+    # container is up.
+    MWAA__CORE__REQUIREMENTS_PATH: ${MWAA__CORE__REQUIREMENTS_PATH}
+    MWAA__CORE__AUTH_TYPE: "testing"
+    # Additional Airflow configuration can be passed here in JSON form.
+    MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS: "{}"
+    MWAA__CORE__FERNET_KEY: '{"FernetKey": "fake-key-nNge+lks3RBeGVrnZ1Dq5GjKerbZKmb7dXNnsNsGy3E="}'
+    MWAA__WEBSERVER__SECRET: '{"secret_key": "fake-key-aYDdF6d+Fjznai5yBW63CUAi0IipJqDHlNSWIun6y8o="}'
+    # Use this enviornment variable to enable encryption with KMS.
+    MWAA__CORE__KMS_KEY_ARN: ${MWAA__CORE__KMS_KEY_ARN}
+    # >> Database configuration
+    MWAA__DB__CREDENTIALS: '{"username": "airflow", "password": "airflow"}'
+    MWAA__DB__POSTGRES_DB: "airflow"
+    MWAA__DB__POSTGRES_HOST: "postgres"
+    MWAA__DB__POSTGRES_PORT: "5432"
+    MWAA__DB__POSTGRES_SSLMODE: "prefer"
+    # >> SQS configuration
+    MWAA__SQS__CREATE_QUEUE: True
+    MWAA__SQS__CUSTOM_ENDPOINT: http://sqs:9324
+    MWAA__SQS__QUEUE_URL: http://sqs:9324/000000000000/celery-queue
+    MWAA__SQS__USE_SSL: False
+    # >> Logging configuration.
+    # Use these environment variables if you want to publish logs to CloudWatch.
+    MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED: ${MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED}
+    MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN: ${MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN}
+    MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_LEVEL: ${MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_LEVEL}
+    MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED: ${MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED}
+    MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN: ${MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN}
+    MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL: ${MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL}
+    MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED: ${MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED}
+    MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN: ${MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN}
+    MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_LEVEL: ${MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_LEVEL}
+    MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED: ${MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED}
+    MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN: ${MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN}
+    MWAA__LOGGING__AIRFLOW_TASK_LOG_LEVEL: ${MWAA__LOGGING__AIRFLOW_TASK_LOG_LEVEL}
+    MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED: ${MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED}
+    MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN: ${MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN}
+    MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_LEVEL: ${MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_LEVEL}
+    MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED: ${MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED}
+    MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN: ${MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN}
+    MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL: ${MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL}
+
+  volumes:
+    - ./dags:/usr/local/airflow/dags
+    - ./plugins:/usr/local/airflow/plugins
+    - ./requirements:/usr/local/airflow/requirements
+    - ./startup:/usr/local/airflow/startup
+
+  depends_on: &airflow-common-depends-on
+    postgres:
+      condition: service_healthy
+    sqs:
+      condition: service_healthy
+
+services:
+  postgres:
+    image: postgres:13
+    container_name: mwaa-292-db
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DB: airflow
+    volumes:
+      - postgres-db-volume:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "airflow"]
+      interval: 10s
+      retries: 5
+      start_period: 5s
+    restart: always
+    ports:
+      - 5432:5432
+    expose:
+      - 5432
+
+  sqs:
+    image: softwaremill/elasticmq:latest
+    healthcheck:
+      # https://github.com/softwaremill/elasticmq/issues/776#issuecomment-1582527921
+      test: ["CMD-SHELL", "wget -q -S -O - 127.0.0.1:9324/?Action=ListQueues"]
+      interval: 10s
+      retries: 5
+      start_period: 5s
+    ports:
+      - 9324:9324
+      - 9325:9325
+    expose:
+      - 9324
+      - 9325
+
+  spy:
+    <<: *airflow-common
+    command: spy
+    container_name: mwaa-292-spy
+
+  webserver:
+    <<: *airflow-common
+    command: webserver
+    container_name: mwaa-292-webserver
+    ports:
+      - 8080:8080
+    expose:
+      - 8080
+
+  # Launches a scheduler/worker hybrid container
+  hybrid:
+    <<: *airflow-common
+    command: hybrid
+    container_name: mwaa-292-hybrid
+
+volumes:
+  postgres-db-volume:
+    name: "mwaa-292-db-volume"

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -545,8 +545,8 @@ def _get_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: Lis
     Get the scheduler subproceses: scheduler, dag-processor, and triggerer.
     
     :param environ: A dictionary containing the environment variables.
-    :param conditions: A list of process conditions.
-    :returns: A list of conditions for the given Airflow command.
+    :param conditions: A list of subprocess conditions.
+    :returns: Scheduler subprocesses.
     """
     return [
             create_airflow_subprocess(
@@ -566,7 +566,7 @@ def _get_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: Lis
 
 def _get_conditions(airflow_cmd: str):
     """
-    Get healthcheck conditions for the given Airflow command.
+    Get conditions for the given Airflow command.
     
     :param airflow_cmd: The command to get conditions for, e.g. "scheduler"
     :returns: A list of conditions for the given Airflow command.

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -620,10 +620,11 @@ def run_airflow_command(cmd: str, environ: Dict[str, str]):
             # The Sidecar healthcheck is currently limited to one healthcheck per port
             # so the hybrid container can only include healthchecks for one subprocess.
             # Only the worker healcheck conditions are enabled to monitor container health, so
-            # we pass an empty list of conditions to the scheduler process.
+            # we pass an empty list of conditions to the scheduler process and make worker
+            # process essential.
             scheduler_subprocesses = _get_airflow_scheduler_subprocesses(environ, [])
             worker_subprocesses = _get_airflow_worker_subprocesses(environ)
-            run_subprocesses(worker_subprocesses + scheduler_subprocesses)
+            run_subprocesses(scheduler_subprocesses, worker_subprocesses)
 
         case _:
             raise ValueError(f"Unexpected command: {cmd}")

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -646,7 +646,6 @@ def run_airflow_command(cmd: str, environ: Dict[str, str]):
                 else:
                     worker_patience_interval = HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT
             except (ValueError, TypeError):
-                print("BANNA!")
                 worker_patience_interval = HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT
 
             worker_subprocesses = _create_airflow_worker_subprocesses(environ,

--- a/images/airflow/2.9.2/python/mwaa/logging/config.py
+++ b/images/airflow/2.9.2/python/mwaa/logging/config.py
@@ -199,7 +199,8 @@ def _configure():
             logging_enabled=logging_enabled,
         )
 
-
+# Airflow has a dedicated logger for the DAG Processor Manager
+DAG_PROCESSOR_LOGGER_NAME = "airflow.processor_manager"
 SCHEDULER_LOGGER_NAME = "mwaa.scheduler"
 SCHEDULER_REQUIREMENTS_LOGGER_NAME = "mwaa.scheduler_requirements"
 SCHEDULER_STARTUP_LOGGER_NAME = "mwaa.scheduler_startup"


### PR DESCRIPTION
Adds the command 'hybrid' to the entrypoint script to allow creation of a container that runs both celery worker and scheduler sub-processes.

*Issue #, if available:* N/A

*Description of changes:*

Introduces a new supported command 'hybrid' to run celery worker and scheduler sub-processes in the same docker container. Health-check conditions for the 'hybrid' container are limited to the 'worker ' sub-process because the Sidecar does not support multiple health-check simultaneous connections at this time. This 'hybrid' container uses the `CeleryExecutor`, but we plan to add a separate container command to support a `LocalExecutor` setup in the future.


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
