### PR TITLE
feat: support LocalExecutor

### DIFF
--- a/images/airflow/2.9.2/python/mwaa/config/sqs.py
+++ b/images/airflow/2.9.2/python/mwaa/config/sqs.py
@@ -124,13 +124,11 @@ def get_sqs_queue_name() -> str:
 
 def should_create_queue() -> bool:
     """
-    Determine whether the SQS queue should be created or not.
+    Determine whether the SQS queue should be created or not. Only used with CeleryExecutor.
 
     :return: True or False.
     """
-    executor_type = os.environ.get("MWAA__CORE__EXECUTOR_TYPE", "CeleryExecutor").lower()
-    create_queue = os.environ.get("MWAA__SQS__CREATE_QUEUE", "false").lower()
-    return (executor_type == "celeryexecutor") and (create_queue == "true")
+    return os.environ.get("MWAA__SQS__CREATE_QUEUE", "false").lower() == "true"
 
 def should_use_ssl() -> bool:
     """

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -564,7 +564,7 @@ def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patienc
 def _create_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: List):
     """
     Get the scheduler subproceses: scheduler, dag-processor, and triggerer.
-    
+
     :param environ: A dictionary containing the environment variables.
     :param conditions: A list of subprocess conditions.
     :returns: Scheduler subprocesses.
@@ -588,7 +588,7 @@ def _create_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: 
 def _create_airflow_process_conditions(airflow_cmd: str):
     """
     Get conditions for the given Airflow command.
-    
+
     :param airflow_cmd: The command to get conditions for, e.g. "scheduler"
     :returns: A list of conditions for the given Airflow command.
     """
@@ -671,8 +671,11 @@ async def main() -> None:
 
     logger.info(f"Warming a Docker container for an Airflow {command}.")
 
+    # Get executor type
+    executor_type = os.environ.get("MWAA__CORE__EXECUTOR_TYPE", "CeleryExecutor")
+
     # Add the necessary environment variables.
-    mwaa_essential_airflow_config = get_essential_airflow_config()
+    mwaa_essential_airflow_config = get_essential_airflow_config(executor_type)
     mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
     mwaa_essential_airflow_environ = get_essential_environ(command)
     mwaa_opinionated_airflow_environ = get_opinionated_environ()
@@ -728,7 +731,8 @@ async def main() -> None:
         # having to create a user manually. Needless to say, this shouldn't be used in
         # production environments.
         await create_airflow_user(environ)
-    create_queue()
+    if executor_type.lower() == "celeryexecutor":
+        create_queue()
 
     # Export the environment variables to .bashrc and .bash_profile to enable
     # users to run a shell on the container and have the necessary environment


### PR DESCRIPTION
1. Adds support for LocalExecutor when `MWAA__SQS__CREATE_QUEUE` is set to false. If we're not creating an SQS queue/using Celery, then we don't want to attempt to create the CeleryExecutor. This is useful for environments where a discrete worker is not necessary/too expensive.
2. Adds a config variable `MWAA__CORE__DISABLE_CORS` (default false), which, when set to true, sets all CORS-related headers to accept all connections. This is required to make MWAA work in embedded environments (i.e. within a portal or webpage)