### PR TITLE
Load default Airflow connections on initialization

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/database/migrate.py
+++ b/images/airflow/2.10.1/python/mwaa/database/migrate.py
@@ -55,10 +55,21 @@ def _migrate_db():
         logging.info("The database is now migrated.")
 
 
+@with_db_lock(1234)
+def _create_default_connections():
+    from airflow.cli.commands import connection_command as airflow_connection_command
+
+    try:
+        args = Namespace(verbose=False)
+        airflow_connection_command.create_default_connections(args)
+        logging.info("The default Airflow connections have been created.")
+    except TimeoutError:
+        logging.warning("Timed out on initializatin of default Airflow connections.")
+
 def _main():
     _verify_environ()
     _migrate_db()
-
+    _create_default_connections()
 
 if __name__ == "__main__":
     _main()

--- a/images/airflow/2.9.2/python/mwaa/database/migrate.py
+++ b/images/airflow/2.9.2/python/mwaa/database/migrate.py
@@ -54,11 +54,21 @@ def _migrate_db():
         airflow_db_command.migratedb(args)
         logging.info("The database is now migrated.")
 
+@with_db_lock(1234)
+def _create_default_connections():
+    from airflow.cli.commands import connection_command as airflow_connection_command
+
+    try:
+        args = Namespace(verbose=False)
+        airflow_connection_command.create_default_connections(args)
+        logging.info("The default Airflow connections have been created.")
+    except TimeoutError:
+        logging.warning("Timed out on initializatin of default Airflow connections.")
 
 def _main():
     _verify_environ()
     _migrate_db()
-
+    _create_default_connections()
 
 if __name__ == "__main__":
     _main()


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

`airflow initdb`, which was the defacto way to initialize the Airflow metadatabase, is now deprecated as of 2.7, and the command was split into: `airflow db migrate` and `airflow connections create-default-connections`. In our images, we are correctly using `airflow db migrate`, but did not port the default connection initialization. This leads to provider-related connections to not be created for new 2.9.2+ environments, which are required for many Operators; an AirflowNotFoundException will be thrown instead and fail the task. Providers' hooks fetch the connection [[base hook implementation]](https://github.com/apache/airflow/blob/4404e64247daf37b350bc7cd835d397256507ad1/airflow/hooks/base.py#L65), which does a lookup that will fail without attempting to create the connection [[connection implementation]](https://github.com/apache/airflow/blob/main/airflow/models/connection.py#L445C9-L445C36). It's theoretically possible that some providers handle this case, but we shouldn't rely on that..

According to the [airflow documentation](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#load-default-connections), this should be done explicitly to retain default connection loading behaviour. Note the difference in documentation for initializing the airflow db between these versions:
[2.6.3 documentation](https://airflow.apache.org/docs/apache-airflow/2.6.3/howto/set-up-database.html)
[2.9.2 documentation](https://airflow.apache.org/docs/apache-airflow/2.9.2/howto/set-up-database.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
