### PR TITLE
Generate cache and pass valid fernet keys in 2.10.1 and 2.10.3 (#196)

### DIFF
--- a/images/airflow/2.10.1/docker-compose.yaml
+++ b/images/airflow/2.10.1/docker-compose.yaml
@@ -19,7 +19,7 @@ x-airflow-common: &airflow-common
     MWAA__CORE__AUTH_TYPE: "testing"
     # Additional Airflow configuration can be passed here in JSON form.
     MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS: "{}"
-    MWAA__CORE__FERNET_KEY: '{"FernetKey": "fake-key-nNge+lks3RBeGVrnZ1Dq5GjKerbZKmb7dXNnsNsGy3E="}'
+    MWAA__CORE__FERNET_KEY: ${FERNET_KEY}
     MWAA__WEBSERVER__SECRET: '{"secret_key": "fake-key-aYDdF6d+Fjznai5yBW63CUAi0IipJqDHlNSWIun6y8o="}'
     # Use this enviornment variable to enable encryption with KMS.
     MWAA__CORE__KMS_KEY_ARN: ${MWAA__CORE__KMS_KEY_ARN}

--- a/images/airflow/2.10.1/generate_fernet_key.py
+++ b/images/airflow/2.10.1/generate_fernet_key.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""
+This Module generates Fernet keys, which are used by Airflow for connection encryption
+"""
+
+from cryptography.fernet import Fernet
+import json
+
+def generate_fernet_key():
+    """
+    Generate a Fernet key and return it as a JSON string.
+
+    :returns A JSON string containing the generated Fernet key in the format {"FernetKey": "<key>"}
+    """
+    key = Fernet.generate_key().decode()
+    return json.dumps({"FernetKey": key})
+
+if __name__ == "__main__":
+    print(generate_fernet_key())

--- a/images/airflow/2.10.1/temporary-pip-install
+++ b/images/airflow/2.10.1/temporary-pip-install
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script is specifically designed for temporarily installing packages needed ONLY before bootstrap steps.
+# It intentionally bypasses constraint checks, since it is intended that the packages will be used for setup/configuration 
+# and then UNINSTALLED before the bootstrap steps, during local setup.
+#
+# NOTE: This script should NOT be used for installing production Airflow/MWAA dependencies.
+# For those, use 'safe-pip-install' which properly handles Airflow/MWAA constraints.
+
+pip3 install "$@"

--- a/images/airflow/2.10.3/docker-compose.yaml
+++ b/images/airflow/2.10.3/docker-compose.yaml
@@ -19,7 +19,7 @@ x-airflow-common: &airflow-common
     MWAA__CORE__AUTH_TYPE: "testing"
     # Additional Airflow configuration can be passed here in JSON form.
     MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS: "{}"
-    MWAA__CORE__FERNET_KEY: '{"FernetKey": "fake-key-nNge+lks3RBeGVrnZ1Dq5GjKerbZKmb7dXNnsNsGy3E="}'
+    MWAA__CORE__FERNET_KEY: ${FERNET_KEY}
     MWAA__WEBSERVER__SECRET: '{"secret_key": "fake-key-aYDdF6d+Fjznai5yBW63CUAi0IipJqDHlNSWIun6y8o="}'
     # Use this enviornment variable to enable encryption with KMS.
     MWAA__CORE__KMS_KEY_ARN: ${MWAA__CORE__KMS_KEY_ARN}

--- a/images/airflow/2.10.3/generate_fernet_key.py
+++ b/images/airflow/2.10.3/generate_fernet_key.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""
+This Module generates Fernet keys, which are used by Airflow for connection encryption
+"""
+
+from cryptography.fernet import Fernet
+import json
+
+def generate_fernet_key():
+    """
+    Generate a Fernet key and return it as a JSON string.
+
+    :returns A JSON string containing the generated Fernet key in the format {"FernetKey": "<key>"}
+    """
+    key = Fernet.generate_key().decode()
+    return json.dumps({"FernetKey": key})
+
+if __name__ == "__main__":
+    print(generate_fernet_key())

--- a/images/airflow/2.10.3/temporary-pip-install
+++ b/images/airflow/2.10.3/temporary-pip-install
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script is specifically designed for temporarily installing packages needed ONLY before bootstrap steps.
+# It intentionally bypasses constraint checks, since it is intended that the packages will be used for setup/configuration 
+# and then UNINSTALLED before the bootstrap steps, during local setup.
+#
+# NOTE: This script should NOT be used for installing production Airflow/MWAA dependencies.
+# For those, use 'safe-pip-install' which properly handles Airflow/MWAA constraints.
+
+pip3 install "$@"


### PR DESCRIPTION
*Issue #, if available:* #196

*Description of changes:*
- Adding the valid fernet key generation changes made in [this pull request](https://github.com/aws/amazon-mwaa-docker-images/pull/207) to the 2.10.1 and 2.10.3 images as well.

Description of testing:

- Built and ran images locally with the run.sh script.
- Used log statements to verify the fernet key was valid and being passed correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
