### PR TITLE
Update references to subprocess status

### DIFF
--- a/images/airflow/2.9.2/python/mwaa/subprocess/conditions.py
+++ b/images/airflow/2.9.2/python/mwaa/subprocess/conditions.py
@@ -494,10 +494,7 @@ class AutoScalingCondition(ProcessCondition):
         :returns A ProcessConditionResponse containing data about the response.
         """
 
-        if process_status in [
-            ProcessStatus.RUNNING_WITH_LOG_READ,
-            ProcessStatus.RUNNING_WITH_NO_LOG_READ,
-        ]:
+        if process_status == ProcessStatus.RUNNING:
             self.worker_task_monitor.cleanup_abandoned_resources()
             if self.worker_task_monitor.is_worker_idle():
                 logger.info(f"Worker process is idle. Pausing task consumption...")


### PR DESCRIPTION
*Issue #, if available:* N/A

Fixing references to old subprocess status in AutoScalingCondition. The RUNNING_WITH_LOG_READ and RUNNING_WITH_NO_LOG_READ no longer exist and have been replaced by the RUNNING status.