### PR TITLE
Reserialize dags on db migration

### DIFF
--- a/images/airflow/2.10.1/BillOfMaterials/2.10.1-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.10.1/BillOfMaterials/2.10.1-dev/Python-Packages-BOM.txt
@@ -6162,10 +6162,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.35.7.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -6437,10 +6437,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.35.7.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -15434,10 +15434,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.10.1/BillOfMaterials/2.10.1-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.10.1/BillOfMaterials/2.10.1-dev/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer-dev/Python-Packages-BOM.txt
@@ -6162,10 +6162,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.35.7.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -6437,10 +6437,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.35.7.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -15434,10 +15434,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer-dev/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer-privileged-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer-privileged-dev/Python-Packages-BOM.txt
@@ -6162,10 +6162,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.35.7.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -6437,10 +6437,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.35.7.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -15434,10 +15434,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer-privileged-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer-privileged-dev/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer-privileged/Python-Packages-BOM.txt
+++ b/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer-privileged/Python-Packages-BOM.txt
@@ -6162,10 +6162,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.35.7.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -6437,10 +6437,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.35.7.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -15434,10 +15434,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer-privileged/System-Packages-BOM.txt
+++ b/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer-privileged/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer/Python-Packages-BOM.txt
+++ b/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer/Python-Packages-BOM.txt
@@ -6162,10 +6162,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.35.7.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -6437,10 +6437,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.35.7.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -15434,10 +15434,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer/System-Packages-BOM.txt
+++ b/images/airflow/2.10.1/BillOfMaterials/2.10.1-explorer/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.10.1/BillOfMaterials/2.10.1/Python-Packages-BOM.txt
+++ b/images/airflow/2.10.1/BillOfMaterials/2.10.1/Python-Packages-BOM.txt
@@ -6162,10 +6162,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.35.7.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -6437,10 +6437,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.35.7.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -15434,10 +15434,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.10.1/BillOfMaterials/2.10.1/System-Packages-BOM.txt
+++ b/images/airflow/2.10.1/BillOfMaterials/2.10.1/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.10.1/python/mwaa/database/migrate.py
+++ b/images/airflow/2.10.1/python/mwaa/database/migrate.py
@@ -45,7 +45,7 @@ def _migrate_db():
         args = Namespace(
             from_revision=None,
             from_version=None,
-            reserialize_dags=None,
+            reserialize_dags=True,
             show_sql_only=None,
             to_revision=None,
             to_version=None,

--- a/images/airflow/2.10.3/BillOfMaterials/2.10.3-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.10.3/BillOfMaterials/2.10.3-dev/Python-Packages-BOM.txt
@@ -6162,10 +6162,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.35.36.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -6437,10 +6437,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.35.36.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -15580,10 +15580,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.10.3/BillOfMaterials/2.10.3-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.10.3/BillOfMaterials/2.10.3-dev/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer-dev/Python-Packages-BOM.txt
@@ -6162,10 +6162,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.35.36.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -6437,10 +6437,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.35.36.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -15580,10 +15580,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer-dev/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer-privileged-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer-privileged-dev/Python-Packages-BOM.txt
@@ -6162,10 +6162,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.35.36.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -6437,10 +6437,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.35.36.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -15580,10 +15580,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer-privileged-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer-privileged-dev/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer-privileged/Python-Packages-BOM.txt
+++ b/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer-privileged/Python-Packages-BOM.txt
@@ -6162,10 +6162,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.35.36.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -6437,10 +6437,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.35.36.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -15580,10 +15580,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer-privileged/System-Packages-BOM.txt
+++ b/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer-privileged/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer/Python-Packages-BOM.txt
+++ b/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer/Python-Packages-BOM.txt
@@ -6162,10 +6162,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.35.36.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -6437,10 +6437,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.35.36.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -15580,10 +15580,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer/System-Packages-BOM.txt
+++ b/images/airflow/2.10.3/BillOfMaterials/2.10.3-explorer/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.10.3/BillOfMaterials/2.10.3/Python-Packages-BOM.txt
+++ b/images/airflow/2.10.3/BillOfMaterials/2.10.3/Python-Packages-BOM.txt
@@ -6162,10 +6162,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.35.36.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -6437,10 +6437,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.35.36.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -15580,10 +15580,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.10.3/BillOfMaterials/2.10.3/System-Packages-BOM.txt
+++ b/images/airflow/2.10.3/BillOfMaterials/2.10.3/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.10.3/python/mwaa/database/migrate.py
+++ b/images/airflow/2.10.3/python/mwaa/database/migrate.py
@@ -40,12 +40,22 @@ def _migrate_db():
         args = Namespace(migration_wait_timeout=1)
         airflow_db_command.check_migrations(args)
         logging.info("The database is already migrated.")
+        args = Namespace(
+            from_revision=None,
+            from_version=None,
+            reserialize_dags=True,
+            show_sql_only=None,
+            to_revision=None,
+            to_version=None,
+            use_migration_files=None,
+        )
+        airflow_db_command.migratedb(args)
     except TimeoutError:
         logging.info("The database is not yet migrated. Migrating...")
         args = Namespace(
             from_revision=None,
             from_version=None,
-            reserialize_dags=None,
+            reserialize_dags=True,
             show_sql_only=None,
             to_revision=None,
             to_version=None,

--- a/images/airflow/2.10.3/python/mwaa/database/migrate.py
+++ b/images/airflow/2.10.3/python/mwaa/database/migrate.py
@@ -40,16 +40,6 @@ def _migrate_db():
         args = Namespace(migration_wait_timeout=1)
         airflow_db_command.check_migrations(args)
         logging.info("The database is already migrated.")
-        args = Namespace(
-            from_revision=None,
-            from_version=None,
-            reserialize_dags=True,
-            show_sql_only=None,
-            to_revision=None,
-            to_version=None,
-            use_migration_files=None,
-        )
-        airflow_db_command.migratedb(args)
     except TimeoutError:
         logging.info("The database is not yet migrated. Migrating...")
         args = Namespace(

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-dev/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-dev/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged-dev/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer-privileged/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2-explorer/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2/Python-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2/Python-Packages-BOM.txt
@@ -5611,10 +5611,10 @@ Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 /usr/local/airflow/.local/lib/python3.11/site-packages/boto3-1.34.106.dist-info/NOTICE
 
 boto3-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/mypy_boto3_builder
-/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/boto3_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2025 Vlad Emelianov
@@ -5886,10 +5886,10 @@ one at http://mozilla.org/MPL/2.0/.
 /usr/local/airflow/.local/lib/python3.11/site-packages/botocore-1.34.106.dist-info/NOTICE
 
 botocore-stubs
-1.36.16
+1.36.21
 MIT License
 https://github.com/youtype/botocore-stubs
-/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.16.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/botocore_stubs-1.36.21.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov
@@ -14905,10 +14905,10 @@ UNKNOWN
 UNKNOWN
 
 types-awscrt
-0.23.9
+0.23.10
 MIT License
 https://github.com/youtype/types-awscrt
-/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.9.dist-info/LICENSE
+/usr/local/airflow/.local/lib/python3.11/site-packages/types_awscrt-0.23.10.dist-info/LICENSE
 MIT License
 
 Copyright (c) 2022 Vlad Emelianov

--- a/images/airflow/2.9.2/BillOfMaterials/2.9.2/System-Packages-BOM.txt
+++ b/images/airflow/2.9.2/BillOfMaterials/2.9.2/System-Packages-BOM.txt
@@ -2,8 +2,8 @@ This Docker image includes the following third-party software/licensing:
 tzdata-2024a: Public Domain
 publicsuffix-list-dafsa-20240212: MPLv2.0
 ncurses-base-6.2: MIT
-amazon-linux-repo-cdn-2023.6.20250203: MIT
-system-release-2023.6.20250203: MIT
+amazon-linux-repo-cdn-2023.6.20250211: MIT
+system-release-2023.6.20250211: MIT
 filesystem-3.14: Public Domain
 glibc-minimal-langpack-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
 glibc-2.34: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL

--- a/images/airflow/2.9.2/python/mwaa/database/migrate.py
+++ b/images/airflow/2.9.2/python/mwaa/database/migrate.py
@@ -45,7 +45,7 @@ def _migrate_db():
         args = Namespace(
             from_revision=None,
             from_version=None,
-            reserialize_dags=None,
+            reserialize_dags=True,
             show_sql_only=None,
             to_revision=None,
             to_version=None,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In previous airflow versions, we had reserialize dags as true. Right now it does not so setting this config to True. Tested by having the run script go to this path and successfully execute the command with this new config.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
