### PR TITLE
Added tini as init process to all airflow images. (#176)

### DIFF
--- a/images/airflow/2.10.1/docker-compose-hybrid.yaml
+++ b/images/airflow/2.10.1/docker-compose-hybrid.yaml
@@ -3,6 +3,7 @@ version: "3.8"
 x-airflow-common: &airflow-common
   image: amazon-mwaa-docker-images/airflow:2.10.1-dev
   restart: always
+  init: true
   environment:
     # AWS credentials
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}

--- a/images/airflow/2.10.1/docker-compose-resetdb.yaml
+++ b/images/airflow/2.10.1/docker-compose-resetdb.yaml
@@ -2,6 +2,7 @@ version: "3.8"
 
 x-airflow-common: &airflow-common
   image: amazon-mwaa-docker-images/airflow:2.10.1-dev
+  init: true
   environment:
     # AWS credentials
     AWS_ACCESS_KEY_ID: "FAKE_AWS_ACCESS_KEY_ID"

--- a/images/airflow/2.10.1/docker-compose.yaml
+++ b/images/airflow/2.10.1/docker-compose.yaml
@@ -3,6 +3,7 @@ version: "3.8"
 x-airflow-common: &airflow-common
   image: amazon-mwaa-docker-images/airflow:2.10.1-dev
   restart: always
+  init: true
   environment:
     # AWS credentials
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}

--- a/images/airflow/2.10.3/docker-compose-hybrid.yaml
+++ b/images/airflow/2.10.3/docker-compose-hybrid.yaml
@@ -3,6 +3,7 @@ version: "3.8"
 x-airflow-common: &airflow-common
   image: amazon-mwaa-docker-images/airflow:2.10.3-dev
   restart: always
+  init: true
   environment:
     # AWS credentials
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}

--- a/images/airflow/2.10.3/docker-compose-resetdb.yaml
+++ b/images/airflow/2.10.3/docker-compose-resetdb.yaml
@@ -2,6 +2,7 @@ version: "3.8"
 
 x-airflow-common: &airflow-common
   image: amazon-mwaa-docker-images/airflow:2.10.3-dev
+  init: true
   environment:
     # AWS credentials
     AWS_ACCESS_KEY_ID: "FAKE_AWS_ACCESS_KEY_ID"

--- a/images/airflow/2.10.3/docker-compose.yaml
+++ b/images/airflow/2.10.3/docker-compose.yaml
@@ -3,6 +3,7 @@ version: "3.8"
 x-airflow-common: &airflow-common
   image: amazon-mwaa-docker-images/airflow:2.10.3-dev
   restart: always
+  init: true
   environment:
     # AWS credentials
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}

--- a/images/airflow/2.9.2/docker-compose-hybrid.yaml
+++ b/images/airflow/2.9.2/docker-compose-hybrid.yaml
@@ -3,6 +3,7 @@ version: "3.8"
 x-airflow-common: &airflow-common
   image: amazon-mwaa-docker-images/airflow:2.9.2-dev
   restart: always
+  init: true
   environment:
     # AWS credentials
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}

--- a/images/airflow/2.9.2/docker-compose-resetdb.yaml
+++ b/images/airflow/2.9.2/docker-compose-resetdb.yaml
@@ -2,6 +2,7 @@ version: "3.8"
 
 x-airflow-common: &airflow-common
   image: amazon-mwaa-docker-images/airflow:2.9.2-dev
+  init: true
   environment:
     # AWS credentials
     AWS_ACCESS_KEY_ID: "FAKE_AWS_ACCESS_KEY_ID"

--- a/images/airflow/2.9.2/docker-compose.yaml
+++ b/images/airflow/2.9.2/docker-compose.yaml
@@ -3,6 +3,7 @@ version: "3.8"
 x-airflow-common: &airflow-common
   image: amazon-mwaa-docker-images/airflow:2.9.2-dev
   restart: always
+  init: true
   environment:
     # AWS credentials
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}


### PR DESCRIPTION
Issue #, if available: [#176](https://github.com/aws/amazon-mwaa-docker-images/issues/176)

*Description of changes:*
- Updated `Dockerfile.base.j2` file to include necessary url components to download `tini`.
- Updated `Dockerfile.derivatives.j2`, set the container entrypoint to use `tini` as init system and launches MWAA's Python entrypoint module.
- Added `tini` installation and permissions setup in `001-init.sh` script.
- Made the above changes to all airflow images.

### UPDATE
Going forward to use docker's inbuilt init. Hence, enabling it in docker compose.

*Description of testing:*
- Built and ran image locally with the run.sh script.
- Checked if tini is running as PID#1 using `/proc/1/status`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
