### PR TITLE
Format subprocess logs for startup script and requirements subprocess.

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -439,6 +439,7 @@ class SubprocessLogHandler(BaseLogHandler):
         stream_name_prefix: str,
         logs_source: str,
         enabled: bool,
+        log_formatter: logging.Formatter | None = None,
     ):
         """
         Initialize the instance.
@@ -457,6 +458,7 @@ class SubprocessLogHandler(BaseLogHandler):
               much changes to the logging configuration.
         """
         super().__init__(log_group_arn, kms_key_arn, enabled)
+        self.formatter = log_formatter
         hostname = socket.gethostname()
         epoch = time.time()
         # Use hostname and epoch timestamp as a combined primary key for stream name.

--- a/images/airflow/2.10.1/python/mwaa/logging/config.py
+++ b/images/airflow/2.10.1/python/mwaa/logging/config.py
@@ -147,6 +147,7 @@ def _configure_subprocesses_logging(
     log_stream_name_prefix: str,
     log_level: str,
     logging_enabled: bool,
+    log_formatter: logging.Formatter | None = None,
 ):
     logger_name = MWAA_LOGGERS[subprocess_name.lower()]
     handler_name = logger_name.replace(".", "_")
@@ -160,6 +161,7 @@ def _configure_subprocesses_logging(
             "stream_name_prefix": log_stream_name_prefix,
             "logs_source": subprocess_name,
             "enabled": logging_enabled,
+            "log_formatter": log_formatter,
         }
         # Setup CloudWatch logging.
         LOGGING_CONFIG["loggers"][logger_name] = {
@@ -190,6 +192,7 @@ def _configure():
             log_stream_name_prefix="requirements_install",
             log_level="INFO",  # We always want to publish requirements logs.
             logging_enabled=logging_enabled,
+            log_formatter=logging.Formatter('[%(levelname)s] - %(message)s')
         )
         _configure_subprocesses_logging(
             f"{comp}_startup",
@@ -197,6 +200,7 @@ def _configure():
             log_stream_name_prefix="startup_script_execution",
             log_level="INFO",  # We always want to publish startup script logs.
             logging_enabled=logging_enabled,
+            log_formatter=logging.Formatter('[%(levelname)s] - %(message)s')
         )
 
 # Airflow has a dedicated logger for the DAG Processor Manager

--- a/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
@@ -439,6 +439,7 @@ class SubprocessLogHandler(BaseLogHandler):
         stream_name_prefix: str,
         logs_source: str,
         enabled: bool,
+        log_formatter: logging.Formatter | None = None,
     ):
         """
         Initialize the instance.
@@ -457,6 +458,7 @@ class SubprocessLogHandler(BaseLogHandler):
               much changes to the logging configuration.
         """
         super().__init__(log_group_arn, kms_key_arn, enabled)
+        self.formatter = log_formatter
         hostname = socket.gethostname()
         epoch = time.time()
         # Use hostname and epoch timestamp as a combined primary key for stream name.

--- a/images/airflow/2.10.3/python/mwaa/logging/config.py
+++ b/images/airflow/2.10.3/python/mwaa/logging/config.py
@@ -147,6 +147,7 @@ def _configure_subprocesses_logging(
     log_stream_name_prefix: str,
     log_level: str,
     logging_enabled: bool,
+    log_formatter: logging.Formatter | None = None,
 ):
     logger_name = MWAA_LOGGERS[subprocess_name.lower()]
     handler_name = logger_name.replace(".", "_")
@@ -160,6 +161,7 @@ def _configure_subprocesses_logging(
             "stream_name_prefix": log_stream_name_prefix,
             "logs_source": subprocess_name,
             "enabled": logging_enabled,
+            "log_formatter": log_formatter,
         }
         # Setup CloudWatch logging.
         LOGGING_CONFIG["loggers"][logger_name] = {
@@ -190,6 +192,7 @@ def _configure():
             log_stream_name_prefix="requirements_install",
             log_level="INFO",  # We always want to publish requirements logs.
             logging_enabled=logging_enabled,
+            log_formatter=logging.Formatter('[%(levelname)s] - %(message)s')
         )
         _configure_subprocesses_logging(
             f"{comp}_startup",
@@ -197,6 +200,7 @@ def _configure():
             log_stream_name_prefix="startup_script_execution",
             log_level="INFO",  # We always want to publish startup script logs.
             logging_enabled=logging_enabled,
+            log_formatter=logging.Formatter('[%(levelname)s] - %(message)s')
         )
 
 # Airflow has a dedicated logger for the DAG Processor Manager

--- a/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
@@ -439,6 +439,7 @@ class SubprocessLogHandler(BaseLogHandler):
         stream_name_prefix: str,
         logs_source: str,
         enabled: bool,
+        log_formatter: logging.Formatter | None = None,
     ):
         """
         Initialize the instance.
@@ -457,6 +458,7 @@ class SubprocessLogHandler(BaseLogHandler):
               much changes to the logging configuration.
         """
         super().__init__(log_group_arn, kms_key_arn, enabled)
+        self.formatter = log_formatter
         hostname = socket.gethostname()
         epoch = time.time()
         # Use hostname and epoch timestamp as a combined primary key for stream name.

--- a/images/airflow/2.9.2/python/mwaa/logging/config.py
+++ b/images/airflow/2.9.2/python/mwaa/logging/config.py
@@ -147,6 +147,7 @@ def _configure_subprocesses_logging(
     log_stream_name_prefix: str,
     log_level: str,
     logging_enabled: bool,
+    log_formatter: logging.Formatter | None = None,
 ):
     logger_name = MWAA_LOGGERS[subprocess_name.lower()]
     handler_name = logger_name.replace(".", "_")
@@ -160,6 +161,7 @@ def _configure_subprocesses_logging(
             "stream_name_prefix": log_stream_name_prefix,
             "logs_source": subprocess_name,
             "enabled": logging_enabled,
+            "log_formatter": log_formatter,
         }
         # Setup CloudWatch logging.
         LOGGING_CONFIG["loggers"][logger_name] = {
@@ -190,6 +192,7 @@ def _configure():
             log_stream_name_prefix="requirements_install",
             log_level="INFO",  # We always want to publish requirements logs.
             logging_enabled=logging_enabled,
+            log_formatter=logging.Formatter('[%(levelname)s] - %(message)s')
         )
         _configure_subprocesses_logging(
             f"{comp}_startup",
@@ -197,6 +200,7 @@ def _configure():
             log_stream_name_prefix="startup_script_execution",
             log_level="INFO",  # We always want to publish startup script logs.
             logging_enabled=logging_enabled,
+            log_formatter=logging.Formatter('[%(levelname)s] - %(message)s')
         )
 
 # Airflow has a dedicated logger for the DAG Processor Manager


### PR DESCRIPTION
*Issue #, if available:N/A*

**Description of changes:**
Added log formatter for subprocess that only runs startup script and installs requirements file. This will help to avoid the risk of eliminating need of adding log level to the log message explicitly. We did not added log formatter to the core airflow subprocess because it already logs the data correctly and in required format.

**Testing**
Ran the container locally and checked if log level prefix is being added before the logs or not.

*Before log formatter*
<img width="981" alt="startup_script_before" src="https://github.com/user-attachments/assets/e729d99e-a787-45cc-9234-01450af09159" />
<img width="1432" alt="requirements_before" src="https://github.com/user-attachments/assets/9fa3dc49-6e29-4378-8fd3-ec782809e935" />

*After log formatter*
<img width="1032" alt="startup_script_after" src="https://github.com/user-attachments/assets/d25c38e7-546d-4e63-b289-2d83e57890ea" />
<img width="1448" alt="requirements_after" src="https://github.com/user-attachments/assets/2fa09afa-dd33-45cf-ac04-aa318cece459" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
