### PR TITLE
Increase worker graceful shutdown time and make it configurable.

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/celery/task_monitor.py
+++ b/images/airflow/2.10.1/python/mwaa/celery/task_monitor.py
@@ -379,7 +379,7 @@ class WorkerTaskMonitor:
     def __init__(
         self,
         mwaa_signal_handling_enabled: bool,
-        graceful_shutdown_seconds: int
+        idleness_verification_interval: int
     ):
         """
         Initialize a WorkerTaskMonitor instance.
@@ -438,7 +438,7 @@ class WorkerTaskMonitor:
 
         self.closed = False
 
-        self.graceful_shutdown_seconds = graceful_shutdown_seconds
+        self.idleness_verification_interval = idleness_verification_interval
     
     def is_closed(self):
         """
@@ -665,8 +665,8 @@ class WorkerTaskMonitor:
             # start gracefully shutting down the worker. Without this, the SQS broker may
             # consume messages from the queue, terminate before creating the corresponding
             # Airflow task instance and abandon SQS messages in-flight.
-            logger.info(f"Pausing task consumption, waiting for {self.graceful_shutdown_seconds} seconds for in-flight tasks...")
-            time.sleep(self.graceful_shutdown_seconds)
+            logger.info(f"Pausing task consumption, waiting for {self.idleness_verification_interval} seconds for in-flight tasks...")
+            time.sleep(self.idleness_verification_interval)
 
     def resume_task_consumption(self):
         """

--- a/images/airflow/2.10.1/python/mwaa/celery/task_monitor.py
+++ b/images/airflow/2.10.1/python/mwaa/celery/task_monitor.py
@@ -379,6 +379,7 @@ class WorkerTaskMonitor:
     def __init__(
         self,
         mwaa_signal_handling_enabled: bool,
+        graceful_shutdown_seconds: int
     ):
         """
         Initialize a WorkerTaskMonitor instance.
@@ -436,6 +437,8 @@ class WorkerTaskMonitor:
         self.stats = get_statsd()
 
         self.closed = False
+
+        self.graceful_shutdown_seconds = graceful_shutdown_seconds
     
     def is_closed(self):
         """
@@ -662,8 +665,8 @@ class WorkerTaskMonitor:
             # start gracefully shutting down the worker. Without this, the SQS broker may
             # consume messages from the queue, terminate before creating the corresponding
             # Airflow task instance and abandon SQS messages in-flight.
-            logger.info("Pausing task consumption.")
-            time.sleep(5)
+            logger.info(f"Pausing task consumption, waiting for {self.graceful_shutdown_seconds} seconds for in-flight tasks...")
+            time.sleep(self.graceful_shutdown_seconds)
 
     def resume_task_consumption(self):
         """

--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -544,13 +544,13 @@ def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patienc
         os.environ.get("MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED", "false").lower() == "true" and task_monitoring_enabled
     )
 
-    mwaa_worker_graceful_shutdown_seconds = int(os.environ.get("MWAA__CORE__MWAA_WORKER_GRACEFUL_SHUTDOWN_SECONDS",
-                                                               "20"))
+    mwaa_worker_idleness_verification_interval = int(os.environ.get("MWAA__CORE__WORKER_IDLENESS_VERIFICATION_INTERVAL",
+                                                                    "20"))
     if task_monitoring_enabled:
-        logger.info(f"Worker task monitoring is enabled with graceful shutdown seconds: "
-                    f"{mwaa_worker_graceful_shutdown_seconds}")
+        ogger.info(f"Worker task monitoring is enabled with idleness verification interval: "
+                   f"{mwaa_worker_idleness_verification_interval}")
         # Initializing the monitor responsible for performing idle worker checks if enabled.
-        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled, mwaa_worker_graceful_shutdown_seconds)
+        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled, mwaa_worker_idleness_verification_interval)
     else:
         logger.info("Worker task monitoring is NOT enabled.")
         worker_task_monitor = None

--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -544,7 +544,7 @@ def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patienc
         os.environ.get("MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED", "false").lower() == "true" and task_monitoring_enabled
     )
 
-    mwaa_worker_idleness_verification_interval = int(os.environ.get("MWAA__CORE__WORKER_IDLENESS_VERIFICATION_INTERVAL",
+    mwaa_worker_idleness_verification_interval = int(environ.get("MWAA__CORE__WORKER_IDLENESS_VERIFICATION_INTERVAL",
                                                                     "20"))
     if task_monitoring_enabled:
         logger.info(f"Worker task monitoring is enabled with idleness verification interval: "

--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -543,10 +543,14 @@ def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patienc
     mwaa_signal_handling_enabled = (
         os.environ.get("MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED", "false").lower() == "true" and task_monitoring_enabled
     )
+
+    mwaa_worker_graceful_shutdown_seconds = int(os.environ.get("MWAA__CORE__MWAA_WORKER_GRACEFUL_SHUTDOWN_SECONDS",
+                                                               "20"))
     if task_monitoring_enabled:
-        logger.info("Worker task monitoring is enabled.")
+        logger.info(f"Worker task monitoring is enabled with graceful shutdown seconds: "
+                    f"{mwaa_worker_graceful_shutdown_seconds}")
         # Initializing the monitor responsible for performing idle worker checks if enabled.
-        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled)
+        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled, mwaa_worker_graceful_shutdown_seconds)
     else:
         logger.info("Worker task monitoring is NOT enabled.")
         worker_task_monitor = None

--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -547,7 +547,7 @@ def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patienc
     mwaa_worker_idleness_verification_interval = int(os.environ.get("MWAA__CORE__WORKER_IDLENESS_VERIFICATION_INTERVAL",
                                                                     "20"))
     if task_monitoring_enabled:
-        ogger.info(f"Worker task monitoring is enabled with idleness verification interval: "
+        logger.info(f"Worker task monitoring is enabled with idleness verification interval: "
                    f"{mwaa_worker_idleness_verification_interval}")
         # Initializing the monitor responsible for performing idle worker checks if enabled.
         worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled, mwaa_worker_idleness_verification_interval)

--- a/images/airflow/2.10.3/python/mwaa/celery/task_monitor.py
+++ b/images/airflow/2.10.3/python/mwaa/celery/task_monitor.py
@@ -379,7 +379,7 @@ class WorkerTaskMonitor:
     def __init__(
         self,
         mwaa_signal_handling_enabled: bool,
-        graceful_shutdown_seconds: int
+        idleness_verification_interval: int
     ):
         """
         Initialize a WorkerTaskMonitor instance.
@@ -438,7 +438,7 @@ class WorkerTaskMonitor:
 
         self.closed = False
 
-        self.graceful_shutdown_seconds = graceful_shutdown_seconds
+        self.idleness_verification_interval = idleness_verification_interval
     
     def is_closed(self):
         """
@@ -665,8 +665,8 @@ class WorkerTaskMonitor:
             # start gracefully shutting down the worker. Without this, the SQS broker may
             # consume messages from the queue, terminate before creating the corresponding
             # Airflow task instance and abandon SQS messages in-flight.
-            logger.info(f"Pausing task consumption, waiting for {self.graceful_shutdown_seconds} seconds for in-flight tasks...")
-            time.sleep(self.graceful_shutdown_seconds)
+            logger.info(f"Pausing task consumption, waiting for {self.idleness_verification_interval} seconds for in-flight tasks...")
+            time.sleep(self.idleness_verification_interval)
 
     def resume_task_consumption(self):
         """

--- a/images/airflow/2.10.3/python/mwaa/celery/task_monitor.py
+++ b/images/airflow/2.10.3/python/mwaa/celery/task_monitor.py
@@ -379,6 +379,7 @@ class WorkerTaskMonitor:
     def __init__(
         self,
         mwaa_signal_handling_enabled: bool,
+        graceful_shutdown_seconds: int
     ):
         """
         Initialize a WorkerTaskMonitor instance.
@@ -436,6 +437,8 @@ class WorkerTaskMonitor:
         self.stats = get_statsd()
 
         self.closed = False
+
+        self.graceful_shutdown_seconds = graceful_shutdown_seconds
     
     def is_closed(self):
         """
@@ -662,8 +665,8 @@ class WorkerTaskMonitor:
             # start gracefully shutting down the worker. Without this, the SQS broker may
             # consume messages from the queue, terminate before creating the corresponding
             # Airflow task instance and abandon SQS messages in-flight.
-            logger.info("Pausing task consumption.")
-            time.sleep(5)
+            logger.info(f"Pausing task consumption, waiting for {self.graceful_shutdown_seconds} seconds for in-flight tasks...")
+            time.sleep(self.graceful_shutdown_seconds)
 
     def resume_task_consumption(self):
         """

--- a/images/airflow/2.10.3/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.3/python/mwaa/entrypoint.py
@@ -543,7 +543,7 @@ def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patienc
         os.environ.get("MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED", "false").lower() == "true" and task_monitoring_enabled
     )
 
-    mwaa_worker_idleness_verification_interval = int(os.environ.get("MWAA__CORE__WORKER_IDLENESS_VERIFICATION_INTERVAL",
+    mwaa_worker_idleness_verification_interval = int(environ.get("MWAA__CORE__WORKER_IDLENESS_VERIFICATION_INTERVAL",
                                                                "20"))
 
     if task_monitoring_enabled:

--- a/images/airflow/2.10.3/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.3/python/mwaa/entrypoint.py
@@ -543,14 +543,14 @@ def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patienc
         os.environ.get("MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED", "false").lower() == "true" and task_monitoring_enabled
     )
 
-    mwaa_worker_graceful_shutdown_seconds = int(os.environ.get("MWAA__CORE__MWAA_WORKER_GRACEFUL_SHUTDOWN_SECONDS",
+    mwaa_worker_idleness_verification_interval = int(os.environ.get("MWAA__CORE__WORKER_IDLENESS_VERIFICATION_INTERVAL",
                                                                "20"))
 
     if task_monitoring_enabled:
-        logger.info(f"Worker task monitoring is enabled with graceful shutdown seconds: "
-                    f"{mwaa_worker_graceful_shutdown_seconds}")
+        logger.info(f"Worker task monitoring is enabled with idleness verification interval: "
+                    f"{mwaa_worker_idleness_verification_interval}")
         # Initializing the monitor responsible for performing idle worker checks if enabled.
-        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled, mwaa_worker_graceful_shutdown_seconds)
+        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled, mwaa_worker_idleness_verification_interval)
     else:
         logger.info("Worker task monitoring is NOT enabled.")
         worker_task_monitor = None

--- a/images/airflow/2.10.3/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.3/python/mwaa/entrypoint.py
@@ -542,10 +542,15 @@ def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patienc
     mwaa_signal_handling_enabled = (
         os.environ.get("MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED", "false").lower() == "true" and task_monitoring_enabled
     )
+
+    mwaa_worker_graceful_shutdown_seconds = int(os.environ.get("MWAA__CORE__MWAA_WORKER_GRACEFUL_SHUTDOWN_SECONDS",
+                                                               "20"))
+
     if task_monitoring_enabled:
-        logger.info("Worker task monitoring is enabled.")
+        logger.info(f"Worker task monitoring is enabled with graceful shutdown seconds: "
+                    f"{mwaa_worker_graceful_shutdown_seconds}")
         # Initializing the monitor responsible for performing idle worker checks if enabled.
-        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled)
+        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled, mwaa_worker_graceful_shutdown_seconds)
     else:
         logger.info("Worker task monitoring is NOT enabled.")
         worker_task_monitor = None

--- a/images/airflow/2.9.2/python/mwaa/celery/task_monitor.py
+++ b/images/airflow/2.9.2/python/mwaa/celery/task_monitor.py
@@ -379,7 +379,7 @@ class WorkerTaskMonitor:
     def __init__(
         self,
         mwaa_signal_handling_enabled: bool,
-        graceful_shutdown_seconds: int
+        idleness_verification_interval: int
     ):
         """
         Initialize a WorkerTaskMonitor instance.
@@ -438,7 +438,7 @@ class WorkerTaskMonitor:
 
         self.closed = False
 
-        self.graceful_shutdown_seconds = graceful_shutdown_seconds
+        self.idleness_verification_interval = idleness_verification_interval
     
     def is_closed(self):
         """
@@ -665,8 +665,8 @@ class WorkerTaskMonitor:
             # start gracefully shutting down the worker. Without this, the SQS broker may
             # consume messages from the queue, terminate before creating the corresponding
             # Airflow task instance and abandon SQS messages in-flight.
-            logger.info(f"Pausing task consumption, waiting for {self.graceful_shutdown_seconds} seconds for in-flight tasks...")
-            time.sleep(self.graceful_shutdown_seconds)
+            logger.info(f"Pausing task consumption, waiting for {self.idleness_verification_interval} seconds for in-flight tasks...")
+            time.sleep(self.idleness_verification_interval)
 
     def resume_task_consumption(self):
         """

--- a/images/airflow/2.9.2/python/mwaa/celery/task_monitor.py
+++ b/images/airflow/2.9.2/python/mwaa/celery/task_monitor.py
@@ -379,6 +379,7 @@ class WorkerTaskMonitor:
     def __init__(
         self,
         mwaa_signal_handling_enabled: bool,
+        graceful_shutdown_seconds: int
     ):
         """
         Initialize a WorkerTaskMonitor instance.
@@ -436,6 +437,8 @@ class WorkerTaskMonitor:
         self.stats = get_statsd()
 
         self.closed = False
+
+        self.graceful_shutdown_seconds = graceful_shutdown_seconds
     
     def is_closed(self):
         """
@@ -662,8 +665,8 @@ class WorkerTaskMonitor:
             # start gracefully shutting down the worker. Without this, the SQS broker may
             # consume messages from the queue, terminate before creating the corresponding
             # Airflow task instance and abandon SQS messages in-flight.
-            logger.info("Pausing task consumption.")
-            time.sleep(5)
+            logger.info(f"Pausing task consumption, waiting for {self.graceful_shutdown_seconds} seconds for in-flight tasks...")
+            time.sleep(self.graceful_shutdown_seconds)
 
     def resume_task_consumption(self):
         """

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -580,14 +580,14 @@ def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patienc
         os.environ.get("MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED", "false").lower() == "true" and task_monitoring_enabled
     )
 
-    mwaa_worker_graceful_shutdown_seconds = int(os.environ.get("MWAA__CORE__MWAA_WORKER_GRACEFUL_SHUTDOWN_SECONDS",
+    mwaa_worker_idleness_verification_interval = int(os.environ.get("MWAA__CORE__WORKER_IDLENESS_VERIFICATION_INTERVAL",
                                                                "20"))
 
     if task_monitoring_enabled:
-        logger.info(f"Worker task monitoring is enabled with graceful shutdown seconds: "
-                    f"{mwaa_worker_graceful_shutdown_seconds}")
+        logger.info(f"Worker task monitoring is enabled with idleness verification interval: "
+                    f"{mwaa_worker_idleness_verification_interval}")
         # Initializing the monitor responsible for performing idle worker checks if enabled.
-        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled, mwaa_worker_graceful_shutdown_seconds)
+        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled, mwaa_worker_idleness_verification_interval)
     else:
         logger.info("Worker task monitoring is NOT enabled.")
         worker_task_monitor = None

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -579,10 +579,15 @@ def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patienc
     mwaa_signal_handling_enabled = (
         os.environ.get("MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED", "false").lower() == "true" and task_monitoring_enabled
     )
+
+    mwaa_worker_graceful_shutdown_seconds = int(os.environ.get("MWAA__CORE__MWAA_WORKER_GRACEFUL_SHUTDOWN_SECONDS",
+                                                               "20"))
+
     if task_monitoring_enabled:
-        logger.info("Worker task monitoring is enabled.")
+        logger.info(f"Worker task monitoring is enabled with graceful shutdown seconds: "
+                    f"{mwaa_worker_graceful_shutdown_seconds}")
         # Initializing the monitor responsible for performing idle worker checks if enabled.
-        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled)
+        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled, mwaa_worker_graceful_shutdown_seconds)
     else:
         logger.info("Worker task monitoring is NOT enabled.")
         worker_task_monitor = None

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -580,7 +580,7 @@ def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patienc
         os.environ.get("MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED", "false").lower() == "true" and task_monitoring_enabled
     )
 
-    mwaa_worker_idleness_verification_interval = int(os.environ.get("MWAA__CORE__WORKER_IDLENESS_VERIFICATION_INTERVAL",
+    mwaa_worker_idleness_verification_interval = int(environ.get("MWAA__CORE__WORKER_IDLENESS_VERIFICATION_INTERVAL",
                                                                "20"))
 
     if task_monitoring_enabled:


### PR DESCRIPTION
*Issue #, if available:*

The current 5 seconds wait time after pausing task consumption is not enough. We have seen some cases where there was still pending SQS.ReceiveMessage requests during the 5 seconds grace period. So this pull request increase the graceful period to 20second, and make it configurable by environment variable.

*Description of changes:*

- `entrypoint.py` reads environment variable `MWAA__CORE__MWAA_WORKER_GRACEFUL_SHUTDOWN_SECONDS`, and make it default to 20 seconds, and pass the value to WorkerTaskMonitor.
- WorkerTaskMonitor will sleep for `MWAA__CORE__MWAA_WORKER_GRACEFUL_SHUTDOWN_SECONDS` seconds after pausing task consumption.
