### PR TITLE
Fix duplicated scheduler processes + make all airflow processes essen…

### DIFF
--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -602,13 +602,18 @@ def run_airflow_command(cmd: str, environ: Dict[str, str]):
             subprocesses = _create_airflow_scheduler_subprocesses(environ, conditions)
             # Schedulers, triggers, and DAG processors are all essential processes and
             # if any fails, we want to exit the container and let it restart.
-            run_subprocesses(subprocesses, essential_subprocesses=subprocesses)
+            run_subprocesses(
+                subprocesses=[],
+                essential_subprocesses=subprocesses)
 
         case "worker":
-            run_subprocesses(_create_airflow_worker_subprocesses(environ))
+            run_subprocesses(
+                subprocesses=[],
+                essential_subprocesses=_create_airflow_worker_subprocesses(environ))
         case "webserver":
             run_subprocesses(
-                [
+                subprocesses=[],
+                essential_subprocesses=[
                     create_airflow_subprocess(
                         ["webserver"],
                         environ=environ,


### PR DESCRIPTION
*Description of changes:*

Found a bug during performance benchmarking where there were duplicates of all scheduler airflow processes running on a scheduler container (so 1 container had 2 schedulers running). 

This PR fixes this issue and also fixes issue where worker and webserver processes are not treated as essential (meaning failed conditions would not cause container to exit).

Tested deploying image locally and deploying to mwaa dev environment.