### PR TITLE
Adding diff-based coverage tests to the quality-checks workflow

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,20 @@
+[run]
+branch = True
+source = .
+omit = 
+    tests/*
+    */tests/*
+    */.venv/*
+    */setup.py
+    images/airflow/*/tests/*
+    images/airflow/*/.venv/*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    pass
+    raise ImportError

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ build
 # Ignore dev requirements files.
 images/airflow/2.*/requirements-dev.txt
 images/airflow/3.*/requirements-dev.txt
+
+# Coverage files
+.coverage
+coverage.xml
+.coverage.*

--- a/images/airflow/2.10.1/requirements.txt
+++ b/images/airflow/2.10.1/requirements.txt
@@ -24,3 +24,6 @@ pydocstyle
 pyright
 ruff
 sqlalchemy-stubs
+pytest
+pytest-cov
+diff-cover

--- a/images/airflow/2.10.3/requirements.txt
+++ b/images/airflow/2.10.3/requirements.txt
@@ -24,3 +24,6 @@ pydocstyle
 pyright
 ruff
 sqlalchemy-stubs
+pytest
+pytest-cov
+diff-cover

--- a/images/airflow/2.9.2/requirements.txt
+++ b/images/airflow/2.9.2/requirements.txt
@@ -24,3 +24,6 @@ pydocstyle
 pyright
 ruff
 sqlalchemy-stubs
+pytest
+pytest-cov
+diff-cover

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test
+python_functions = test_*

--- a/quality-checks/diff-coverage_test.sh
+++ b/quality-checks/diff-coverage_test.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+
+# This script tests coverage of modified/added python code only, until we add more unit tests
+# Test fails if coverage of the new code is below 80%
+# TODO : In the future, replace with a full fledged coverage test script
+
+set -e
+
+# Color codes and unicode symbols for formatting
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+CHECK_MARK="\xE2\x9C\x94"
+CROSS_MARK="\xE2\x9C\x98"
+
+# Create temporary directory
+TEMP_DIR=$(mktemp -d)
+
+# Helper functions for formatting
+print_header() {
+    echo -e "\n═══════════════════════════════════════════"
+    echo -e "$1"
+    echo -e "═══════════════════════════════════════════"
+}
+
+print_section() {
+    echo -e "\n$1"
+    echo "───────────────────────────────────────────"
+}
+
+print_success() {
+    echo -e "${GREEN}${CHECK_MARK} $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}${CROSS_MARK} $1${NC}"
+}
+
+format_coverage_output() {
+    local coverage_text="$1"
+    local output=""
+
+    while IFS= read -r line; do
+        if [[ $line == *"Diff Coverage"* ]] || [[ $line == "-------------"* ]] || [[ $line == "Diff:"* ]]; then
+            # Headers and separators stay uncolored
+            output+="${line}\n"
+        elif [[ $line == *"Failure"* ]]; then
+            # Failure message in red
+            output+="${RED}${line}${NC}\n"
+        elif [[ $line == *": Missing lines"* ]]; then
+            # Files with missing coverage
+            file_path=$(echo "$line" | cut -d' ' -f1)
+            coverage=$(echo "$line" | grep -o '([0-9.]*%)')
+            missing_lines=$(echo "$line" | grep -o ': Missing lines.*')
+            coverage_num=$(echo "$coverage" | tr -d '()%')
+
+            if (( $(echo "$coverage_num < 80" | bc -l) )); then
+                output+="${file_path} ${RED}${coverage}${NC}${RED}${missing_lines}${NC}\n"
+            else
+                output+="${file_path} ${GREEN}${coverage}${NC}${missing_lines}\n"
+            fi
+        elif [[ $line == *"Total:"* ]] || [[ $line == *"Missing:"* ]]; then
+            # Statistics lines
+            label=$(echo "$line" | cut -d: -f1):
+            value=$(echo "$line" | cut -d: -f2)
+            output+="${label}${value}\n"
+        elif [[ $line == *"Coverage:"* ]]; then
+            # Final coverage percentage
+            label="Coverage:"
+            value=$(echo "$line" | cut -d: -f2 | tr -d ' ')
+            coverage_num=$(echo "$value" | tr -d '%')
+            
+            if (( $(echo "$coverage_num < 80" | bc -l) )); then
+                output+="${label} ${RED}${value}${NC}\n"
+            else
+                output+="${label} ${GREEN}${value}${NC}\n"
+            fi
+        else
+            # Any other lines
+            output+="${line}\n"
+        fi
+    done <<< "$coverage_text"
+
+    echo -e "$output"
+}
+
+get_base_branch() {
+    echo -e "${BLUE}Fetching main branch for comparison...${NC}" >&2
+    if git fetch --deepen=50 https://github.com/aws/amazon-mwaa-docker-images.git main >/dev/null 2>&1; then
+        echo "FETCH_HEAD"  # This points to the fetched main branch
+    else
+        echo -e "${RED}Error: Could not fetch main branch. Please check your internet connection.${NC}" >&2
+        exit 1
+    fi
+}
+
+# shellcheck disable=SC2317
+cleanup() {
+    # Remove temporary directory
+    rm -rf "$TEMP_DIR"
+}
+
+trap cleanup EXIT
+
+check_coverage() {
+    local dir=$1
+    local base_branch=$2
+    local version
+    version=$(basename "$dir")
+    local venv_dir="${dir}/.venv"
+    local coverage_file="${dir}/coverage.xml"
+    local results_file="${TEMP_DIR}/${version}_results.txt"
+    local failed=""
+
+    # Check if virtualenv exists
+    if [[ ! -d "$venv_dir" ]]; then
+        echo "Virtual environment doesn't exist at ${venv_dir}. Please run the script ./create_venvs.py."
+        exit 1
+    fi
+
+    # shellcheck source=/dev/null
+    source "${venv_dir}/bin/activate"
+
+    # Run pytest with coverage
+    if ! pytest "tests/images/airflow/${version}" \
+        --cov="${dir}" \
+        --cov-report="xml:${coverage_file}" \
+        --cov-report=term-missing > "${TEMP_DIR}/pytest.log" 2>&1; then
+        print_error "pytest failed for ${dir}:"
+        cat "${TEMP_DIR}/pytest.log"
+        deactivate
+        return 1
+    fi
+
+    # Run diff-cover and capture output
+    if ! diff-cover "${coverage_file}" --compare-branch="$base_branch" --fail-under=80 > "${TEMP_DIR}/coverage.txt" 2>&1; then
+        print_error "Coverage check failed for ${dir}"
+        failed="true"
+    else
+        print_success "Coverage check passed for ${dir}"
+    fi
+
+    # Create formatted results
+    {
+        if [ -n "$failed" ]; then
+            print_header "Results for ${dir} (${RED}FAILED${NC})"
+        else
+            print_header "Results for ${dir} (${GREEN}PASSED${NC})"
+        fi
+        echo
+        coverage_text=$(cat "${TEMP_DIR}/coverage.txt")
+        echo -e "$(format_coverage_output "$coverage_text")"
+    } > "$results_file"
+
+    deactivate
+
+    [ -z "$failed" ]
+    return $?
+}
+
+main() {
+    local status=0
+
+    print_header "Coverage Check On Added Code"
+
+    # Check for untracked files
+    local untracked_files
+    untracked_files=$(git ls-files --others --exclude-standard | grep "^images/airflow/.*\.py$" || true)
+    if [ -n "$untracked_files" ]; then
+        echo -e "\n${YELLOW}Warning: Found untracked python files that won't be included in coverage check:${NC}"
+        printf '%s\n' "$untracked_files"
+        echo -e "${YELLOW}Run 'git add' on these files to include them in coverage checks.${NC}\n"
+    fi
+
+    # Get the base branch once
+    local base_branch
+    base_branch=$(get_base_branch)
+
+    # Get list of modified directories
+    local modified_dirs
+    modified_dirs=$(git diff --name-only "$base_branch" | grep "^images/airflow/.*\.py$" | cut -d/ -f1-3 | sort -u || true)
+
+    if [ -z "$modified_dirs" ]; then
+        print_success "No python code modifications found in airflow image directories"
+        exit 0
+    fi
+
+    print_section "Modified Image Directories"
+    for dir in $modified_dirs; do
+        echo "  - $dir"
+    done
+
+    # Check each modified image directory
+    for dir in $modified_dirs; do
+        if [ -d "$dir" ]; then
+            echo -e "\n${BLUE}Checking ${dir}...${NC}"
+            if ! check_coverage "$dir" "$base_branch"; then
+                status=1
+            fi
+        fi
+    done
+
+    # Show final results
+    print_header "Detailed Coverage Report"
+    for results in "${TEMP_DIR}"/*_results.txt; do
+        if [ -f "$results" ]; then
+            cat "$results"
+        fi
+    done
+
+    if [ $status -ne 0 ]; then
+        echo
+        print_error "Some coverage checks failed. Please ensure all modified code has adequate test coverage."
+    else
+        echo
+        print_success "All coverage checks passed!"
+    fi
+
+    exit $status
+}
+
+main

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 # running repository scripts and maintenance tasks, such as generating
 # Dockerfiles, linting, testing, and other scripts that help ensure code
 # quality.
-diff-cover==9.2.4
 Jinja2==3.1.4
 MarkupSafe==2.1.5
 nodeenv==1.8.0


### PR DESCRIPTION
*Issue #, if available:* 237

*Description of changes:* 
- Adding coverage tests to the quality-checks workflow that enforces a threshold of 80% coverage on newly added code only.
- The script:
  - Fetches the main branch from aws/amazon-mwaa-docker-images (50 commits back) for comparison
  - Identifies changes in image directories compared to main
  - Runs pytest with coverage in each modified image version's virtual environment
  - Uses diff-cover to compare coverage against main branch
  - Provides formatted coverage reports showing pass/fail status for each version
  - Cleans up temporary files once done

**Note:** This implements an incremental approach to coverage testing, focusing only on new changes.

**Added files:**
- `.coveragerc`: Coverage configuration
- `pytest.ini`: Pytest configuration
- `quality-checks/diff-coverage_test.sh`: Main coverage test script
- Updated `.gitignore` to exclude coverage artifacts

**Testing:**
- Made changes in local repo, and verified the behavior of script as part of the quality-checks in the following cases : 
  - Only runs the checks on newly added code, warns if there are untracked changes, since they will be ignored
  - If there is an unexpected error like import error, displays the entire log, else only the coverage summary
  - Tested these changes by running git workflow locally using 'act' tool, but this couldn't catch the errors arising due to shallow copy being fetched by git fetch, since 'act' bind mounts the git repo from local machine, so resolved this by unshallowing the fetch to 50 commits and pushing to the draft PR, and ensuring workflow passes.
  - Attached sample outputs below: 

### Here is a failed coverage test output, showing the coverage, the files and the uncovered line numbers.
<img width="669" alt="coverage_failure" src="https://github.com/user-attachments/assets/0e0fa84a-4339-498c-9498-0e28dd50978c" />

### Here is a successful coverage test output. It only runs for the images where changes have been made.
<img width="477" alt="coverage_success" src="https://github.com/user-attachments/assets/0730e408-ee1c-4c1e-8e05-beef023efb6c" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
