### PR TITLE
Add dependabot config with airflow ignored.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directories: 
+      - "/images/airflow/*/etc"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # For Airflow, ignore all updates
+      - dependency-name: "apache-airflow"


### PR DESCRIPTION
*Issue #, if available:*
Closes #132 

*Description of changes:*
Adds Airflow to the dependabot ignore list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
