### PR TITLE
Fix issue 123: Repeated reserialization of DAGs

### DIFF
--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.34.143
+1.34.149
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.143.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.149.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.34.143
+1.34.149
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.143.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.149.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.21.0
+0.21.2
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.0.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.2.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/System-Packages-BOM.txt
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240708: MIT
-system-release-2023.5.20240708: MIT
+amazon-linux-repo-cdn-2023.5.20240722: MIT
+system-release-2023.5.20240722: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.96: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.97: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0
@@ -430,8 +430,8 @@ giflib-5.2.1: MIT
 dejavu-serif-fonts-2.37: Bitstream Vera and Public Domain
 chkconfig-1.15: GPLv2
 alsa-lib-1.2.7.2: LGPLv2+
-java-17-amazon-corretto-headless-17.0.11+9: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
-java-17-amazon-corretto-17.0.11+9: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
+java-17-amazon-corretto-headless-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
+java-17-amazon-corretto-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
 libcurl-devel-8.5.0: curl
 cyrus-sasl-lib-2.1.27: BSD with advertising
 openldap-2.4.57: OpenLDAP

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.34.143
+1.34.149
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.143.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.149.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.34.143
+1.34.149
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.143.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.149.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.21.0
+0.21.2
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.0.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.2.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/System-Packages-BOM.txt
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240708: MIT
-system-release-2023.5.20240708: MIT
+amazon-linux-repo-cdn-2023.5.20240722: MIT
+system-release-2023.5.20240722: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.96: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.97: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0
@@ -430,8 +430,8 @@ giflib-5.2.1: MIT
 dejavu-serif-fonts-2.37: Bitstream Vera and Public Domain
 chkconfig-1.15: GPLv2
 alsa-lib-1.2.7.2: LGPLv2+
-java-17-amazon-corretto-headless-17.0.11+9: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
-java-17-amazon-corretto-17.0.11+9: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
+java-17-amazon-corretto-headless-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
+java-17-amazon-corretto-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
 libcurl-devel-8.5.0: curl
 cyrus-sasl-lib-2.1.27: BSD with advertising
 openldap-2.4.57: OpenLDAP

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.34.143
+1.34.149
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.143.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.149.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.34.143
+1.34.149
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.143.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.149.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.21.0
+0.21.2
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.0.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.2.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/System-Packages-BOM.txt
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240708: MIT
-system-release-2023.5.20240708: MIT
+amazon-linux-repo-cdn-2023.5.20240722: MIT
+system-release-2023.5.20240722: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.96: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.97: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0
@@ -430,8 +430,8 @@ giflib-5.2.1: MIT
 dejavu-serif-fonts-2.37: Bitstream Vera and Public Domain
 chkconfig-1.15: GPLv2
 alsa-lib-1.2.7.2: LGPLv2+
-java-17-amazon-corretto-headless-17.0.11+9: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
-java-17-amazon-corretto-17.0.11+9: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
+java-17-amazon-corretto-headless-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
+java-17-amazon-corretto-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
 libcurl-devel-8.5.0: curl
 cyrus-sasl-lib-2.1.27: BSD with advertising
 openldap-2.4.57: OpenLDAP

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.34.143
+1.34.149
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.143.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.149.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.34.143
+1.34.149
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.143.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.149.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.21.0
+0.21.2
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.0.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.2.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/System-Packages-BOM.txt
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240708: MIT
-system-release-2023.5.20240708: MIT
+amazon-linux-repo-cdn-2023.5.20240722: MIT
+system-release-2023.5.20240722: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.96: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.97: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0
@@ -430,8 +430,8 @@ giflib-5.2.1: MIT
 dejavu-serif-fonts-2.37: Bitstream Vera and Public Domain
 chkconfig-1.15: GPLv2
 alsa-lib-1.2.7.2: LGPLv2+
-java-17-amazon-corretto-headless-17.0.11+9: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
-java-17-amazon-corretto-17.0.11+9: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
+java-17-amazon-corretto-headless-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
+java-17-amazon-corretto-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
 libcurl-devel-8.5.0: curl
 cyrus-sasl-lib-2.1.27: BSD with advertising
 openldap-2.4.57: OpenLDAP

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.34.143
+1.34.149
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.143.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.149.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.34.143
+1.34.149
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.143.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.149.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.21.0
+0.21.2
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.0.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.2.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/System-Packages-BOM.txt
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240708: MIT
-system-release-2023.5.20240708: MIT
+amazon-linux-repo-cdn-2023.5.20240722: MIT
+system-release-2023.5.20240722: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.96: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.97: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0
@@ -430,8 +430,8 @@ giflib-5.2.1: MIT
 dejavu-serif-fonts-2.37: Bitstream Vera and Public Domain
 chkconfig-1.15: GPLv2
 alsa-lib-1.2.7.2: LGPLv2+
-java-17-amazon-corretto-headless-17.0.11+9: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
-java-17-amazon-corretto-17.0.11+9: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
+java-17-amazon-corretto-headless-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
+java-17-amazon-corretto-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
 libcurl-devel-8.5.0: curl
 cyrus-sasl-lib-2.1.27: BSD with advertising
 openldap-2.4.57: OpenLDAP

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.34.143
+1.34.149
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.143.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.149.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.34.143
+1.34.149
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.143.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.149.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.21.0
+0.21.2
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.0.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.2.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2/System-Packages-BOM.txt
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240708: MIT
-system-release-2023.5.20240708: MIT
+amazon-linux-repo-cdn-2023.5.20240722: MIT
+system-release-2023.5.20240722: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.96: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.97: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0
@@ -430,8 +430,8 @@ giflib-5.2.1: MIT
 dejavu-serif-fonts-2.37: Bitstream Vera and Public Domain
 chkconfig-1.15: GPLv2
 alsa-lib-1.2.7.2: LGPLv2+
-java-17-amazon-corretto-headless-17.0.11+9: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
-java-17-amazon-corretto-17.0.11+9: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
+java-17-amazon-corretto-headless-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
+java-17-amazon-corretto-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
 libcurl-devel-8.5.0: curl
 cyrus-sasl-lib-2.1.27: BSD with advertising
 openldap-2.4.57: OpenLDAP

--- a/images/airflow/2.9.2/python/mwaa/database/migrate.py
+++ b/images/airflow/2.9.2/python/mwaa/database/migrate.py
@@ -1,0 +1,69 @@
+"""
+This script is responsible for running Airflow meta database migrations.
+
+IMPORTANT NOTE: This script must be run with all the required environments exported,
+just like when running any Airflow command, as it imports Airflow modules and needs to
+connect to the meta database, thus all configurations need to be set.
+"""
+
+from argparse import Namespace
+import logging.config
+import os
+import sys
+
+from mwaa.utils.dblock import with_db_lock
+
+
+# Usually, we pass the `__name__` variable instead as that defaults to the module path,
+# i.e. `mwaa.entrypoint` in this case. However, since this is a script, `__name__` will
+# have the value of `__main__`, hence we hard-code the module path.
+logger = logging.getLogger("mwaa.database.migrate")
+
+
+def _verify_environ():
+    """
+    This script is supposed to have all the environment variables required for running
+    Airflow, since we will be using Airflow modules directly. This function verifies
+    they are set by ensuring the existence of the `AWS_EXECUTION_ENV`, which we add
+    during the creation of the `environ` dictionary in the entrypoint.py.
+    """
+    if not os.environ.get("AWS_EXECUTION_ENV", "").startswith("Amazon_MWAA_"):
+        logger.error("The necessary environment variables are not set.")
+        sys.exit(1)
+
+
+@with_db_lock(1234)
+def _migrate_db():
+    from airflow.cli.commands import db_command as airflow_db_command
+
+    try:
+        args = Namespace(migration_wait_timeout=1)
+        airflow_db_command.check_migrations(args)
+        logging.info("The database is already migrated.")
+    except TimeoutError:
+        logging.info("The database is not yet migrated. Migrating...")
+        args = Namespace(
+            from_revision=None,
+            from_version=None,
+            reserialize_dags=None,
+            show_sql_only=None,
+            to_revision=None,
+            to_version=None,
+            use_migration_files=None,
+        )
+        airflow_db_command.migratedb(args)
+        logging.info("The database is now migrated.")
+
+
+def _main():
+    _verify_environ()
+    _migrate_db()
+
+
+if __name__ == "__main__":
+    _main()
+else:
+    logger.error(
+        "This module cannot be imported. It should be run directly using: python -m mwaa.database.migrate"
+    )
+    sys.exit(1)

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -96,7 +96,6 @@ USER_REQUIREMENTS_MAX_INSTALL_TIME = timedelta(minutes=9)
 CONTAINER_START_TIME = time.time()
 
 
-@with_db_lock(1234)
 async def airflow_db_init(environ: dict[str, str]):
     """
     Initialize Airflow database.
@@ -105,13 +104,9 @@ async def airflow_db_init(environ: dict[str, str]):
     function does this. This function is called in the entrypoint to make sure that,
     for any Airflow component, the database is initialized before it starts.
 
-    This function uses a DB lock to make sure that no two processes execute this
-    function at the same time.
-
     :param environ: A dictionary containing the environment variables.
     """
-    logger.info("Calling 'airflow db migrate' to initialize the database.")
-    await run_command("airflow db migrate", env=environ)
+    await run_command("python3 -m mwaa.database.migrate", env=environ)
 
 
 @with_db_lock(4321)


### PR DESCRIPTION
*Issue #, if available:* #124

## Description of changes

Issue #124 happens because we are always calling `airflow db migrate` to make sure the database is migrated. The assumption was that the operation is a no-op if the DB is already initialized. However, this is not the case, and a reserialization of DAGs is happening every time this command is called. To avoid this, I am changing the code for executing migration to check if migration is needed.

## Testing

I did multiple tests using the Docker Compose setup. More testing by Amazon MWAA developers before this PR is merged. Suggested testing:

1. Create an internal 2.9.2 environment and make sure it is functioning normally. Also check ECS logs to ensure there are no issues.
2. Create a pre-2.9.2 environment and do an in-place upgrade to 2.9.2 and make sure the process is flawless.
3. Run a 2.9.2 environment with auto scaling enabled (ensuring that workers are being created and terminated continuously) and make sure migrations are not causing any issues.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
