### PR TITLE
Pass environment variables to safe-pip-install

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -261,6 +261,7 @@ async def install_user_requirements(cmd: str, environ: dict[str, str]):
 
         pip_process = Subprocess(
             cmd=["safe-pip-install", "-r", requirements_file, *extra_args],
+            env=environ,
             process_logger=subprocess_logger,
             conditions=[
                 TimeoutCondition(USER_REQUIREMENTS_MAX_INSTALL_TIME),

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.35.6
+1.35.16
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.6.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.16.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.35.6
+1.35.16
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.6.dist-info/LICENSE
+https://github.com/youtype/botocore-stubs
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.16.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -9645,10 +9645,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-logs
-1.35.0
+1.35.12
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.0.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.12.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.21.2
+0.21.5
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.2.dist-info/LICENSE
+https://github.com/youtype/types-awscrt
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.5.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14935,10 +14935,10 @@ UNKNOWN
 UNKNOWN
 
 types-s3transfer
-0.10.1
+0.10.2
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_s3transfer-0.10.1.dist-info/LICENSE
+https://github.com/youtype/types-s3transfer
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_s3transfer-0.10.2.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/System-Packages-BOM.txt
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240819: MIT
-system-release-2023.5.20240819: MIT
+amazon-linux-repo-cdn-2023.5.20240903: MIT
+system-release-2023.5.20240903: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.102: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.106: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.35.6
+1.35.16
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.6.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.16.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.35.6
+1.35.16
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.6.dist-info/LICENSE
+https://github.com/youtype/botocore-stubs
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.16.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -9645,10 +9645,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-logs
-1.35.0
+1.35.12
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.0.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.12.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.21.2
+0.21.5
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.2.dist-info/LICENSE
+https://github.com/youtype/types-awscrt
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.5.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14935,10 +14935,10 @@ UNKNOWN
 UNKNOWN
 
 types-s3transfer
-0.10.1
+0.10.2
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_s3transfer-0.10.1.dist-info/LICENSE
+https://github.com/youtype/types-s3transfer
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_s3transfer-0.10.2.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/System-Packages-BOM.txt
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240819: MIT
-system-release-2023.5.20240819: MIT
+amazon-linux-repo-cdn-2023.5.20240903: MIT
+system-release-2023.5.20240903: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.102: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.106: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.35.6
+1.35.16
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.6.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.16.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.35.6
+1.35.16
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.6.dist-info/LICENSE
+https://github.com/youtype/botocore-stubs
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.16.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -9645,10 +9645,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-logs
-1.35.0
+1.35.12
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.0.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.12.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.21.2
+0.21.5
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.2.dist-info/LICENSE
+https://github.com/youtype/types-awscrt
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.5.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14935,10 +14935,10 @@ UNKNOWN
 UNKNOWN
 
 types-s3transfer
-0.10.1
+0.10.2
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_s3transfer-0.10.1.dist-info/LICENSE
+https://github.com/youtype/types-s3transfer
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_s3transfer-0.10.2.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/System-Packages-BOM.txt
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240819: MIT
-system-release-2023.5.20240819: MIT
+amazon-linux-repo-cdn-2023.5.20240903: MIT
+system-release-2023.5.20240903: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.102: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.106: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.35.6
+1.35.16
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.6.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.16.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.35.6
+1.35.16
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.6.dist-info/LICENSE
+https://github.com/youtype/botocore-stubs
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.16.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -9645,10 +9645,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-logs
-1.35.0
+1.35.12
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.0.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.12.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.21.2
+0.21.5
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.2.dist-info/LICENSE
+https://github.com/youtype/types-awscrt
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.5.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14935,10 +14935,10 @@ UNKNOWN
 UNKNOWN
 
 types-s3transfer
-0.10.1
+0.10.2
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_s3transfer-0.10.1.dist-info/LICENSE
+https://github.com/youtype/types-s3transfer
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_s3transfer-0.10.2.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/System-Packages-BOM.txt
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240819: MIT
-system-release-2023.5.20240819: MIT
+amazon-linux-repo-cdn-2023.5.20240903: MIT
+system-release-2023.5.20240903: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.102: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.106: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.35.6
+1.35.16
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.6.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.16.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.35.6
+1.35.16
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.6.dist-info/LICENSE
+https://github.com/youtype/botocore-stubs
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.16.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -9645,10 +9645,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-logs
-1.35.0
+1.35.12
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.0.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.12.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.21.2
+0.21.5
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.2.dist-info/LICENSE
+https://github.com/youtype/types-awscrt
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.5.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14935,10 +14935,10 @@ UNKNOWN
 UNKNOWN
 
 types-s3transfer
-0.10.1
+0.10.2
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_s3transfer-0.10.1.dist-info/LICENSE
+https://github.com/youtype/types-s3transfer
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_s3transfer-0.10.2.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/System-Packages-BOM.txt
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240819: MIT
-system-release-2023.5.20240819: MIT
+amazon-linux-repo-cdn-2023.5.20240903: MIT
+system-release-2023.5.20240903: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.102: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.106: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.35.6
+1.35.16
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.6.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.35.16.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.35.6
+1.35.16
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.6.dist-info/LICENSE
+https://github.com/youtype/botocore-stubs
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.35.16.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -9645,10 +9645,10 @@ UNKNOWN
 UNKNOWN
 
 mypy-boto3-logs
-1.35.0
+1.35.12
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.0.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/mypy_boto3_logs-1.35.12.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2024 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.21.2
+0.21.5
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.2.dist-info/LICENSE
+https://github.com/youtype/types-awscrt
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.21.5.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14935,10 +14935,10 @@ UNKNOWN
 UNKNOWN
 
 types-s3transfer
-0.10.1
+0.10.2
 MIT License
-https://youtype.github.io/mypy_boto3_builder/
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_s3transfer-0.10.1.dist-info/LICENSE
+https://github.com/youtype/types-s3transfer
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_s3transfer-0.10.2.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2/System-Packages-BOM.txt
@@ -55,8 +55,8 @@ libgcc-11.4.1: GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and 
 crypto-policies-20220428: LGPLv2+
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.5.20240819: MIT
-system-release-2023.5.20240819: MIT
+amazon-linux-repo-cdn-2023.5.20240903: MIT
+system-release-2023.5.20240903: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
@@ -138,7 +138,7 @@ libedit-3.1: BSD
 llvm-libs-15.0.7: Apache-2.0 WITH LLVM-exception OR NCSA
 libXau-1.0.9: MIT
 libxcb-1.13.1: MIT
-kernel-headers-6.1.102: GPLv2 and Redistributable, no modification permitted
+kernel-headers-6.1.106: GPLv2 and Redistributable, no modification permitted
 jansson-2.14: MIT
 graphite2-1.3.14: (LGPLv2+ or GPLv2+ or MPLv1.1) and (Netscape or GPLv2+ or LGPLv2+)
 emacs-filesystem-28.2: GPLv3+ and CC0

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -261,6 +261,7 @@ async def install_user_requirements(cmd: str, environ: dict[str, str]):
 
         pip_process = Subprocess(
             cmd=["safe-pip-install", "-r", requirements_file, *extra_args],
+            env=environ,
             process_logger=subprocess_logger,
             conditions=[
                 TimeoutCondition(USER_REQUIREMENTS_MAX_INSTALL_TIME),


### PR DESCRIPTION
*Issue #, if available:* fixes #126

*Description of changes:*

Adding back passing of environment variables to pip package install. This allows the use of credentials via environment variables for private pypi repos. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
