### PR TITLE
Publish hybrid requirements and startup script logs to CloudWatch

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -228,6 +228,9 @@ async def install_user_requirements(cmd: str, environ: dict[str, str]):
     """
     requirements_file = environ.get("MWAA__CORE__REQUIREMENTS_PATH")
     logger.info(f"MWAA__CORE__REQUIREMENTS_PATH = {requirements_file}")
+    # For hybrid worker/scheduler containers we publish the requirement install logs
+    # to the worker CloudWatch log group.
+    logger_prefix = "worker" if cmd == "hybrid" else cmd;
     if requirements_file and os.path.isfile(requirements_file):
         logger.info(f"Installing user requirements from {requirements_file}...")
 
@@ -237,7 +240,7 @@ async def install_user_requirements(cmd: str, environ: dict[str, str]):
             # use CloudWatch for logging.
             *set(
                 [
-                    logging.getLogger(MWAA_LOGGERS.get(f"{cmd}_requirements")),
+                    logging.getLogger(MWAA_LOGGERS.get(f"{logger_prefix}_requirements")),
                     logger,
                 ]
             ),
@@ -266,7 +269,7 @@ async def install_user_requirements(cmd: str, environ: dict[str, str]):
             conditions=[
                 TimeoutCondition(USER_REQUIREMENTS_MAX_INSTALL_TIME),
             ],
-            friendly_name=f"{cmd}_requirements",
+            friendly_name=f"{logger_prefix}_requirements",
         )
         pip_process.start()
         if pip_process.process and pip_process.process.returncode != 0:
@@ -296,7 +299,10 @@ def execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]:
 
     EXECUTE_USER_STARTUP_SCRIPT_PATH = "execute-user-startup-script"
     POST_STARTUP_SCRIPT_VERIFICATION_PATH = "post-startup-script-verification"
-    PROCESS_LOGGER = logging.getLogger(MWAA_LOGGERS.get(f"{cmd}_startup"))
+    # For hybrid worker/scheduler containers we publish the startup script logs
+    # to the worker CloudWatch log group.
+    PROCESS_LOGGER_PREFIX = "worker" if cmd == "hybrid" else cmd;
+    PROCESS_LOGGER = logging.getLogger(MWAA_LOGGERS.get(f"{PROCESS_LOGGER_PREFIX}_startup"))
 
     if os.path.isfile(startup_script_path):
         logger.info("Executing customer startup script.")
@@ -309,7 +315,7 @@ def execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]:
             conditions=[
                 TimeoutCondition(STARTUP_SCRIPT_MAX_EXECUTION_TIME),
             ],
-            friendly_name=f"{cmd}_startup",
+            friendly_name=f"{PROCESS_LOGGER_PREFIX}_startup",
             sigterm_patience_interval=STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL,
         )
         startup_script_process.start()
@@ -325,7 +331,7 @@ def execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]:
             conditions=[
                 TimeoutCondition(STARTUP_SCRIPT_MAX_EXECUTION_TIME),
             ],
-            friendly_name=f"{cmd}_startup",
+            friendly_name=f"{PROCESS_LOGGER_PREFIX}_startup",
         )
         verification_process.start()
 

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -723,7 +723,6 @@ async def main() -> None:
         )
 
     logger.info(f"Warming a Docker container for an Airflow {command}.")
-    logger.info(f"Hello world.")
 
     # Get executor type
     executor_type = os.environ.get("MWAA__CORE__EXECUTOR_TYPE", "CeleryExecutor")

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -264,6 +264,9 @@ async def install_user_requirements(cmd: str, environ: dict[str, str]):
     """
     requirements_file = environ.get("MWAA__CORE__REQUIREMENTS_PATH")
     logger.info(f"MWAA__CORE__REQUIREMENTS_PATH = {requirements_file}")
+    # For hybrid worker/scheduler containers we publish the requirements logs to the worker 
+    # CloudWatch log group.
+    logger_prefix = "worker" if cmd == "hybrid" else cmd;
     if requirements_file and os.path.isfile(requirements_file):
         logger.info(f"Installing user requirements from {requirements_file}...")
 
@@ -273,7 +276,7 @@ async def install_user_requirements(cmd: str, environ: dict[str, str]):
             # use CloudWatch for logging.
             *set(
                 [
-                    logging.getLogger(MWAA_LOGGERS.get(f"{cmd}_requirements")),
+                    logging.getLogger(MWAA_LOGGERS.get(f"{logger_prefix}_requirements")),
                     logger,
                 ]
             ),
@@ -302,7 +305,7 @@ async def install_user_requirements(cmd: str, environ: dict[str, str]):
             conditions=[
                 TimeoutCondition(USER_REQUIREMENTS_MAX_INSTALL_TIME),
             ],
-            friendly_name=f"{cmd}_requirements",
+            friendly_name=f"{logger_prefix}_requirements",
         )
         pip_process.start()
         if pip_process.process and pip_process.process.returncode != 0:
@@ -332,7 +335,10 @@ def execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]:
 
     EXECUTE_USER_STARTUP_SCRIPT_PATH = "execute-user-startup-script"
     POST_STARTUP_SCRIPT_VERIFICATION_PATH = "post-startup-script-verification"
-    PROCESS_LOGGER = logging.getLogger(MWAA_LOGGERS.get(f"{cmd}_startup"))
+    # For hybrid worker/scheduler containers we publish the startup script logs
+    # to the worker CloudWatch log group.
+    PROCESS_LOGGER_PREFIX = "worker" if cmd == "hybrid" else cmd;
+    PROCESS_LOGGER = logging.getLogger(MWAA_LOGGERS.get(f"{PROCESS_LOGGER_PREFIX}_startup"))
 
     if os.path.isfile(startup_script_path):
         logger.info("Executing customer startup script.")
@@ -345,7 +351,7 @@ def execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]:
             conditions=[
                 TimeoutCondition(STARTUP_SCRIPT_MAX_EXECUTION_TIME),
             ],
-            friendly_name=f"{cmd}_startup",
+            friendly_name=f"{PROCESS_LOGGER_PREFIX}_startup",
             sigterm_patience_interval=STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL,
         )
         startup_script_process.start()
@@ -361,7 +367,7 @@ def execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]:
             conditions=[
                 TimeoutCondition(STARTUP_SCRIPT_MAX_EXECUTION_TIME),
             ],
-            friendly_name=f"{cmd}_startup",
+            friendly_name=f"{PROCESS_LOGGER_PREFIX}_startup",
         )
         verification_process.start()
 
@@ -717,6 +723,7 @@ async def main() -> None:
         )
 
     logger.info(f"Warming a Docker container for an Airflow {command}.")
+    logger.info(f"Hello world.")
 
     # Get executor type
     executor_type = os.environ.get("MWAA__CORE__EXECUTOR_TYPE", "CeleryExecutor")
@@ -772,7 +779,6 @@ async def main() -> None:
 
     await install_user_requirements(command, environ)
     await airflow_db_init(environ)
-    await increase_pool_size_if_default_size(environ)
     if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "testing":
         # In "simple" auth mode, we create an admin user "airflow" with password
         # "airflow". We use this to make the Docker Compose setup easy to use without

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -778,6 +778,7 @@ async def main() -> None:
 
     await install_user_requirements(command, environ)
     await airflow_db_init(environ)
+    await increase_pool_size_if_default_size(environ)
     if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "testing":
         # In "simple" auth mode, we create an admin user "airflow" with password
         # "airflow". We use this to make the Docker Compose setup easy to use without


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

These changes fix an issue where an unsupported logger name was being used to try to publish startup script and requirements install logs for hybrid worker/scheduler containers. This issue resulted in missing requirements and startup script logs in CloudWatch. This fix adds logic to publish requirements and startup script logs via the worker logger in the case of hybrid container.s These changes were tested by deploying MWAA environments using Airflow 2.9.2, 2.10.1, and 2.10.3 to confirm the missing requirements and startup script logs are published to the worker CloudWatch log group.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
