### PR TITLE
Generate dev version of requirements in create_venvs script

### DIFF
--- a/.github/workflows/quality-checks.yaml
+++ b/.github/workflows/quality-checks.yaml
@@ -44,7 +44,7 @@ jobs:
         run: git config --global --add safe.directory /__w/amazon-mwaa-docker-images/amazon-mwaa-docker-images
 
       - name: Create the necessary Python virtual environments...
-        run: python3.11 ./create_venvs.py
+        run: python3.11 ./create_venvs.py --target production
 
       - name: Run quality checks...
         run: python3.11 ./quality-checks/run_all.py

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .venv
 venv
 
+# Pyenv local overrides
+.python-version
+
 # Python cache files
 __pycache__/
 *.py[cod]
@@ -12,3 +15,6 @@ __pycache__/
 # Build directories
 build
 
+# Ignore dev requirements files.
+images/airflow/2.*/requirements-dev.txt
+images/airflow/3.*/requirements-dev.txt

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To experiment with the image using a vanilla Docker setup, follow these steps:
    package, execute the following command:
 
 ```
-python3 create_venvs.py
+python3 create_venvs.py --target <development | production>
 ```
 
 3. Build the Airflow v2.9.2 Docker image

--- a/create_venvs.py
+++ b/create_venvs.py
@@ -124,7 +124,6 @@ def main():
         "--recreate", action="store_true", help="Recreate the venv if it exists"
     )
 
-    # Ensure that a build target is set, rather than using a default to prevent 
     development_target_choice = "development"
     build_targets = [development_target_choice, "production"]
     parser.add_argument(


### PR DESCRIPTION
*Issue #, if available:*
52

*Description of changes:* 

Generate `requirements-dev.txt` file in the create_venvs script and replace psycopg2 with psycopg2-binary.

This means that pg_config will not be required for a development build.  psycopg2 should still be built from source for a production build as per the guidance of psycopg2-binary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
