### PR TITLE
Replace migratedb with initdb for database initialization

### DIFF
--- a/images/airflow/2.10.3/python/mwaa/database/migrate.py
+++ b/images/airflow/2.10.3/python/mwaa/database/migrate.py
@@ -51,7 +51,7 @@ def _migrate_db():
             to_version=None,
             use_migration_files=None,
         )
-        airflow_db_command.migratedb(args)
+        airflow_db_command.initdb(args)
         logging.info("The database is now migrated.")
 
 


### PR DESCRIPTION
This PR replaces the `migratedb` call with `initdb` in `migrate.py` to ensure the default behavior of Airflow database initialization is used.

This is my first open-source contribution! 
