### PR TITLE
Fix for start-up script not working in local docker image

### DIFF
--- a/images/airflow/2.10.1/docker-compose.yaml
+++ b/images/airflow/2.10.1/docker-compose.yaml
@@ -18,6 +18,8 @@ x-airflow-common: &airflow-common
     # container is up.
     MWAA__CORE__REQUIREMENTS_PATH: ${MWAA__CORE__REQUIREMENTS_PATH}
     MWAA__CORE__AUTH_TYPE: "testing"
+    # Use this environment variable if you have a custom start-up script.
+    MWAA__CORE__STARTUP_SCRIPT_PATH: ${MWAA__CORE__STARTUP_SCRIPT_PATH}
     # Additional Airflow configuration can be passed here in JSON form.
     MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS: "{}"
     MWAA__CORE__FERNET_KEY: ${FERNET_KEY}

--- a/images/airflow/2.10.1/startup/startup.sh
+++ b/images/airflow/2.10.1/startup/startup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+#Add your startup script for testing here

--- a/images/airflow/2.10.3/docker-compose.yaml
+++ b/images/airflow/2.10.3/docker-compose.yaml
@@ -18,6 +18,8 @@ x-airflow-common: &airflow-common
     # container is up.
     MWAA__CORE__REQUIREMENTS_PATH: ${MWAA__CORE__REQUIREMENTS_PATH}
     MWAA__CORE__AUTH_TYPE: "testing"
+    # Use this environment variable if you have a custom start-up script.
+    MWAA__CORE__STARTUP_SCRIPT_PATH: ${MWAA__CORE__STARTUP_SCRIPT_PATH}
     # Additional Airflow configuration can be passed here in JSON form.
     MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS: "{}"
     MWAA__CORE__FERNET_KEY: ${FERNET_KEY}

--- a/images/airflow/2.10.3/startup/startup.sh
+++ b/images/airflow/2.10.3/startup/startup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+#Add your startup script for testing here

--- a/images/airflow/2.9.2/docker-compose.yaml
+++ b/images/airflow/2.9.2/docker-compose.yaml
@@ -18,6 +18,8 @@ x-airflow-common: &airflow-common
     # container is up.
     MWAA__CORE__REQUIREMENTS_PATH: ${MWAA__CORE__REQUIREMENTS_PATH}
     MWAA__CORE__AUTH_TYPE: "testing"
+    # Use this environment variable if you have a custom start-up script.
+    MWAA__CORE__STARTUP_SCRIPT_PATH: ${MWAA__CORE__STARTUP_SCRIPT_PATH}
     # Additional Airflow configuration can be passed here in JSON form.
     MWAA__CORE__CREATED_AT: "Tue Sep 18 23:05:58 UTC 2024"
     MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS: "{}"

--- a/images/airflow/2.9.2/startup/startup.sh
+++ b/images/airflow/2.9.2/startup/startup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+#Add your startup script for testing here


### PR DESCRIPTION
*Issue #, if available:*
The startup script didn't work for local docker image testing. So there was no way to test startup scripts.

*Description of changes:*
- Added a startup script path environment variable in docker-compose file.
- Tested by running local docker image with a startup script.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
