### PR TITLE
Raise exception for missing customer_env_vars.json file.

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -353,7 +353,8 @@ def execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]:
                 "script defines environment variables, this error message indicates that "
                 "those variables won't be exported to the Airflow tasks."
             )
-            return {}
+            PROCESS_LOGGER.error("[ERROR] An unexpected error occurred: Failed to locate environment variables file from startup script.")
+            raise Exception("Failed to access customer environment variables file: Service was unable to create or locate /tmp/customer_env_vars.json")
 
     else:
         logger.info(f"No startup script found at {startup_script_path}.")

--- a/images/airflow/2.10.3/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.3/python/mwaa/entrypoint.py
@@ -352,7 +352,8 @@ def execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]:
                 "script defines environment variables, this error message indicates that "
                 "those variables won't be exported to the Airflow tasks."
             )
-            return {}
+            PROCESS_LOGGER.error("[ERROR] An unexpected error occurred: Failed to locate environment variables file from startup script.")
+            raise Exception("Failed to access customer environment variables file: Service was unable to create or locate /tmp/customer_env_vars.json")
 
     else:
         logger.info(f"No startup script found at {startup_script_path}.")

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -389,7 +389,8 @@ def execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]:
                 "script defines environment variables, this error message indicates that "
                 "those variables won't be exported to the Airflow tasks."
             )
-            return {}
+            PROCESS_LOGGER.error("[ERROR] An unexpected error occurred: Failed to locate environment variables file from startup script.")
+            raise Exception("Failed to access customer environment variables file: Service was unable to create or locate /tmp/customer_env_vars.json")
 
     else:
         logger.info(f"No startup script found at {startup_script_path}.")

--- a/tests/images/airflow/2.10.1/python/mwaa/test_entrypoint_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/test_entrypoint_2_10_1.py
@@ -78,8 +78,11 @@ def test_missing_customer_env_vars_file(mock_environ):
         mock_process = MagicMock()
         mock_subprocess.return_value = mock_process
 
-        result = entrypoint.execute_startup_script("worker", mock_environ)
-        assert result == {}
+        with pytest.raises(Exception) as exc_info:
+            entrypoint.execute_startup_script("worker", mock_environ)
+
+        assert ("Failed to access customer environment variables file: Service was unable "
+                "to create or locate /tmp/customer_env_vars.json") in str(exc_info.value)
 
 
 @pytest.mark.parametrize("subprocess_error", [

--- a/tests/images/airflow/2.10.3/python/mwaa/test_entrypoint_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/test_entrypoint_2_10_3.py
@@ -78,8 +78,11 @@ def test_missing_customer_env_vars_file(mock_environ):
         mock_process = MagicMock()
         mock_subprocess.return_value = mock_process
 
-        result = entrypoint.execute_startup_script("worker", mock_environ)
-        assert result == {}
+        with pytest.raises(Exception) as exc_info:
+            entrypoint.execute_startup_script("worker", mock_environ)
+
+        assert ("Failed to access customer environment variables file: Service was unable "
+                "to create or locate /tmp/customer_env_vars.json") in str(exc_info.value)
 
 
 @pytest.mark.parametrize("subprocess_error", [

--- a/tests/images/airflow/2.9.2/python/mwaa/test_entrypoint_2_9_2.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/test_entrypoint_2_9_2.py
@@ -78,8 +78,11 @@ def test_missing_customer_env_vars_file(mock_environ):
         mock_process = MagicMock()
         mock_subprocess.return_value = mock_process
 
-        result = entrypoint.execute_startup_script("worker", mock_environ)
-        assert result == {}
+        with pytest.raises(Exception) as exc_info:
+            entrypoint.execute_startup_script("worker", mock_environ)
+
+        assert ("Failed to access customer environment variables file: Service was unable "
+                "to create or locate /tmp/customer_env_vars.json") in str(exc_info.value)
 
 
 @pytest.mark.parametrize("subprocess_error", [


### PR DESCRIPTION
*Issue #, if available:N/A*

*Description of changes:*
Currently, when `customer_env_vars.json` file fails to be created due to service-side issues, the error is only logged silently, which can cause issue later while debugging the main issue. This change makes the container fail explicitly by raising an exception instead of silently continuing execution.

*Testing:*
1. Verified container failure by simulating missing `customer_env_vars.json` file.
2. Confirmed appropriate error message is thrown.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
