### PR TITLE
Provide celery with improved db engine pool configuration

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/config/celery.py
+++ b/images/airflow/2.10.1/python/mwaa/config/celery.py
@@ -35,6 +35,8 @@ def create_celery_config() -> dict[str, Any]:
             "is_secure": should_use_ssl(),
             "region": get_aws_region(),
         },
+        "pool_pre_ping": True,
+        "pool_recycle": 1200,
     }
 
     return celery_config

--- a/images/airflow/2.10.3/python/mwaa/config/celery.py
+++ b/images/airflow/2.10.3/python/mwaa/config/celery.py
@@ -35,6 +35,8 @@ def create_celery_config() -> dict[str, Any]:
             "is_secure": should_use_ssl(),
             "region": get_aws_region(),
         },
+        "pool_pre_ping": True,
+        "pool_recycle": 1200,
     }
 
     return celery_config

--- a/images/airflow/2.9.2/python/mwaa/config/celery.py
+++ b/images/airflow/2.9.2/python/mwaa/config/celery.py
@@ -35,6 +35,8 @@ def create_celery_config() -> dict[str, Any]:
             "is_secure": should_use_ssl(),
             "region": get_aws_region(),
         },
+        "pool_pre_ping": True,
+        "pool_recycle": 1200,
     }
 
     return celery_config


### PR DESCRIPTION
### Overview

Added database connection pool configuration settings for Celery to improve reliability and performance:

- Enabled connection health checks with pool_pre_ping
- Set connection recycling to 20 minutes

These settings help prevent stale connections and better manage database connection lifecycle. The lack of this configuration is the root cause behind the notorious `psycopg2.OperationalError: SSL connection has been closed unexpectedly`

### Testing

To test the new Celery configuration, two MWAA environments were compared, both using RDS proxies with an IdleClientTimeout of 1 minute to accelerate testing. The orange environment, the control, uses the current MWAA default Airflow and Celery configuration, while the blue environment, the subject, uses the updated configuration. Below are the total psycopg2 errors reported for both environments.

![image](https://github.com/user-attachments/assets/75479725-6a3e-4318-9ac5-1bb71fdbc20c)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
