### PR TITLE
Refactor logging to be async

### DIFF
--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.34.149
+1.35.6
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.149.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.6.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.34.149
+1.35.6
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.149.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.6.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -9645,10 +9645,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-logs
-1.34.66
+1.35.0
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.34.66.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.0.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -9674,10 +9674,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-sqs
-1.34.121
+1.35.0
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_sqs-1.34.121.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_sqs-1.35.0.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/System-Packages-BOM.txt
@@ -32,14 +32,14 @@ coreutils-single-8.32: GPLv3+
 libblkid-2.37.4: LGPLv2+
 libsigsegv-2.13: GPLv2+
 libtasn1-4.19.0: GPLv3+ and LGPLv2+
-ca-certificates-2023.2.64: Public Domain
+ca-certificates-2023.2.68: Public Domain
 glib2-2.74.7: LGPLv2+
 libverto-0.3.2: MIT
 libcurl-minimal-8.5.0: curl
 libxcrypt-4.4.33: LGPL-2.1-or-later AND BSD-3-Clause AND BSD-2-Clause AND BSD-2-Clause-FreeBSD AND 0BSD AND CC0-1.0 AND LicenseRef-Fedora-Public-Domain
 python3-libs-3.9.16: Python
 libyaml-0.2.5: MIT
-libarchive-3.5.3: BSD
+libarchive-3.7.4: BSD-2-Clause AND FSFULLR AND GPL-2.0-or-later WITH Libtool-exception AND BSD-3-Clause AND FSFUL
 rpm-libs-4.16.1.3: GPLv2+ and LGPLv2+ with exceptions
 libsolv-0.7.22: BSD
 gnupg2-minimal-2.3.7: GPLv3+
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240722: MIT
-system-release-2023.5.20240722: MIT
+amazon-linux-repo-cdn-2023.5.20240819: MIT
+system-release-2023.5.20240819: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -87,7 +87,7 @@ gawk-5.1.0: GPLv3+ and GPLv2+ and LGPLv2+ and BSD
 p11-kit-trust-0.24.1: BSD
 openssl-libs-3.0.8: ASL 2.0
 python3-pip-wheel-21.3.1: MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)
-krb5-libs-1.21: MIT
+krb5-libs-1.21.3: MIT
 curl-minimal-8.5.0: curl
 python3-3.9.16: Python
 python3-libcomps-0.1.20: GPL-2.0-or-later
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.97: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.102: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0
@@ -182,9 +182,6 @@ libtool-ltdl-2.4.7: LGPLv2+
 libstemmer-0: BSD
 libstdc++-devel-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD
 libutempter-1.2.1: LGPLv2+
-libproxy-0.4.15: LGPLv2+
-glib-networking-2.68.2: LGPLv2+
-libsoup-2.72.0: LGPLv2
 libpkgconf-1.8.0: ISC
 libjpeg-turbo-2.1.4: IJG
 gdk-pixbuf2-2.42.10: LGPLv2+
@@ -206,7 +203,7 @@ kmod-libs-29: LGPLv2+
 kernel-srpm-macros-1.0: MIT
 json-glib-1.6.6: LGPLv2+
 info-6.7: GPLv3+
-hwdata-0.353: GPLv2+
+hwdata-0.384: GPL-2.0-or-later
 libpciaccess-0.16: MIT
 libdrm-2.4.110: MIT
 mesa-va-drivers-22.3.3: MIT
@@ -292,7 +289,7 @@ google-noto-sans-vf-fonts-20201206: OFL
 langpacks-core-font-en-3.0: GPLv2+
 cairo-1.17.6: LGPLv2 or MPLv1.1
 harfbuzz-7.0.0: MIT
-freetype-2.13.0: (FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement
+freetype-2.13.2: (FTL OR GPL-2.0-or-later) AND BSD-3-Clause AND MIT AND MIT-Modern-Variant AND LicenseRef-Fedora-Public-Domain AND Zlib
 fontconfig-2.13.94: MIT and Public Domain and UCD
 libXft-2.3.3: MIT
 tk-8.6.10: TCL
@@ -311,6 +308,10 @@ findutils-4.8.0: GPLv3+
 file-5.39: BSD
 efi-srpm-macros-5: GPLv3+
 dwz-0.14: GPLv2+ and GPLv3+
+duktape-2.7.0: MIT
+libproxy-0.5.7: LGPL-2.1-or-later
+glib-networking-2.68.2: LGPLv2+
+libsoup-2.72.0: LGPLv2
 diffutils-3.8: GPLv3+
 dbus-common-1.12.28: (GPLv2+ or AFL) and GPLv2+
 dbus-broker-32: ASL 2.0
@@ -360,7 +361,7 @@ ncurses-devel-6.2: MIT
 sysprof-capture-devel-3.40.1: BSD-2-Clause-Patent
 glib2-devel-2.74.7: LGPLv2+
 harfbuzz-devel-7.0.0: MIT
-freetype-devel-2.13.0: (FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement
+freetype-devel-2.13.2: (FTL OR GPL-2.0-or-later) AND BSD-3-Clause AND MIT AND MIT-Modern-Variant AND LicenseRef-Fedora-Public-Domain AND Zlib
 valgrind-devel-3.19.0: GPLv2+
 libdrm-devel-2.4.110: MIT
 xz-devel-5.2.5: Public Domain
@@ -381,11 +382,11 @@ openssl-devel-3.0.8: ASL 2.0
 sqlite-devel-3.40.0: Public Domain
 gcc-c++-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD
 net-tools-2.0: GPLv2+
+libappstream-glib-0.7.18: LGPLv2+
 gdbm-devel-1.19: GPLv3+
 tix-devel-8.4.3: TCL
 autoconf-2.69: GPLv2+ and GFDL
 git-core-2.40.1: BSD-3-Clause AND GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later AND MIT
-libappstream-glib-0.7.18: LGPLv2+
 desktop-file-utils-0.26: GPLv2+
 systemtap-sdt-devel-4.8: GPLv2+ and Public Domain
 glibc-gconv-extra-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -435,8 +436,8 @@ java-17-amazon-corretto-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with adve
 libcurl-devel-8.5.0: curl
 cyrus-sasl-lib-2.1.27: BSD with advertising
 openldap-2.4.57: OpenLDAP
-libpq-15.7: PostgreSQL
-libpq-devel-15.7: PostgreSQL
+libpq-15.8: PostgreSQL
+libpq-devel-15.8: PostgreSQL
 procps-ng-3.3.17: GPL+ and GPLv2 and GPLv2+ and GPLv3+ and LGPLv2+
 oniguruma-6.9.7.1: BSD
 jq-1.7.1: MIT AND ICU AND CC-BY-3.0

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.34.149
+1.35.6
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.149.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.6.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.34.149
+1.35.6
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.149.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.6.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -9645,10 +9645,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-logs
-1.34.66
+1.35.0
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.34.66.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.0.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -9674,10 +9674,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-sqs
-1.34.121
+1.35.0
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_sqs-1.34.121.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_sqs-1.35.0.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/System-Packages-BOM.txt
@@ -32,14 +32,14 @@ coreutils-single-8.32: GPLv3+
 libblkid-2.37.4: LGPLv2+
 libsigsegv-2.13: GPLv2+
 libtasn1-4.19.0: GPLv3+ and LGPLv2+
-ca-certificates-2023.2.64: Public Domain
+ca-certificates-2023.2.68: Public Domain
 glib2-2.74.7: LGPLv2+
 libverto-0.3.2: MIT
 libcurl-minimal-8.5.0: curl
 libxcrypt-4.4.33: LGPL-2.1-or-later AND BSD-3-Clause AND BSD-2-Clause AND BSD-2-Clause-FreeBSD AND 0BSD AND CC0-1.0 AND LicenseRef-Fedora-Public-Domain
 python3-libs-3.9.16: Python
 libyaml-0.2.5: MIT
-libarchive-3.5.3: BSD
+libarchive-3.7.4: BSD-2-Clause AND FSFULLR AND GPL-2.0-or-later WITH Libtool-exception AND BSD-3-Clause AND FSFUL
 rpm-libs-4.16.1.3: GPLv2+ and LGPLv2+ with exceptions
 libsolv-0.7.22: BSD
 gnupg2-minimal-2.3.7: GPLv3+
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240722: MIT
-system-release-2023.5.20240722: MIT
+amazon-linux-repo-cdn-2023.5.20240819: MIT
+system-release-2023.5.20240819: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -87,7 +87,7 @@ gawk-5.1.0: GPLv3+ and GPLv2+ and LGPLv2+ and BSD
 p11-kit-trust-0.24.1: BSD
 openssl-libs-3.0.8: ASL 2.0
 python3-pip-wheel-21.3.1: MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)
-krb5-libs-1.21: MIT
+krb5-libs-1.21.3: MIT
 curl-minimal-8.5.0: curl
 python3-3.9.16: Python
 python3-libcomps-0.1.20: GPL-2.0-or-later
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.97: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.102: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0
@@ -182,9 +182,6 @@ libtool-ltdl-2.4.7: LGPLv2+
 libstemmer-0: BSD
 libstdc++-devel-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD
 libutempter-1.2.1: LGPLv2+
-libproxy-0.4.15: LGPLv2+
-glib-networking-2.68.2: LGPLv2+
-libsoup-2.72.0: LGPLv2
 libpkgconf-1.8.0: ISC
 libjpeg-turbo-2.1.4: IJG
 gdk-pixbuf2-2.42.10: LGPLv2+
@@ -206,7 +203,7 @@ kmod-libs-29: LGPLv2+
 kernel-srpm-macros-1.0: MIT
 json-glib-1.6.6: LGPLv2+
 info-6.7: GPLv3+
-hwdata-0.353: GPLv2+
+hwdata-0.384: GPL-2.0-or-later
 libpciaccess-0.16: MIT
 libdrm-2.4.110: MIT
 mesa-va-drivers-22.3.3: MIT
@@ -292,7 +289,7 @@ google-noto-sans-vf-fonts-20201206: OFL
 langpacks-core-font-en-3.0: GPLv2+
 cairo-1.17.6: LGPLv2 or MPLv1.1
 harfbuzz-7.0.0: MIT
-freetype-2.13.0: (FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement
+freetype-2.13.2: (FTL OR GPL-2.0-or-later) AND BSD-3-Clause AND MIT AND MIT-Modern-Variant AND LicenseRef-Fedora-Public-Domain AND Zlib
 fontconfig-2.13.94: MIT and Public Domain and UCD
 libXft-2.3.3: MIT
 tk-8.6.10: TCL
@@ -311,6 +308,10 @@ findutils-4.8.0: GPLv3+
 file-5.39: BSD
 efi-srpm-macros-5: GPLv3+
 dwz-0.14: GPLv2+ and GPLv3+
+duktape-2.7.0: MIT
+libproxy-0.5.7: LGPL-2.1-or-later
+glib-networking-2.68.2: LGPLv2+
+libsoup-2.72.0: LGPLv2
 diffutils-3.8: GPLv3+
 dbus-common-1.12.28: (GPLv2+ or AFL) and GPLv2+
 dbus-broker-32: ASL 2.0
@@ -360,7 +361,7 @@ ncurses-devel-6.2: MIT
 sysprof-capture-devel-3.40.1: BSD-2-Clause-Patent
 glib2-devel-2.74.7: LGPLv2+
 harfbuzz-devel-7.0.0: MIT
-freetype-devel-2.13.0: (FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement
+freetype-devel-2.13.2: (FTL OR GPL-2.0-or-later) AND BSD-3-Clause AND MIT AND MIT-Modern-Variant AND LicenseRef-Fedora-Public-Domain AND Zlib
 valgrind-devel-3.19.0: GPLv2+
 libdrm-devel-2.4.110: MIT
 xz-devel-5.2.5: Public Domain
@@ -381,11 +382,11 @@ openssl-devel-3.0.8: ASL 2.0
 sqlite-devel-3.40.0: Public Domain
 gcc-c++-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD
 net-tools-2.0: GPLv2+
+libappstream-glib-0.7.18: LGPLv2+
 gdbm-devel-1.19: GPLv3+
 tix-devel-8.4.3: TCL
 autoconf-2.69: GPLv2+ and GFDL
 git-core-2.40.1: BSD-3-Clause AND GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later AND MIT
-libappstream-glib-0.7.18: LGPLv2+
 desktop-file-utils-0.26: GPLv2+
 systemtap-sdt-devel-4.8: GPLv2+ and Public Domain
 glibc-gconv-extra-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -435,8 +436,8 @@ java-17-amazon-corretto-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with adve
 libcurl-devel-8.5.0: curl
 cyrus-sasl-lib-2.1.27: BSD with advertising
 openldap-2.4.57: OpenLDAP
-libpq-15.7: PostgreSQL
-libpq-devel-15.7: PostgreSQL
+libpq-15.8: PostgreSQL
+libpq-devel-15.8: PostgreSQL
 procps-ng-3.3.17: GPL+ and GPLv2 and GPLv2+ and GPLv3+ and LGPLv2+
 oniguruma-6.9.7.1: BSD
 jq-1.7.1: MIT AND ICU AND CC-BY-3.0

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.34.149
+1.35.6
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.149.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.6.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.34.149
+1.35.6
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.149.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.6.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -9645,10 +9645,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-logs
-1.34.66
+1.35.0
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.34.66.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.0.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -9674,10 +9674,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-sqs
-1.34.121
+1.35.0
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_sqs-1.34.121.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_sqs-1.35.0.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/System-Packages-BOM.txt
@@ -32,14 +32,14 @@ coreutils-single-8.32: GPLv3+
 libblkid-2.37.4: LGPLv2+
 libsigsegv-2.13: GPLv2+
 libtasn1-4.19.0: GPLv3+ and LGPLv2+
-ca-certificates-2023.2.64: Public Domain
+ca-certificates-2023.2.68: Public Domain
 glib2-2.74.7: LGPLv2+
 libverto-0.3.2: MIT
 libcurl-minimal-8.5.0: curl
 libxcrypt-4.4.33: LGPL-2.1-or-later AND BSD-3-Clause AND BSD-2-Clause AND BSD-2-Clause-FreeBSD AND 0BSD AND CC0-1.0 AND LicenseRef-Fedora-Public-Domain
 python3-libs-3.9.16: Python
 libyaml-0.2.5: MIT
-libarchive-3.5.3: BSD
+libarchive-3.7.4: BSD-2-Clause AND FSFULLR AND GPL-2.0-or-later WITH Libtool-exception AND BSD-3-Clause AND FSFUL
 rpm-libs-4.16.1.3: GPLv2+ and LGPLv2+ with exceptions
 libsolv-0.7.22: BSD
 gnupg2-minimal-2.3.7: GPLv3+
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240722: MIT
-system-release-2023.5.20240722: MIT
+amazon-linux-repo-cdn-2023.5.20240819: MIT
+system-release-2023.5.20240819: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -87,7 +87,7 @@ gawk-5.1.0: GPLv3+ and GPLv2+ and LGPLv2+ and BSD
 p11-kit-trust-0.24.1: BSD
 openssl-libs-3.0.8: ASL 2.0
 python3-pip-wheel-21.3.1: MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)
-krb5-libs-1.21: MIT
+krb5-libs-1.21.3: MIT
 curl-minimal-8.5.0: curl
 python3-3.9.16: Python
 python3-libcomps-0.1.20: GPL-2.0-or-later
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.97: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.102: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0
@@ -182,9 +182,6 @@ libtool-ltdl-2.4.7: LGPLv2+
 libstemmer-0: BSD
 libstdc++-devel-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD
 libutempter-1.2.1: LGPLv2+
-libproxy-0.4.15: LGPLv2+
-glib-networking-2.68.2: LGPLv2+
-libsoup-2.72.0: LGPLv2
 libpkgconf-1.8.0: ISC
 libjpeg-turbo-2.1.4: IJG
 gdk-pixbuf2-2.42.10: LGPLv2+
@@ -206,7 +203,7 @@ kmod-libs-29: LGPLv2+
 kernel-srpm-macros-1.0: MIT
 json-glib-1.6.6: LGPLv2+
 info-6.7: GPLv3+
-hwdata-0.353: GPLv2+
+hwdata-0.384: GPL-2.0-or-later
 libpciaccess-0.16: MIT
 libdrm-2.4.110: MIT
 mesa-va-drivers-22.3.3: MIT
@@ -292,7 +289,7 @@ google-noto-sans-vf-fonts-20201206: OFL
 langpacks-core-font-en-3.0: GPLv2+
 cairo-1.17.6: LGPLv2 or MPLv1.1
 harfbuzz-7.0.0: MIT
-freetype-2.13.0: (FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement
+freetype-2.13.2: (FTL OR GPL-2.0-or-later) AND BSD-3-Clause AND MIT AND MIT-Modern-Variant AND LicenseRef-Fedora-Public-Domain AND Zlib
 fontconfig-2.13.94: MIT and Public Domain and UCD
 libXft-2.3.3: MIT
 tk-8.6.10: TCL
@@ -311,6 +308,10 @@ findutils-4.8.0: GPLv3+
 file-5.39: BSD
 efi-srpm-macros-5: GPLv3+
 dwz-0.14: GPLv2+ and GPLv3+
+duktape-2.7.0: MIT
+libproxy-0.5.7: LGPL-2.1-or-later
+glib-networking-2.68.2: LGPLv2+
+libsoup-2.72.0: LGPLv2
 diffutils-3.8: GPLv3+
 dbus-common-1.12.28: (GPLv2+ or AFL) and GPLv2+
 dbus-broker-32: ASL 2.0
@@ -360,7 +361,7 @@ ncurses-devel-6.2: MIT
 sysprof-capture-devel-3.40.1: BSD-2-Clause-Patent
 glib2-devel-2.74.7: LGPLv2+
 harfbuzz-devel-7.0.0: MIT
-freetype-devel-2.13.0: (FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement
+freetype-devel-2.13.2: (FTL OR GPL-2.0-or-later) AND BSD-3-Clause AND MIT AND MIT-Modern-Variant AND LicenseRef-Fedora-Public-Domain AND Zlib
 valgrind-devel-3.19.0: GPLv2+
 libdrm-devel-2.4.110: MIT
 xz-devel-5.2.5: Public Domain
@@ -381,11 +382,11 @@ openssl-devel-3.0.8: ASL 2.0
 sqlite-devel-3.40.0: Public Domain
 gcc-c++-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD
 net-tools-2.0: GPLv2+
+libappstream-glib-0.7.18: LGPLv2+
 gdbm-devel-1.19: GPLv3+
 tix-devel-8.4.3: TCL
 autoconf-2.69: GPLv2+ and GFDL
 git-core-2.40.1: BSD-3-Clause AND GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later AND MIT
-libappstream-glib-0.7.18: LGPLv2+
 desktop-file-utils-0.26: GPLv2+
 systemtap-sdt-devel-4.8: GPLv2+ and Public Domain
 glibc-gconv-extra-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -435,8 +436,8 @@ java-17-amazon-corretto-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with adve
 libcurl-devel-8.5.0: curl
 cyrus-sasl-lib-2.1.27: BSD with advertising
 openldap-2.4.57: OpenLDAP
-libpq-15.7: PostgreSQL
-libpq-devel-15.7: PostgreSQL
+libpq-15.8: PostgreSQL
+libpq-devel-15.8: PostgreSQL
 procps-ng-3.3.17: GPL+ and GPLv2 and GPLv2+ and GPLv3+ and LGPLv2+
 oniguruma-6.9.7.1: BSD
 jq-1.7.1: MIT AND ICU AND CC-BY-3.0

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.34.149
+1.35.6
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.149.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.6.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.34.149
+1.35.6
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.149.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.6.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -9645,10 +9645,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-logs
-1.34.66
+1.35.0
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.34.66.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.0.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -9674,10 +9674,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-sqs
-1.34.121
+1.35.0
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_sqs-1.34.121.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_sqs-1.35.0.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/System-Packages-BOM.txt
@@ -32,14 +32,14 @@ coreutils-single-8.32: GPLv3+
 libblkid-2.37.4: LGPLv2+
 libsigsegv-2.13: GPLv2+
 libtasn1-4.19.0: GPLv3+ and LGPLv2+
-ca-certificates-2023.2.64: Public Domain
+ca-certificates-2023.2.68: Public Domain
 glib2-2.74.7: LGPLv2+
 libverto-0.3.2: MIT
 libcurl-minimal-8.5.0: curl
 libxcrypt-4.4.33: LGPL-2.1-or-later AND BSD-3-Clause AND BSD-2-Clause AND BSD-2-Clause-FreeBSD AND 0BSD AND CC0-1.0 AND LicenseRef-Fedora-Public-Domain
 python3-libs-3.9.16: Python
 libyaml-0.2.5: MIT
-libarchive-3.5.3: BSD
+libarchive-3.7.4: BSD-2-Clause AND FSFULLR AND GPL-2.0-or-later WITH Libtool-exception AND BSD-3-Clause AND FSFUL
 rpm-libs-4.16.1.3: GPLv2+ and LGPLv2+ with exceptions
 libsolv-0.7.22: BSD
 gnupg2-minimal-2.3.7: GPLv3+
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240722: MIT
-system-release-2023.5.20240722: MIT
+amazon-linux-repo-cdn-2023.5.20240819: MIT
+system-release-2023.5.20240819: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -87,7 +87,7 @@ gawk-5.1.0: GPLv3+ and GPLv2+ and LGPLv2+ and BSD
 p11-kit-trust-0.24.1: BSD
 openssl-libs-3.0.8: ASL 2.0
 python3-pip-wheel-21.3.1: MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)
-krb5-libs-1.21: MIT
+krb5-libs-1.21.3: MIT
 curl-minimal-8.5.0: curl
 python3-3.9.16: Python
 python3-libcomps-0.1.20: GPL-2.0-or-later
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.97: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.102: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0
@@ -182,9 +182,6 @@ libtool-ltdl-2.4.7: LGPLv2+
 libstemmer-0: BSD
 libstdc++-devel-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD
 libutempter-1.2.1: LGPLv2+
-libproxy-0.4.15: LGPLv2+
-glib-networking-2.68.2: LGPLv2+
-libsoup-2.72.0: LGPLv2
 libpkgconf-1.8.0: ISC
 libjpeg-turbo-2.1.4: IJG
 gdk-pixbuf2-2.42.10: LGPLv2+
@@ -206,7 +203,7 @@ kmod-libs-29: LGPLv2+
 kernel-srpm-macros-1.0: MIT
 json-glib-1.6.6: LGPLv2+
 info-6.7: GPLv3+
-hwdata-0.353: GPLv2+
+hwdata-0.384: GPL-2.0-or-later
 libpciaccess-0.16: MIT
 libdrm-2.4.110: MIT
 mesa-va-drivers-22.3.3: MIT
@@ -292,7 +289,7 @@ google-noto-sans-vf-fonts-20201206: OFL
 langpacks-core-font-en-3.0: GPLv2+
 cairo-1.17.6: LGPLv2 or MPLv1.1
 harfbuzz-7.0.0: MIT
-freetype-2.13.0: (FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement
+freetype-2.13.2: (FTL OR GPL-2.0-or-later) AND BSD-3-Clause AND MIT AND MIT-Modern-Variant AND LicenseRef-Fedora-Public-Domain AND Zlib
 fontconfig-2.13.94: MIT and Public Domain and UCD
 libXft-2.3.3: MIT
 tk-8.6.10: TCL
@@ -311,6 +308,10 @@ findutils-4.8.0: GPLv3+
 file-5.39: BSD
 efi-srpm-macros-5: GPLv3+
 dwz-0.14: GPLv2+ and GPLv3+
+duktape-2.7.0: MIT
+libproxy-0.5.7: LGPL-2.1-or-later
+glib-networking-2.68.2: LGPLv2+
+libsoup-2.72.0: LGPLv2
 diffutils-3.8: GPLv3+
 dbus-common-1.12.28: (GPLv2+ or AFL) and GPLv2+
 dbus-broker-32: ASL 2.0
@@ -360,7 +361,7 @@ ncurses-devel-6.2: MIT
 sysprof-capture-devel-3.40.1: BSD-2-Clause-Patent
 glib2-devel-2.74.7: LGPLv2+
 harfbuzz-devel-7.0.0: MIT
-freetype-devel-2.13.0: (FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement
+freetype-devel-2.13.2: (FTL OR GPL-2.0-or-later) AND BSD-3-Clause AND MIT AND MIT-Modern-Variant AND LicenseRef-Fedora-Public-Domain AND Zlib
 valgrind-devel-3.19.0: GPLv2+
 libdrm-devel-2.4.110: MIT
 xz-devel-5.2.5: Public Domain
@@ -381,11 +382,11 @@ openssl-devel-3.0.8: ASL 2.0
 sqlite-devel-3.40.0: Public Domain
 gcc-c++-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD
 net-tools-2.0: GPLv2+
+libappstream-glib-0.7.18: LGPLv2+
 gdbm-devel-1.19: GPLv3+
 tix-devel-8.4.3: TCL
 autoconf-2.69: GPLv2+ and GFDL
 git-core-2.40.1: BSD-3-Clause AND GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later AND MIT
-libappstream-glib-0.7.18: LGPLv2+
 desktop-file-utils-0.26: GPLv2+
 systemtap-sdt-devel-4.8: GPLv2+ and Public Domain
 glibc-gconv-extra-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -435,8 +436,8 @@ java-17-amazon-corretto-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with adve
 libcurl-devel-8.5.0: curl
 cyrus-sasl-lib-2.1.27: BSD with advertising
 openldap-2.4.57: OpenLDAP
-libpq-15.7: PostgreSQL
-libpq-devel-15.7: PostgreSQL
+libpq-15.8: PostgreSQL
+libpq-devel-15.8: PostgreSQL
 procps-ng-3.3.17: GPL+ and GPLv2 and GPLv2+ and GPLv3+ and LGPLv2+
 oniguruma-6.9.7.1: BSD
 jq-1.7.1: MIT AND ICU AND CC-BY-3.0

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.34.149
+1.35.6
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.149.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.6.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.34.149
+1.35.6
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.149.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.6.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -9645,10 +9645,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-logs
-1.34.66
+1.35.0
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.34.66.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.0.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -9674,10 +9674,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-sqs
-1.34.121
+1.35.0
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_sqs-1.34.121.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_sqs-1.35.0.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/System-Packages-BOM.txt
@@ -32,14 +32,14 @@ coreutils-single-8.32: GPLv3+
 libblkid-2.37.4: LGPLv2+
 libsigsegv-2.13: GPLv2+
 libtasn1-4.19.0: GPLv3+ and LGPLv2+
-ca-certificates-2023.2.64: Public Domain
+ca-certificates-2023.2.68: Public Domain
 glib2-2.74.7: LGPLv2+
 libverto-0.3.2: MIT
 libcurl-minimal-8.5.0: curl
 libxcrypt-4.4.33: LGPL-2.1-or-later AND BSD-3-Clause AND BSD-2-Clause AND BSD-2-Clause-FreeBSD AND 0BSD AND CC0-1.0 AND LicenseRef-Fedora-Public-Domain
 python3-libs-3.9.16: Python
 libyaml-0.2.5: MIT
-libarchive-3.5.3: BSD
+libarchive-3.7.4: BSD-2-Clause AND FSFULLR AND GPL-2.0-or-later WITH Libtool-exception AND BSD-3-Clause AND FSFUL
 rpm-libs-4.16.1.3: GPLv2+ and LGPLv2+ with exceptions
 libsolv-0.7.22: BSD
 gnupg2-minimal-2.3.7: GPLv3+
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240722: MIT
-system-release-2023.5.20240722: MIT
+amazon-linux-repo-cdn-2023.5.20240819: MIT
+system-release-2023.5.20240819: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -87,7 +87,7 @@ gawk-5.1.0: GPLv3+ and GPLv2+ and LGPLv2+ and BSD
 p11-kit-trust-0.24.1: BSD
 openssl-libs-3.0.8: ASL 2.0
 python3-pip-wheel-21.3.1: MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)
-krb5-libs-1.21: MIT
+krb5-libs-1.21.3: MIT
 curl-minimal-8.5.0: curl
 python3-3.9.16: Python
 python3-libcomps-0.1.20: GPL-2.0-or-later
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.97: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.102: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0
@@ -182,9 +182,6 @@ libtool-ltdl-2.4.7: LGPLv2+
 libstemmer-0: BSD
 libstdc++-devel-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD
 libutempter-1.2.1: LGPLv2+
-libproxy-0.4.15: LGPLv2+
-glib-networking-2.68.2: LGPLv2+
-libsoup-2.72.0: LGPLv2
 libpkgconf-1.8.0: ISC
 libjpeg-turbo-2.1.4: IJG
 gdk-pixbuf2-2.42.10: LGPLv2+
@@ -206,7 +203,7 @@ kmod-libs-29: LGPLv2+
 kernel-srpm-macros-1.0: MIT
 json-glib-1.6.6: LGPLv2+
 info-6.7: GPLv3+
-hwdata-0.353: GPLv2+
+hwdata-0.384: GPL-2.0-or-later
 libpciaccess-0.16: MIT
 libdrm-2.4.110: MIT
 mesa-va-drivers-22.3.3: MIT
@@ -292,7 +289,7 @@ google-noto-sans-vf-fonts-20201206: OFL
 langpacks-core-font-en-3.0: GPLv2+
 cairo-1.17.6: LGPLv2 or MPLv1.1
 harfbuzz-7.0.0: MIT
-freetype-2.13.0: (FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement
+freetype-2.13.2: (FTL OR GPL-2.0-or-later) AND BSD-3-Clause AND MIT AND MIT-Modern-Variant AND LicenseRef-Fedora-Public-Domain AND Zlib
 fontconfig-2.13.94: MIT and Public Domain and UCD
 libXft-2.3.3: MIT
 tk-8.6.10: TCL
@@ -311,6 +308,10 @@ findutils-4.8.0: GPLv3+
 file-5.39: BSD
 efi-srpm-macros-5: GPLv3+
 dwz-0.14: GPLv2+ and GPLv3+
+duktape-2.7.0: MIT
+libproxy-0.5.7: LGPL-2.1-or-later
+glib-networking-2.68.2: LGPLv2+
+libsoup-2.72.0: LGPLv2
 diffutils-3.8: GPLv3+
 dbus-common-1.12.28: (GPLv2+ or AFL) and GPLv2+
 dbus-broker-32: ASL 2.0
@@ -360,7 +361,7 @@ ncurses-devel-6.2: MIT
 sysprof-capture-devel-3.40.1: BSD-2-Clause-Patent
 glib2-devel-2.74.7: LGPLv2+
 harfbuzz-devel-7.0.0: MIT
-freetype-devel-2.13.0: (FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement
+freetype-devel-2.13.2: (FTL OR GPL-2.0-or-later) AND BSD-3-Clause AND MIT AND MIT-Modern-Variant AND LicenseRef-Fedora-Public-Domain AND Zlib
 valgrind-devel-3.19.0: GPLv2+
 libdrm-devel-2.4.110: MIT
 xz-devel-5.2.5: Public Domain
@@ -381,11 +382,11 @@ openssl-devel-3.0.8: ASL 2.0
 sqlite-devel-3.40.0: Public Domain
 gcc-c++-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD
 net-tools-2.0: GPLv2+
+libappstream-glib-0.7.18: LGPLv2+
 gdbm-devel-1.19: GPLv3+
 tix-devel-8.4.3: TCL
 autoconf-2.69: GPLv2+ and GFDL
 git-core-2.40.1: BSD-3-Clause AND GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later AND MIT
-libappstream-glib-0.7.18: LGPLv2+
 desktop-file-utils-0.26: GPLv2+
 systemtap-sdt-devel-4.8: GPLv2+ and Public Domain
 glibc-gconv-extra-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -435,8 +436,8 @@ java-17-amazon-corretto-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with adve
 libcurl-devel-8.5.0: curl
 cyrus-sasl-lib-2.1.27: BSD with advertising
 openldap-2.4.57: OpenLDAP
-libpq-15.7: PostgreSQL
-libpq-devel-15.7: PostgreSQL
+libpq-15.8: PostgreSQL
+libpq-devel-15.8: PostgreSQL
 procps-ng-3.3.17: GPL+ and GPLv2 and GPLv2+ and GPLv3+ and LGPLv2+
 oniguruma-6.9.7.1: BSD
 jq-1.7.1: MIT AND ICU AND CC-BY-3.0

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.34.149
+1.35.6
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.34.149.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.6.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.34.149
+1.35.6
 MIT License
 https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.34.149.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.6.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -9645,10 +9645,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-logs
-1.34.66
+1.35.0
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.34.66.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.0.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -9674,10 +9674,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-sqs
-1.34.121
+1.35.0
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_sqs-1.34.121.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_sqs-1.35.0.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2/System-Packages-BOM.txt
@@ -32,14 +32,14 @@ coreutils-single-8.32: GPLv3+
 libblkid-2.37.4: LGPLv2+
 libsigsegv-2.13: GPLv2+
 libtasn1-4.19.0: GPLv3+ and LGPLv2+
-ca-certificates-2023.2.64: Public Domain
+ca-certificates-2023.2.68: Public Domain
 glib2-2.74.7: LGPLv2+
 libverto-0.3.2: MIT
 libcurl-minimal-8.5.0: curl
 libxcrypt-4.4.33: LGPL-2.1-or-later AND BSD-3-Clause AND BSD-2-Clause AND BSD-2-Clause-FreeBSD AND 0BSD AND CC0-1.0 AND LicenseRef-Fedora-Public-Domain
 python3-libs-3.9.16: Python
 libyaml-0.2.5: MIT
-libarchive-3.5.3: BSD
+libarchive-3.7.4: BSD-2-Clause AND FSFULLR AND GPL-2.0-or-later WITH Libtool-exception AND BSD-3-Clause AND FSFUL
 rpm-libs-4.16.1.3: GPLv2+ and LGPLv2+ with exceptions
 libsolv-0.7.22: BSD
 gnupg2-minimal-2.3.7: GPLv3+
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240722: MIT
-system-release-2023.5.20240722: MIT
+amazon-linux-repo-cdn-2023.5.20240819: MIT
+system-release-2023.5.20240819: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -87,7 +87,7 @@ gawk-5.1.0: GPLv3+ and GPLv2+ and LGPLv2+ and BSD
 p11-kit-trust-0.24.1: BSD
 openssl-libs-3.0.8: ASL 2.0
 python3-pip-wheel-21.3.1: MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)
-krb5-libs-1.21: MIT
+krb5-libs-1.21.3: MIT
 curl-minimal-8.5.0: curl
 python3-3.9.16: Python
 python3-libcomps-0.1.20: GPL-2.0-or-later
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.97: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.102: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0
@@ -182,9 +182,6 @@ libtool-ltdl-2.4.7: LGPLv2+
 libstemmer-0: BSD
 libstdc++-devel-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD
 libutempter-1.2.1: LGPLv2+
-libproxy-0.4.15: LGPLv2+
-glib-networking-2.68.2: LGPLv2+
-libsoup-2.72.0: LGPLv2
 libpkgconf-1.8.0: ISC
 libjpeg-turbo-2.1.4: IJG
 gdk-pixbuf2-2.42.10: LGPLv2+
@@ -206,7 +203,7 @@ kmod-libs-29: LGPLv2+
 kernel-srpm-macros-1.0: MIT
 json-glib-1.6.6: LGPLv2+
 info-6.7: GPLv3+
-hwdata-0.353: GPLv2+
+hwdata-0.384: GPL-2.0-or-later
 libpciaccess-0.16: MIT
 libdrm-2.4.110: MIT
 mesa-va-drivers-22.3.3: MIT
@@ -292,7 +289,7 @@ google-noto-sans-vf-fonts-20201206: OFL
 langpacks-core-font-en-3.0: GPLv2+
 cairo-1.17.6: LGPLv2 or MPLv1.1
 harfbuzz-7.0.0: MIT
-freetype-2.13.0: (FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement
+freetype-2.13.2: (FTL OR GPL-2.0-or-later) AND BSD-3-Clause AND MIT AND MIT-Modern-Variant AND LicenseRef-Fedora-Public-Domain AND Zlib
 fontconfig-2.13.94: MIT and Public Domain and UCD
 libXft-2.3.3: MIT
 tk-8.6.10: TCL
@@ -311,6 +308,10 @@ findutils-4.8.0: GPLv3+
 file-5.39: BSD
 efi-srpm-macros-5: GPLv3+
 dwz-0.14: GPLv2+ and GPLv3+
+duktape-2.7.0: MIT
+libproxy-0.5.7: LGPL-2.1-or-later
+glib-networking-2.68.2: LGPLv2+
+libsoup-2.72.0: LGPLv2
 diffutils-3.8: GPLv3+
 dbus-common-1.12.28: (GPLv2+ or AFL) and GPLv2+
 dbus-broker-32: ASL 2.0
@@ -360,7 +361,7 @@ ncurses-devel-6.2: MIT
 sysprof-capture-devel-3.40.1: BSD-2-Clause-Patent
 glib2-devel-2.74.7: LGPLv2+
 harfbuzz-devel-7.0.0: MIT
-freetype-devel-2.13.0: (FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement
+freetype-devel-2.13.2: (FTL OR GPL-2.0-or-later) AND BSD-3-Clause AND MIT AND MIT-Modern-Variant AND LicenseRef-Fedora-Public-Domain AND Zlib
 valgrind-devel-3.19.0: GPLv2+
 libdrm-devel-2.4.110: MIT
 xz-devel-5.2.5: Public Domain
@@ -381,11 +382,11 @@ openssl-devel-3.0.8: ASL 2.0
 sqlite-devel-3.40.0: Public Domain
 gcc-c++-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD
 net-tools-2.0: GPLv2+
+libappstream-glib-0.7.18: LGPLv2+
 gdbm-devel-1.19: GPLv3+
 tix-devel-8.4.3: TCL
 autoconf-2.69: GPLv2+ and GFDL
 git-core-2.40.1: BSD-3-Clause AND GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later AND MIT
-libappstream-glib-0.7.18: LGPLv2+
 desktop-file-utils-0.26: GPLv2+
 systemtap-sdt-devel-4.8: GPLv2+ and Public Domain
 glibc-gconv-extra-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -435,8 +436,8 @@ java-17-amazon-corretto-17.0.12+7: ASL 1.1 and ASL 2.0 and BSD and BSD with adve
 libcurl-devel-8.5.0: curl
 cyrus-sasl-lib-2.1.27: BSD with advertising
 openldap-2.4.57: OpenLDAP
-libpq-15.7: PostgreSQL
-libpq-devel-15.7: PostgreSQL
+libpq-15.8: PostgreSQL
+libpq-devel-15.8: PostgreSQL
 procps-ng-3.3.17: GPL+ and GPLv2 and GPLv2+ and GPLv3+ and LGPLv2+
 oniguruma-6.9.7.1: BSD
 jq-1.7.1: MIT AND ICU AND CC-BY-3.0

--- a/images/airflow/2.9.2/explore-image.sh
+++ b/images/airflow/2.9.2/explore-image.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker container run -it amazon-mwaa/airflow:2.9.2-explorer-dev
+docker container run -it amazon-mwaa-docker-images/airflow:2.9.2-explorer-dev

--- a/images/airflow/2.9.2/python/mwaa/subprocess/__init__.py
+++ b/images/airflow/2.9.2/python/mwaa/subprocess/__init__.py
@@ -10,19 +10,9 @@ class ProcessStatus(Enum):
     An enum that represents the status of a process.
 
     The status can be one of the following:
-    - FINISHED_WITH_NO_MORE_LOGS: The process has finished and there are no more logs to
-      read.
-    - FINISHED_WITH_LOG_READ: The process has finished but a log was recently read,
-      meaning there are potentially more logs that need to be read.
-    - RUNNING_WITH_NO_LOG_READ: The process is running but no log was read in the latest
-      attempt to read logs, thus a sleep is required before attempting to read more
-      logs to avoid spiking the CPU.
-    - RUNNING_WITH_LOG_READ: The process is running and a log was read in the latest
-      attempt, thus we should continue trying to read more logs to avoid delaying
-      logs publishing.
+    - FINISHED: The process has finished.
+    - RUNNING: The process is running. 
     """
 
-    FINISHED_WITH_NO_MORE_LOGS = 0
-    FINISHED_WITH_LOG_READ = 1
-    RUNNING_WITH_NO_LOG_READ = 2
-    RUNNING_WITH_LOG_READ = 3
+    FINISHED = 1
+    RUNNING = 2

--- a/images/airflow/2.9.2/python/mwaa/subprocess/subprocess.py
+++ b/images/airflow/2.9.2/python/mwaa/subprocess/subprocess.py
@@ -35,7 +35,7 @@ _SIGTERM_DEFAULT_PATIENCE_INTERVAL = timedelta(seconds=90)
 
 # The time for which the log reader will sleep when subprocess is still running
 # But last log read was empty.
-_SUBPROCESS_LOG_POLL_IDLE_SLEEP_INTERVAL = timedelta(milliseconds=50)
+_SUBPROCESS_LOG_POLL_IDLE_SLEEP_INTERVAL = timedelta(milliseconds=100)
 
 
 module_logger = logging.getLogger(__name__)
@@ -223,12 +223,11 @@ class Subprocess:
         Execute a single iteration of the execution loop.
 
         The execution loop is a loop that continuously monitors the status of the
-        process and captures logs if any. This method executes a single iteration and
-        exit, expecting the caller to repeatedly call this method until it returns
-        `False`, meaning that the process has exited and there are no more logs to
-        ingest.
+        process. This method executes a single iteration and exits, expecting the
+        caller to repeatedly call this method until it returns
+        `False`, meaning that the process has exited.
 
-        :return: True if the process is still running and/or there are more logs to read.
+        :return: True if the process is still running.
         """
         if not self.process:
             # Process is not running anymore.
@@ -244,9 +243,7 @@ class Subprocess:
         if self.process_status == ProcessStatus.FINISHED:
             # We are done; call shutdown to ensure that we free all resources.
             self.shutdown()
-        elif self.process_status in [
-            ProcessStatus.RUNNING
-        ]:
+        elif self.process_status == ProcessStatus.RUNNING:
             # The process is still running, so we need to check conditions.
             failed_conditions = self._check_process_conditions()
 
@@ -295,9 +292,7 @@ class Subprocess:
             return
         self.is_shut_down = True
 
-        if self.process and self.process_status in [
-            ProcessStatus.RUNNING
-        ]:
+        if self.process and self.process_status == ProcessStatus.RUNNING:
             self._shutdown_python_subprocess(self.process)
         self.process = None
 

--- a/images/airflow/2.9.2/python/mwaa/subprocess/subprocess.py
+++ b/images/airflow/2.9.2/python/mwaa/subprocess/subprocess.py
@@ -20,6 +20,7 @@ import signal
 import subprocess
 import sys
 import time
+from threading import Thread
 
 # Our imports
 from mwaa.logging.loggers import CompositeLogger
@@ -31,6 +32,10 @@ from mwaa.subprocess.conditions import ProcessCondition, ProcessConditionRespons
 # The maximum time we can wait for a process to gracefully respond to a SIGTERM signal
 # from us before we forcefully terminate the process with a SIGKILL.
 _SIGTERM_DEFAULT_PATIENCE_INTERVAL = timedelta(seconds=90)
+
+# The time for which the log reader will sleep when subprocess is still running
+# But last log read was empty.
+_SUBPROCESS_LOG_POLL_IDLE_SLEEP_INTERVAL = timedelta(milliseconds=50)
 
 
 module_logger = logging.getLogger(__name__)
@@ -88,6 +93,7 @@ class Subprocess:
 
         self.start_time: float | None = None
         self.process: Popen[Any] | None = None
+        self.log_thread: Thread | None = None
 
         self.is_shut_down = False
 
@@ -161,15 +167,17 @@ class Subprocess:
             # Stop the process at exit.
             atexit.register(self.shutdown)
 
-            self.process_status = ProcessStatus.RUNNING_WITH_NO_LOG_READ
+            self.process_status = ProcessStatus.RUNNING
 
+            self.log_thread = Thread(target=self._read_subprocess_log_stream, args=(self.process,))
             if auto_enter_execution_loop:
+                self.log_thread.start()
+                start_time = time.time()
                 while self.execution_loop_iter():
-                    if self.process_status == ProcessStatus.RUNNING_WITH_NO_LOG_READ:
-                        # There are no pending logs in the process, so we sleep for a while
-                        # to avoid getting into a continuous execution that spikes the CPU
-                        # and impacts the Airflow process.
-                        time.sleep(1)
+                    dt = time.time() - start_time
+                    time.sleep(max(1.0 - dt, 0))
+                    start_time = time.time()
+                self.log_thread.join()
         except Exception as ex:
             module_logger.fatal(
                 "Unexpected error occurred while trying to start a process "
@@ -187,6 +195,29 @@ class Subprocess:
 
         return failed_conditions
 
+    def _read_subprocess_log_stream(self, process: Popen[Any]):
+        """
+        Poll process stdout and forward logs to subprocess logger
+        until process has terminated and stream is empty.
+        If stream is empty but process is still running then sleep
+        for small duration to avoid wasted cpu resources.
+        """
+        stream = process.stdout
+        while True:
+            if not stream or stream.closed:
+                break
+            line = stream.readline()
+            if line == b"":
+                if process.poll() is not None:
+                    break
+                else:
+                    time.sleep(_SUBPROCESS_LOG_POLL_IDLE_SLEEP_INTERVAL.total_seconds())
+            else:
+                self.process_logger.info(line.decode("utf-8"))
+    
+    def _get_subprocess_status(self, process: Popen[Any]):
+        return ProcessStatus.RUNNING if process.poll() is None else ProcessStatus.FINISHED
+
     def execution_loop_iter(self):
         """
         Execute a single iteration of the execution loop.
@@ -203,23 +234,18 @@ class Subprocess:
             # Process is not running anymore.
             return False
 
-        if self.process_status == ProcessStatus.FINISHED_WITH_NO_MORE_LOGS:
-            # The process has finished and there are no more logs to read so we
+        if self.process_status == ProcessStatus.FINISHED:
+            # The process has finished.
             # just return False so the caller stop looping.
             return False
 
-        self.process_status = self._capture_output_line_from_process(self.process)
+        self.process_status = self._get_subprocess_status(self.process)
 
-        process_completed_and_logs_processed = (
-            self.process_status == ProcessStatus.FINISHED_WITH_NO_MORE_LOGS
-        )
-
-        if process_completed_and_logs_processed:
+        if self.process_status == ProcessStatus.FINISHED:
             # We are done; call shutdown to ensure that we free all resources.
             self.shutdown()
         elif self.process_status in [
-            ProcessStatus.RUNNING_WITH_NO_LOG_READ,
-            ProcessStatus.RUNNING_WITH_LOG_READ,
+            ProcessStatus.RUNNING
         ]:
             # The process is still running, so we need to check conditions.
             failed_conditions = self._check_process_conditions()
@@ -233,10 +259,10 @@ class Subprocess:
 """.strip()
                 )
                 self.shutdown()
-                self.process_status = ProcessStatus.FINISHED_WITH_NO_MORE_LOGS
-                process_completed_and_logs_processed = True
+                self.process_status = ProcessStatus.FINISHED
+                return False
 
-        return not process_completed_and_logs_processed
+        return True
 
     def _create_python_subprocess(self) -> Popen[Any]:
         module_logger.info(f"Starting new subprocess for command '{self.cmd}'...")
@@ -262,31 +288,6 @@ class Subprocess:
         )
         return process
 
-    def _capture_output_line_from_process(self, process: Popen[Any]):
-        """
-        Read log lines from the Airflow process and upload them to CloudWatch.
-
-        :param process: The process to read lines from.
-
-        :return: The process status. See ProcessStatus enum for the possible values.
-        """
-        line = b""
-        if process.stdout and not process.stdout.closed:
-            line = process.stdout.readline()
-        process_finished = process.poll() is not None
-        if line == b"" and process_finished:
-            return ProcessStatus.FINISHED_WITH_NO_MORE_LOGS
-        if line:
-            # Send the log to the logger.
-            self.process_logger.info(line.decode("utf-8"))
-            return (
-                ProcessStatus.FINISHED_WITH_LOG_READ
-                if process_finished
-                else ProcessStatus.RUNNING_WITH_LOG_READ
-            )
-        else:
-            return ProcessStatus.RUNNING_WITH_NO_LOG_READ
-
     def shutdown(self):
         """Stop and close the subprocess and its resources."""
         if self.is_shut_down:
@@ -295,8 +296,7 @@ class Subprocess:
         self.is_shut_down = True
 
         if self.process and self.process_status in [
-            ProcessStatus.RUNNING_WITH_NO_LOG_READ,
-            ProcessStatus.RUNNING_WITH_LOG_READ,
+            ProcessStatus.RUNNING
         ]:
             self._shutdown_python_subprocess(self.process)
         self.process = None
@@ -334,6 +334,16 @@ class Subprocess:
             f"Process {action_taken}. Return code is {self.process.returncode}."
         )
 
+    def start_log_capture(self):
+        """Start async capturing of logs from subprocess and forward them to process logger"""
+        if self.log_thread:
+            self.log_thread.start()
+
+    def finish_log_capture(self):
+        """Block until capturing of subprocess logs is complete"""
+        if self.log_thread:
+            self.log_thread.join()
+
 
 def run_subprocesses(
     subprocesses: List[Subprocess], essential_subprocesses: List[Subprocess] = []
@@ -358,19 +368,14 @@ def run_subprocesses(
     all_processes = subprocesses + essential_subprocesses
     for s in all_processes:
         s.start(False)  # False since we want to run the subprocesses in parallel
+        s.start_log_capture()
     running_processes = all_processes
-    read_some_logs = True
     while len(running_processes) > 0:
-        read_some_logs = False
+        start_time = time.time()
         finished_processes: List[Subprocess] = []
         for s in running_processes:
             if not s.execution_loop_iter():
                 finished_processes.append(s)
-            if s.process_status in [
-                ProcessStatus.FINISHED_WITH_LOG_READ,
-                ProcessStatus.RUNNING_WITH_LOG_READ,
-            ]:
-                read_some_logs = True
 
         # Remove finished processes from the list of running processes.
         running_processes = [s for s in running_processes if s not in finished_processes]
@@ -388,11 +393,11 @@ def run_subprocesses(
             for s in running_processes:
                 s.shutdown()
             break
+        dt = time.time() - start_time
+        time.sleep(max(1.0 - dt, 0))
+    for s in all_processes:
+        s.finish_log_capture()
 
-        if not read_some_logs:
-            # We didn't read any logs from any process. Sleep for a bit so we don't
-            # enter into a tight loop that spikes the CPU.
-            time.sleep(1)
 
 
 def _sigterm_handler(signal: int, frame: Optional[FrameType]):


### PR DESCRIPTION
*Description of changes:*

Performance testing MWAA airflow images revealed flaws with how logging is plumbed to CloudWatch. 

Currently, when airflow publishes log statements it is sent to an os pipe to be polled and read by the entrypoint process and then forwarded to cloudwatch. When this pipe is full, airflow must halt until logs are read before continuing execution. This means airflow execution is upper-bounded by how fast the entrypoint can read logs. 

The entrypoint has many other priorities in this critical loop (heartbeat healthcheck, db healthcheck, polling other subprocess logs, etc) and it has be measured that airflow scheduler is significantly throttled by this mechanism when log volume is large.

This PR aims to fix this by separating log polling into its own thread. This allows for faster log reading that is decoupled from the execution of the entrypoint process loop. Below is "before" and "after" profiler flamegraph results of a mwaa scheduler over a 1-minute period of execution under heavy scheduling and log load.

### Before
![Screenshot 2024-08-27 at 1 43 08 AM](https://github.com/user-attachments/assets/d2ecf5f9-7260-4de3-9654-ac0a48cee457)


### After
![Screenshot 2024-08-27 at 1 40 26 AM](https://github.com/user-attachments/assets/dddfc792-54c3-47a9-9f6d-20c5927b3088)

In the before, we see that waiting for the log message to be read by the entry point is all the scheduler was able to do in the entire 1-minute interval. However with async logging, scheduler is able to complete multiple loops.


