### PR TITLE
Fix Hybrid Container Healthcheck Throttling

### DIFF
--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -645,7 +645,7 @@ def run_airflow_command(cmd: str, environ: Dict[str, str]):
 
             worker_subprocesses = _create_airflow_worker_subprocesses(environ,
                                                                    sigterm_patience_interval=worker_patience_interval)
-            run_subprocesses(worker_subprocesses + scheduler_subprocesses)
+            run_subprocesses(scheduler_subprocesses + worker_subprocesses)
 
         case _:
             raise ValueError(f"Unexpected command: {cmd}")

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -645,7 +645,7 @@ def run_airflow_command(cmd: str, environ: Dict[str, str]):
 
             worker_subprocesses = _create_airflow_worker_subprocesses(environ,
                                                                    sigterm_patience_interval=worker_patience_interval)
-            run_subprocesses(scheduler_subprocesses + worker_subprocesses)
+            run_subprocesses(worker_subprocesses + scheduler_subprocesses)
 
         case _:
             raise ValueError(f"Unexpected command: {cmd}")

--- a/images/airflow/2.9.2/python/mwaa/subprocess/subprocess.py
+++ b/images/airflow/2.9.2/python/mwaa/subprocess/subprocess.py
@@ -83,7 +83,7 @@ class Subprocess:
         # some messages are useful to both, the customer (typically the customer's
         # CloudWatch) and the service (Fargate, i.e. the service's CloudWatch).
         self.dual_logger = CompositeLogger(
-            "process_module_dual_logger_{friendly_name}",  # name can be anything unused.
+            "process_module_dual_logger",  # name can be anything unused.
             # We use a set to avoid double logging using the module logger if the user
             # doesn't pass a logger.
             *set([self.process_logger, module_logger]),


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Discovered an issue where the worker healthchecks were not being performed in the hybrid container when the worker subprocess was run after the scheduler subprocess. Upon further investigation the root cause was determined to be the throttling conditions for the method `_check_process_conditions` which restricted the container to one call of the function per 60 seconds. This PR removes calls to `_check_process_conditions` in the subprocess `execution_loop_iter` loop if the subprocess does not have conditions. Also changes the throttle settings of `_check_process_conditions` to be instance level rather than global so that it is throttled per subprocess.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
