### PR TITLE
Fix issue: Sentry causes failures in 2.9.2

### DIFF
--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -259,7 +259,6 @@ async def install_user_requirements(cmd: str, environ: dict[str, str]):
 
         pip_process = Subprocess(
             cmd=["safe-pip-install", "-r", requirements_file, *extra_args],
-            env=environ,
             process_logger=subprocess_logger,
             conditions=[
                 TimeoutCondition(USER_REQUIREMENTS_MAX_INSTALL_TIME),
@@ -683,6 +682,7 @@ async def main() -> None:
     # being captured and sent to the service hosting.
     logger.debug(f"Environment variables: %s", environ)
 
+    await install_user_requirements(command, environ)
     await airflow_db_init(environ)
     if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "testing":
         # In "simple" auth mode, we create an admin user "airflow" with password
@@ -691,7 +691,6 @@ async def main() -> None:
         # production environments.
         await create_airflow_user(environ)
     create_queue()
-    await install_user_requirements(command, environ)
 
     # Export the environment variables to .bashrc and .bash_profile to enable
     # users to run a shell on the container and have the necessary environment


### PR DESCRIPTION
*Issue #, if available:* #121

*Description of changes:*

Fix issue #121. The issue is caused because we are trying to initialize the DB before installing the requirements. This causes this line in Airflow code base to fail because `sentry_sdk` isn't installed yet:

https://github.com/apache/airflow/blob/2.9.2/airflow/sentry.py#L58

To fix this issue, I moved the installation of PIP requirements before the DB initialization.

This is unrelated to this issue, but when creating a process to install the requirements, there is no need to pass the environment variables we craft for Airflow processes, as what we simply just running a pip install command.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
