### PR TITLE
Run pyright and ruff with the configuration from the correct directory

### DIFF
--- a/quality-checks/lint_python.sh
+++ b/quality-checks/lint_python.sh
@@ -28,9 +28,9 @@ check_dir() {
     source "${venv_dir}/bin/activate"
     # Run ruff and Pyright
     echo "Running ruff..."
-    ruff check "${dir}" || status=1
+    (cd "${dir}"; ruff check) || status=1
     echo "Running Pyright..."
-    pyright "${dir}" || status=1
+    (cd "${dir}"; pyright) || status=1
     deactivate
 
     echo


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Quality checks currently do not correctly run against files under `./images` due to how pyright resolves its configuration from `pyrightconfig.json`.  Specifically, pyright will use the `pyrightconfig.json` file in your current directory even if you specify a different root path as an argument.

This is evidenced by running pyright manually in verbose mode:
```
$ source images/airflow/2.10.3/.venv/bin/activate
$ pyright --verbose
Loading configuration file at /local/home/bnd/opensource/amazon-mwaa-docker-images/pyrightconfig.json
Execution environment: python
  Extra paths:
    (none)
  Python version: 3.11
  Python platform: All
  Search paths:
    /local/home/bnd/opensource/amazon-mwaa-docker-images/images/airflow/2.10.3/.venv/lib/python3.11/site-packages/pyright/dist/dist/typeshed-fallback/stdlib
    /local/home/bnd/opensource/amazon-mwaa-docker-images
    /local/home/bnd/opensource/amazon-mwaa-docker-images/typings
    /local/home/bnd/opensource/amazon-mwaa-docker-images/images/airflow/2.10.3/.venv/lib/python3.11/site-packages/pyright/dist/dist/typeshed-fallback/stubs/...
    /home/bnd/.local/share/rtx/installs/python/3.11.5/lib/python3.11
    /home/bnd/.local/share/rtx/installs/python/3.11.5/lib/python3.11/lib-dynload
    /local/home/bnd/opensource/amazon-mwaa-docker-images/images/airflow/2.10.3/.venv/lib/python3.11/site-packages
Found 3 source files
pyright 1.1.397
0 errors, 0 warnings, 0 informations
Completed in 0.886sec
```

Two valid approaches exist:
1. Switch directory to the target one prior to running pyright (and ruff, for that matter)
   * This is achieved generally by using a subshell which first `cd`s into the target directory, then runs pyright on the current directory
2. Specify the correct `pyrightconfig.json` path
   * This can be achieved with the `-p` switch pointing to the `pyrightconfig.json` file in the target folder

This draft PR uses approach 1 and applies it to both ruff and pyright as it is less likely to be impacted by nuanced semantics caused by running the tools from a different directory.  I'm leaving this as a draft PR as there are 80+ pyright failures per image directory that I do not have availability to resolve.  Most of these failures are unnecessary imports or incomplete typings on things like lists (e.g. `foo = []` vs `foo: list[str] = []`).

Fixing this linting will ensure invalid code, such as missing imports, are caught before being merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
