### PR TITLE
Adding fix for incorrect log level bug for versions 2.10.1 & 2.10.3

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.10.1/python/mwaa/config/setup_environment.py
@@ -1,0 +1,272 @@
+"""
+Environment configuration module for Amazon MWAA.
+
+This module handles the setup and configuration of environment variables
+and settings required for running Apache Airflow in Amazon MWAA (Managed
+Workflows for Apache Airflow) environments.
+"""
+# Python imports
+from datetime import timedelta
+from typing import Dict
+import json
+import logging
+import os
+import shlex
+import time
+
+# Our imports
+from mwaa.config.airflow import (
+    get_essential_airflow_config,
+    get_opinionated_airflow_config,
+    get_user_airflow_config
+)
+from mwaa.logging.config import MWAA_LOGGERS
+from mwaa.config.environ import get_essential_environ, get_opinionated_environ
+from mwaa.subprocess.subprocess import Subprocess
+from mwaa.subprocess.conditions import TimeoutCondition
+
+
+
+logger = logging.getLogger("mwaa.entrypoint")
+
+STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL = timedelta(seconds=5)
+STARTUP_SCRIPT_MAX_EXECUTION_TIME = (
+    timedelta(minutes=5) - STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL
+)
+
+def _execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]:
+    """
+    Execute user startup script.
+
+    :param cmd - The MWAA command the container is running, e.g. "worker", "scheduler". This is used for logging
+    purposes so the logs of the execution of the startup script get sent to the correct place.
+    :param environ: A dictionary containing the environment variables.
+    """
+    startup_script_path = os.environ.get("MWAA__CORE__STARTUP_SCRIPT_PATH", "")
+    if not startup_script_path:
+        logger.info("MWAA__CORE__STARTUP_SCRIPT_PATH is not provided.")
+        return {}
+
+    EXECUTE_USER_STARTUP_SCRIPT_PATH = "execute-user-startup-script"
+    POST_STARTUP_SCRIPT_VERIFICATION_PATH = "post-startup-script-verification"
+    # For hybrid worker/scheduler containers we publish the startup script logs
+    # to the worker CloudWatch log group.
+    PROCESS_LOGGER_PREFIX = "worker" if cmd == "hybrid" else cmd;
+    PROCESS_LOGGER = logging.getLogger(MWAA_LOGGERS.get(f"{PROCESS_LOGGER_PREFIX}_startup"))
+
+    if os.path.isfile(startup_script_path):
+        logger.info("Executing customer startup script.")
+
+        start_time = time.time()  # Capture start time
+        startup_script_process = Subprocess(
+            cmd=["/bin/bash", EXECUTE_USER_STARTUP_SCRIPT_PATH],
+            env=environ,
+            process_logger=PROCESS_LOGGER,
+            conditions=[
+                TimeoutCondition(STARTUP_SCRIPT_MAX_EXECUTION_TIME),
+            ],
+            friendly_name=f"{PROCESS_LOGGER_PREFIX}_startup",
+            sigterm_patience_interval=STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL,
+        )
+        startup_script_process.start()
+        end_time = time.time()
+        duration = end_time - start_time
+        PROCESS_LOGGER.info(f"Startup script execution time: {duration:.2f} seconds.")
+
+        logger.info("Executing post startup script verification.")
+        verification_process = Subprocess(
+            cmd=["/bin/bash", POST_STARTUP_SCRIPT_VERIFICATION_PATH],
+            env=environ,
+            process_logger=PROCESS_LOGGER,
+            conditions=[
+                TimeoutCondition(STARTUP_SCRIPT_MAX_EXECUTION_TIME),
+            ],
+            friendly_name=f"{PROCESS_LOGGER_PREFIX}_startup",
+        )
+        verification_process.start()
+
+        customer_env_vars_path = "/tmp/customer_env_vars.json"
+        if os.path.isfile(customer_env_vars_path):
+            try:
+                with open(customer_env_vars_path, "r") as f:
+                    customer_env_dict = json.load(f)
+                logger.info("Successfully read the customer's environment variables.")
+                return customer_env_dict
+            except Exception as e:
+                logger.error(f"Error reading the customer's environment variables: {e}")
+                PROCESS_LOGGER.error(
+                    "[ERROR] Failed to load environment variables from startup script. "
+                    "Please verify your startup script configuration."
+                )
+                raise Exception(f"Failed to read customer's environment variables from startup script: {e}")
+
+        else:
+            logger.error(
+                "An unexpected error occurred: the file containing the customer-defined "
+                "environment variables could not be located. If the customer's startup "
+                "script defines environment variables, this error message indicates that "
+                "those variables won't be exported to the Airflow tasks."
+            )
+            PROCESS_LOGGER.error(
+                "[ERROR] An unexpected error occurred: Failed to locate environment variables file from startup script.")
+            raise Exception(
+                "Failed to access customer environment variables file: Service was unable to create or locate /tmp/customer_env_vars.json")
+
+    else:
+        logger.info(f"No startup script found at {startup_script_path}.")
+        return {}
+
+def _export_env_variables(environ: dict[str, str]):
+    """
+    Export the environment variables to .bashrc and .bash_profile.
+
+    For Airflow to function properly, a bunch of environment variables needs to be
+    defined, which we do in the entrypoint. However, during development, a need might
+    arise for bashing into the Docker container and doing some debugging, e.g. running
+    a bunch of Airflow CLI commands. This won't be possible if the necessary environment
+    variables are not defined, which is the case unless we have them defined in the
+    .bashrc/.bash_profile files. This function does exactly that.
+
+    :param environ: A dictionary containing the environment variables to export.
+    """
+    # Get the home directory of the current user
+    home_dir = os.path.expanduser("~")
+    bashrc_path = os.path.join(home_dir, ".bashrc")
+    bash_profile_path = os.path.join(home_dir, ".bash_profile")
+
+    # Environment variables to append
+    env_vars_to_append = [
+        f"export {key}={shlex.quote(value)}\n" for key, value in environ.items()
+    ]
+
+    # Append to .bashrc
+    with open(bashrc_path, "a") as bashrc:
+        bashrc.writelines(env_vars_to_append)
+
+    # Append to .bash_profile
+    with open(bash_profile_path, "a") as bash_profile:
+        bash_profile.writelines(env_vars_to_append)
+
+def _is_protected_os_environ(key: str) -> bool:
+    # Protected environment variables
+    protected_vars = [
+        # Environment ID and name are set by MWAA for
+        # informational purposes, and shouldn't be overridden by the customer.
+        "AIRFLOW_ENV_ID",
+        "AIRFLOW_ENV_NAME",
+        # Airflow home directory cannot be overridden
+        # as this will break MWAA setup.
+        "AIRFLOW_HOME",
+        # This is an internal MWAA identifier and
+        # shouldn't be modified by users.
+        "AIRFLOW_TASK_REVISION_ID",
+        # Airflow version is managed by MWAA and
+        # shouldn't be overridden manually.
+        "AIRFLOW_VERSION",
+        # The following two are needed by the IAM
+        # plugin and shouldn't be overridden.
+        "AIRFLOW__AWS_MWAA__REDIRECT_URL",
+        "JWT_PUBLIC_KEY",
+        # This is set to match the endpoint created
+        # by MWAA and shouldn't be overridden.
+        "AIRFLOW__WEBSERVER__BASE_URL",
+        # Default AWS region set by MWAA and used for AWS services.
+        "AWS_DEFAULT_REGION",
+        # AWS_REGION has a broader scope that is used by not just MWAA but
+        # by the AWS SDK in general if the default region is not set.
+        "AWS_REGION",
+        # This identifies the customer account associated
+        # with the MWAA environment.
+        "CUSTOMER_ACCOUNT_ID",
+        # These following are set by or needed for Fargate and
+        # shouldn't be modified by the user.
+        "ECS_AGENT_URI",
+        "ECS_CONTAINER_METADATA_URI",
+        "ECS_CONTAINER_METADATA_URI_V4",
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        "AWS_EXECUTION_ENV",
+        # We don't allow the customer to override the PYTHONPATH, as this can break our
+        # Python setup easily.
+        "PYTHONPATH",
+        # We disable Python buffering as we want to make
+        # sure all print statements are sent to us immediately
+        # so we can control when to send them to CloudWatch Logs.
+        "PYTHONUNBUFFERED",
+        # This is used to validate the version of Watchtower installed
+        # which we don't allow the customer to override.
+        "WATCHTOWER_VERSION",
+    ]
+
+    # Check whether this is an MWAA configuration or a protected variable
+    return key.startswith("MWAA__") or key in protected_vars
+
+def setup_environment_variables(command: str, executor_type: str) -> Dict:
+    """Set up and return environment variables for Airflow execution.
+
+            Configures the necessary environment variables based on the provided command
+            and executor type for running Airflow tasks.
+
+            Args:
+                command (str): The Airflow command to be executed.
+                executor_type (str): The type of executor to be used (e.g., 'Local', 'Celery').
+
+            Returns:
+                Dict: A dictionary containing all configured environment variables
+                      required for the Airflow execution.
+    """
+    # Add the necessary environment variables.
+    mwaa_essential_airflow_config = get_essential_airflow_config(executor_type)
+    mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
+    mwaa_essential_airflow_environ = get_essential_environ(command)
+    mwaa_opinionated_airflow_environ = get_opinionated_environ()
+    user_airflow_config = get_user_airflow_config()
+
+
+    startup_script_environ = _execute_startup_script(
+        command,
+        {
+            **os.environ,
+            **mwaa_opinionated_airflow_config,
+            **mwaa_opinionated_airflow_environ,
+            **user_airflow_config,
+            **mwaa_essential_airflow_environ,
+            **mwaa_essential_airflow_config,
+        },
+    )
+    environ = {
+        **os.environ,
+        # Custom configuration and environment variables that we think are good, but
+        # allow the user to override.
+        **mwaa_opinionated_airflow_config,
+        **mwaa_opinionated_airflow_environ,
+        # What the user defined in the startup script.
+        **startup_script_environ,
+        # What the user passed via Airflow config secrets (specified by the
+        # MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS environment variable.)
+        **user_airflow_config,
+        # The MWAA__x__y environment variables that are passed to the container are
+        # considered protected environment variables that cannot be overridden at
+        # runtime to avoid breaking the functionality of the container.
+        **{
+            key: value
+            for (key, value) in os.environ.items()
+            if _is_protected_os_environ(key)
+        },
+        # Essential variables that our setup will not function properly without, hence
+        # it always has the highest priority.
+        **mwaa_essential_airflow_config,
+        **mwaa_essential_airflow_environ,
+    }
+
+    # IMPORTANT NOTE: The level for this should stay "DEBUG" to avoid logging customer
+    # custom environment variables, which potentially contains sensitive credentials,
+    # to stdout which, in this case of Fargate hosting (like in Amazon MWAA), ends up
+    # being captured and sent to the service hosting.
+    logger.debug(f"Environment variables: %s", environ)
+
+    # Export the environment variables to .bashrc and .bash_profile to enable
+    # users to run a shell on the container and have the necessary environment
+    # variables set for using airflow CLI.
+    _export_env_variables(environ)
+
+    return environ

--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -12,28 +12,15 @@ after setting up the necessary configurations.
 # is setup, its `logger` object will not have the right setup.
 # ruff: noqa: E402
 # fmt: off
+from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 import logging.config
-from mwaa.logging.config import (
-    DAG_PROCESSOR_LOGGER_NAME,
-    LOGGING_CONFIG,
-    SCHEDULER_LOGGER_NAME,
-    TRIGGERER_LOGGER_NAME,
-    WEBSERVER_LOGGER_NAME,
-    WORKER_LOGGER_NAME,
-)
-logging.config.dictConfig(LOGGING_CONFIG)
+logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
 # fmt: on
 
 # Python imports
-from datetime import timedelta
-from functools import cache
-from typing import Callable, Dict, List, Optional
 import asyncio
-import json
 import logging
 import os
-import re
-import shlex
 import sys
 import time
 
@@ -42,38 +29,46 @@ import boto3
 from botocore.exceptions import ClientError
 
 # Our imports
-from mwaa.celery.task_monitor import WorkerTaskMonitor
-from mwaa.config.airflow import (
-    get_essential_airflow_config,
-    get_opinionated_airflow_config,
-    get_user_airflow_config,
-)
-from mwaa.config.environ import get_essential_environ, get_opinionated_environ
+from mwaa.execute_command import execute_command
+from mwaa.config.setup_environment import setup_environment_variables
 from mwaa.config.sqs import (
     get_sqs_queue_name,
     should_create_queue,
 )
-from mwaa.logging.config import MWAA_LOGGERS
-from mwaa.logging.loggers import CompositeLogger
-from mwaa.subprocess.conditions import (
-    SIDECAR_DEFAULT_HEALTH_PORT,
-    AirflowDbReachableCondition,
-    TaskMonitoringCondition,
-    ProcessCondition,
-    SidecarHealthCondition,
-    TimeoutCondition,
-)
-from mwaa.subprocess.subprocess import Subprocess, run_subprocesses
 from mwaa.utils.cmd import run_command
 from mwaa.utils.dblock import with_db_lock
-from mwaa.utils.encoding import auto_decode
-
+from mwaa.utils.user_requirements import install_user_requirements
 
 # Usually, we pass the `__name__` variable instead as that defaults to the
 # module path, i.e. `mwaa.entrypoint` in this case. However, since this is
 # the entrypoint script, `__name__` will have the value of `__main__`, hence
 # we hard-code the module path.
 logger = logging.getLogger("mwaa.entrypoint")
+
+
+def _setup_console_log_level(command: str):
+    # Set up console log level environment variable based on command
+    component_mapping = {
+        'scheduler': 'MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL',
+        'worker': 'MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL',
+        'webserver': 'MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_LEVEL'
+    }
+
+    if command in component_mapping:
+        source_var = component_mapping[command]
+        os.environ['AIRFLOW_CONSOLE_LOG_LEVEL'] = os.environ[source_var]
+    else:
+        os.environ['AIRFLOW_CONSOLE_LOG_LEVEL'] = 'INFO'
+
+
+def _configure_root_logger(command: str):
+    _setup_console_log_level(command)
+    # Doing a local import because we can't import
+    # LOGGING_CONFIG before setting AIRFLOW_CONSOLE_LOG_LEVEL
+    # as it will lead to root logger's log level set to default value
+    from mwaa.logging.config import LOGGING_CONFIG
+    logging.config.dictConfig(LOGGING_CONFIG)
+
 
 # TODO Fix the "type: ignore"s in this file.
 
@@ -88,22 +83,11 @@ AVAILABLE_COMMANDS = [
     "test-requirements",
     "test-startup-script",
 ]
-MWAA_DOCS_REQUIREMENTS_GUIDE = "https://docs.aws.amazon.com/mwaa/latest/userguide/working-dags-dependencies.html#working-dags-dependencies-test-create"
-STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL = timedelta(seconds=5)
-STARTUP_SCRIPT_MAX_EXECUTION_TIME = (
-    timedelta(minutes=5) - STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL
-)
-USER_REQUIREMENTS_MAX_INSTALL_TIME = timedelta(minutes=9)
 
 # Save the start time of the container. This is used later to with the sidecar
 # monitoring because we need to have a grace period before we start reporting timeouts
 # related to sidecar endpoint not reporting health messages.
 CONTAINER_START_TIME = time.time()
-
-# Hybrid container runs both scheduler and worker as essential subprocesses.
-# Therefore the default worker patience is increased to mitigate task
-# failures due to scheduler failure.
-HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT = timedelta(seconds=130)
 
 
 async def airflow_db_init(environ: dict[str, str]):
@@ -117,20 +101,6 @@ async def airflow_db_init(environ: dict[str, str]):
     :param environ: A dictionary containing the environment variables.
     """
     await run_command("python3 -m mwaa.database.migrate", env=environ)
-
-
-@with_db_lock(4321)
-async def airflow_db_reset(environ: dict[str, str]):
-    """
-    Reset Airflow metadata database.
-
-    This function resets the Airflow metadata database. It is called when the `resetdb`
-    command is specified.
-
-    :param environ: A dictionary containing the environment variables.
-    """
-    logger.info("Resetting Airflow metadata database.")
-    await run_command("airflow db reset --yes", env=environ)
 
 
 @with_db_lock(5678)
@@ -192,487 +162,6 @@ def create_queue() -> None:
             raise e
 
 
-def _read_requirements_file(requirements_file: str) -> str:
-    with open(requirements_file, "rb") as f:
-        return auto_decode(f.read())
-
-
-def _requirements_has_constraints(requirements_file: str):
-    content = _read_requirements_file(requirements_file)
-    for line in content.splitlines():
-        # Notice that this regex check will also match lines with commented out
-        # constraints flag. This is intentional as a mechanism for users who want to
-        # avoid enforcing the default Airflow constraints, yet don't want to provide a
-        # constraints file.
-        if re.search(r"-c |--constraint ", line):
-            return True
-    return False
-
-
-async def install_user_requirements(cmd: str, environ: dict[str, str]):
-    """
-    Install user requirements.
-
-    User requirements should be placed in a requirements.txt file and the environment
-    variable `MWAA__CORE__REQUIREMENTS_PATH` should be set to the location of that file.
-    In a Docker Compose setup, you would usually want to create a volume that maps a
-    requirements.txt file in the host machine somewhere in the container, and then set
-    the `MWAA__CORE__REQUIREMENTS_PATH` accordingly.
-
-    :param environ: A dictionary containing the environment variables.
-    """
-    requirements_file = environ.get("MWAA__CORE__REQUIREMENTS_PATH")
-    logger.info(f"MWAA__CORE__REQUIREMENTS_PATH = {requirements_file}")
-    # For hybrid worker/scheduler containers we publish the requirement install logs
-    # to the worker CloudWatch log group.
-    logger_prefix = "worker" if cmd == "hybrid" else cmd;
-    if requirements_file and os.path.isfile(requirements_file):
-        logger.info(f"Installing user requirements from {requirements_file}...")
-
-        subprocess_logger = CompositeLogger(
-            "requirements_composite_logging",  # name can be anything unused.
-            # We use a set to avoid double logging to console if the user doesn't
-            # use CloudWatch for logging.
-            *set(
-                [
-                    logging.getLogger(MWAA_LOGGERS.get(f"{logger_prefix}_requirements")),
-                    logger,
-                ]
-            ),
-        )
-
-        extra_args = []
-        try:
-            if not _requirements_has_constraints(requirements_file):
-                subprocess_logger.warning(
-                    "WARNING: Constraints should be specified for requirements.txt. "
-                    f"Please see {MWAA_DOCS_REQUIREMENTS_GUIDE}"
-                )
-                subprocess_logger.warning("Forcing local constraints")
-                extra_args = ["-c", os.environ["AIRFLOW_CONSTRAINTS_FILE"]]
-        except Exception as e:
-            subprocess_logger.warning(f"Unable to scan requirements file: {e}")
-            subprocess_logger.warning(
-                "Cannot determine whether the requirements.txt file has constraints "
-                "or not; forcing local constraints."
-            )
-            extra_args = ["-c", os.environ["AIRFLOW_CONSTRAINTS_FILE"]]
-
-        pip_process = Subprocess(
-            cmd=["safe-pip-install", "-r", requirements_file, *extra_args],
-            env=environ,
-            process_logger=subprocess_logger,
-            conditions=[
-                TimeoutCondition(USER_REQUIREMENTS_MAX_INSTALL_TIME),
-            ],
-            friendly_name=f"{logger_prefix}_requirements",
-        )
-        pip_process.start()
-        if pip_process.process and pip_process.process.returncode != 0:
-            subprocess_logger.error(
-                "ERROR: pip installation exited with a non-zero error code. This could "
-                "be the result of package conflict. Notice that MWAA enforces a list "
-                "of critical packages, e.g. Airflow, Celery, among others, whose "
-                "version cannot be overridden by the customer as that can break our "
-                "setup. Please double check your requirements.txt file."
-            )
-    else:
-        logger.info("No user requirements to install.")
-
-
-def execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]:
-    """
-    Execute user startup script.
-
-    :param cmd - The MWAA command the container is running, e.g. "worker", "scheduler". This is used for logging
-    purposes so the logs of the execution of the startup script get sent to the correct place.
-    :param environ: A dictionary containing the environment variables.
-    """
-    startup_script_path = os.environ.get("MWAA__CORE__STARTUP_SCRIPT_PATH", "")
-    if not startup_script_path:
-        logger.info("MWAA__CORE__STARTUP_SCRIPT_PATH is not provided.")
-        return {}
-
-    EXECUTE_USER_STARTUP_SCRIPT_PATH = "execute-user-startup-script"
-    POST_STARTUP_SCRIPT_VERIFICATION_PATH = "post-startup-script-verification"
-    # For hybrid worker/scheduler containers we publish the startup script logs
-    # to the worker CloudWatch log group.
-    PROCESS_LOGGER_PREFIX = "worker" if cmd == "hybrid" else cmd;
-    PROCESS_LOGGER = logging.getLogger(MWAA_LOGGERS.get(f"{PROCESS_LOGGER_PREFIX}_startup"))
-
-    if os.path.isfile(startup_script_path):
-        logger.info("Executing customer startup script.")
-
-        start_time = time.time()  # Capture start time
-        startup_script_process = Subprocess(
-            cmd=["/bin/bash", EXECUTE_USER_STARTUP_SCRIPT_PATH],
-            env=environ,
-            process_logger=PROCESS_LOGGER,
-            conditions=[
-                TimeoutCondition(STARTUP_SCRIPT_MAX_EXECUTION_TIME),
-            ],
-            friendly_name=f"{PROCESS_LOGGER_PREFIX}_startup",
-            sigterm_patience_interval=STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL,
-        )
-        startup_script_process.start()
-        end_time = time.time()
-        duration = end_time - start_time
-        PROCESS_LOGGER.info(f"Startup script execution time: {duration:.2f} seconds.")
-
-        logger.info("Executing post startup script verification.")
-        verification_process = Subprocess(
-            cmd=["/bin/bash", POST_STARTUP_SCRIPT_VERIFICATION_PATH],
-            env=environ,
-            process_logger=PROCESS_LOGGER,
-            conditions=[
-                TimeoutCondition(STARTUP_SCRIPT_MAX_EXECUTION_TIME),
-            ],
-            friendly_name=f"{PROCESS_LOGGER_PREFIX}_startup",
-        )
-        verification_process.start()
-
-        customer_env_vars_path = "/tmp/customer_env_vars.json"
-        if os.path.isfile(customer_env_vars_path):
-            try:
-                with open(customer_env_vars_path, "r") as f:
-                    customer_env_dict = json.load(f)
-                logger.info("Successfully read the customer's environment variables.")
-                return customer_env_dict
-            except Exception as e:
-                logger.error(f"Error reading the customer's environment variables: {e}")
-                PROCESS_LOGGER.error(
-                    "[ERROR] Failed to load environment variables from startup script. "
-                    "Please verify your startup script configuration."
-                )
-                raise Exception(f"Failed to read customer's environment variables from startup script: {e}")
-
-        else:
-            logger.error(
-                "An unexpected error occurred: the file containing the customer-defined "
-                "environment variables could not be located. If the customer's startup "
-                "script defines environment variables, this error message indicates that "
-                "those variables won't be exported to the Airflow tasks."
-            )
-            PROCESS_LOGGER.error("[ERROR] An unexpected error occurred: Failed to locate environment variables file from startup script.")
-            raise Exception("Failed to access customer environment variables file: Service was unable to create or locate /tmp/customer_env_vars.json")
-
-    else:
-        logger.info(f"No startup script found at {startup_script_path}.")
-        return {}
-
-
-def export_env_variables(environ: dict[str, str]):
-    """
-    Export the environment variables to .bashrc and .bash_profile.
-
-    For Airflow to function properly, a bunch of environment variables needs to be
-    defined, which we do in the entrypoint. However, during development, a need might
-    arise for bashing into the Docker container and doing some debugging, e.g. running
-    a bunch of Airflow CLI commands. This won't be possible if the necessary environment
-    variables are not defined, which is the case unless we have them defined in the
-    .bashrc/.bash_profile files. This function does exactly that.
-
-    :param environ: A dictionary containing the environment variables to export.
-    """
-    # Get the home directory of the current user
-    home_dir = os.path.expanduser("~")
-    bashrc_path = os.path.join(home_dir, ".bashrc")
-    bash_profile_path = os.path.join(home_dir, ".bash_profile")
-
-    # Environment variables to append
-    env_vars_to_append = [
-        f"export {key}={shlex.quote(value)}\n" for key, value in environ.items()
-    ]
-
-    # Append to .bashrc
-    with open(bashrc_path, "a") as bashrc:
-        bashrc.writelines(env_vars_to_append)
-
-    # Append to .bash_profile
-    with open(bash_profile_path, "a") as bash_profile:
-        bash_profile.writelines(env_vars_to_append)
-
-
-def create_airflow_subprocess(
-    args: List[str],
-    environ: Dict[str, str],
-    logger_name: str,
-    friendly_name: str,
-    conditions: List[ProcessCondition] = [],
-    on_sigterm: Optional[Callable[[], None]] = None,
-    sigterm_patience_interval: timedelta | None = None
-):
-    """
-    Create a subprocess for an Airflow command.
-
-    Notice that while this function creates the sub-process, it will not start it.
-    So, the caller is responsible for starting it.
-
-    :param args - The arguments to pass to the Airflow CLI.
-    :param environ - A dictionary containing the environment variables.
-    :param logger_name - The name of the logger to use for capturing the generated logs.
-
-    :returns The created subprocess.
-    """
-    logger: logging.Logger = logging.getLogger(logger_name)
-    kwargs = {
-            "cmd": ["airflow", *args],
-            "env": environ,
-            "process_logger": logger,
-            "friendly_name": friendly_name,
-            "conditions": conditions,
-            "on_sigterm": on_sigterm,
-            "is_essential": True
-    }
-    if sigterm_patience_interval is not None:
-        kwargs['sigterm_patience_interval'] = sigterm_patience_interval
-    return Subprocess(
-        **kwargs
-    )
-
-
-def _is_protected_os_environ(key: str) -> bool:
-    # Protected environment variables
-    protected_vars = [
-        # Environment ID and name are set by MWAA for
-        # informational purposes, and shouldn't be overridden by the customer.
-        "AIRFLOW_ENV_ID",
-        "AIRFLOW_ENV_NAME",
-        # Airflow home directory cannot be overridden
-        # as this will break MWAA setup.
-        "AIRFLOW_HOME",
-        # This is an internal MWAA identifier and
-        # shouldn't be modified by users.
-        "AIRFLOW_TASK_REVISION_ID",
-        # Airflow version is managed by MWAA and
-        # shouldn't be overridden manually.
-        "AIRFLOW_VERSION",
-        # The following two are needed by the IAM
-        # plugin and shouldn't be overridden.
-        "AIRFLOW__AWS_MWAA__REDIRECT_URL",
-        "JWT_PUBLIC_KEY",
-        # This is set to match the endpoint created
-        # by MWAA and shouldn't be overridden.
-        "AIRFLOW__WEBSERVER__BASE_URL",
-        # Default AWS region set by MWAA and used for AWS services.
-        "AWS_DEFAULT_REGION",
-        # AWS_REGION has a broader scope that is used by not just MWAA but
-        # by the AWS SDK in general if the default region is not set.
-        "AWS_REGION",
-        # This identifies the customer account associated
-        # with the MWAA environment.
-        "CUSTOMER_ACCOUNT_ID",
-        # These following are set by or needed for Fargate and
-        # shouldn't be modified by the user.
-        "ECS_AGENT_URI",
-        "ECS_CONTAINER_METADATA_URI",
-        "ECS_CONTAINER_METADATA_URI_V4",
-        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
-        "AWS_EXECUTION_ENV",
-        # We don't allow the customer to override the PYTHONPATH, as this can break our
-        # Python setup easily.
-        "PYTHONPATH",
-        # We disable Python buffering as we want to make
-        # sure all print statements are sent to us immediately
-        # so we can control when to send them to CloudWatch Logs.
-        "PYTHONUNBUFFERED",
-        # This is used to validate the version of Watchtower installed
-        # which we don't allow the customer to override.
-        "WATCHTOWER_VERSION",
-    ]
-
-    # Check whether this is an MWAA configuration or a protected variable
-    return key.startswith("MWAA__") or key in protected_vars
-
-
-@cache
-def _is_sidecar_health_monitoring_enabled():
-    enabled = (
-        os.environ.get(
-            "MWAA__HEALTH_MONITORING__ENABLE_SIDECAR_HEALTH_MONITORING", "false"
-        ).lower()
-        == "true"
-    )
-    if enabled:
-        logger.info("Sidecar health monitoring is enabled.")
-    else:
-        logger.info("Sidecar health monitoring is NOT enabled.")
-    return enabled
-
-
-def _get_sidecar_health_port():
-    try:
-        return int(
-            os.environ.get(
-                "MWAA__HEALTH_MONITORING__SIDECAR_HEALTH_PORT",
-                SIDECAR_DEFAULT_HEALTH_PORT,
-            )
-        )
-    except:
-        return SIDECAR_DEFAULT_HEALTH_PORT
-
-
-def _create_airflow_webserver_subprocesses(environ: Dict[str, str]):
-    return [
-        create_airflow_subprocess(
-            ["webserver"],
-            environ=environ,
-            logger_name=WEBSERVER_LOGGER_NAME,
-            friendly_name="webserver",
-            conditions=[
-                AirflowDbReachableCondition(airflow_component="webserver"),
-            ],
-        ),
-    ]
-
-
-def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patience_interval: timedelta | None = None):
-    conditions = _create_airflow_process_conditions('worker')
-    # MWAA__CORE__TASK_MONITORING_ENABLED is set to 'true' for workers where we want to monitor count of tasks currently getting
-    # executed on the worker. This will be used to determine if idle worker checks are to be enabled.
-    task_monitoring_enabled = (
-        os.environ.get("MWAA__CORE__TASK_MONITORING_ENABLED", "false").lower() == "true"
-    )
-    # If MWAA__CORE__TERMINATE_IF_IDLE is set to 'true', then as part of the task monitoring if the task count reaches zero, then the
-    # worker will be terminated.
-    terminate_if_idle = (
-        os.environ.get("MWAA__CORE__TERMINATE_IF_IDLE", "false").lower() == "true" and task_monitoring_enabled
-    )
-    # If MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED is set to 'true', then as part of the task monitoring, the monitor will expect certain
-    # signals to be sent from MWAA. These signals will represent MWAA service side events such as start of an environment update.
-    mwaa_signal_handling_enabled = (
-        os.environ.get("MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED", "false").lower() == "true" and task_monitoring_enabled
-    )
-
-    mwaa_worker_idleness_verification_interval = int(environ.get("MWAA__CORE__WORKER_IDLENESS_VERIFICATION_INTERVAL",
-                                                                    "20"))
-    if task_monitoring_enabled:
-        logger.info(f"Worker task monitoring is enabled with idleness verification interval: "
-                   f"{mwaa_worker_idleness_verification_interval}")
-        # Initializing the monitor responsible for performing idle worker checks if enabled.
-        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled, mwaa_worker_idleness_verification_interval)
-    else:
-        logger.info("Worker task monitoring is NOT enabled.")
-        worker_task_monitor = None
-
-    if worker_task_monitor:
-        conditions.append(TaskMonitoringCondition(worker_task_monitor, terminate_if_idle))
-
-    def on_sigterm() -> None:
-        # When a SIGTERM is caught, we pause the Airflow Task consumption and wait 5 seconds in order
-        # for any in-flight messages in the SQS broker layer to be processed and
-        # corresponding Airflow task instance to be created. Once that is done, we can
-        # start gracefully shutting down the worker. Without this, the SQS broker may
-        # consume messages from the queue, terminate before creating the corresponding
-        # Airflow task instance and abandon SQS messages in-flight.
-        if worker_task_monitor:
-            worker_task_monitor.pause_task_consumption()
-            time.sleep(5)
-
-    # Finally, return the worker subprocesses.
-    return [
-            create_airflow_subprocess(
-                ["celery", "worker"],
-                environ=environ,
-                logger_name=WORKER_LOGGER_NAME,
-                friendly_name="worker",
-                conditions=conditions,
-                on_sigterm=on_sigterm,
-                sigterm_patience_interval=sigterm_patience_interval
-            )
-        ]
-
-
-def _create_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: List):
-    """
-    Get the scheduler subproceses: scheduler, dag-processor, and triggerer.
-
-    :param environ: A dictionary containing the environment variables.
-    :param conditions: A list of subprocess conditions.
-    :returns: Scheduler subprocesses.
-    """
-    return [
-            create_airflow_subprocess(
-                [airflow_cmd],
-                environ=environ,
-                logger_name=logger_name,
-                friendly_name=friendly_name,
-                conditions=conditions if airflow_cmd == "scheduler" else [],
-            )
-            for airflow_cmd, logger_name, friendly_name in [
-                ("scheduler", SCHEDULER_LOGGER_NAME, "scheduler"),
-                ("dag-processor", DAG_PROCESSOR_LOGGER_NAME, "dag-processor"),
-                ("triggerer", TRIGGERER_LOGGER_NAME, "triggerer"),
-            ]
-        ]
-
-
-def _create_airflow_process_conditions(airflow_cmd: str):
-    """
-    Get conditions for the given Airflow command.
-
-    :param airflow_cmd: The command to get conditions for, e.g. "scheduler"
-    :returns: A list of conditions for the given Airflow command.
-    """
-    conditions: List[ProcessCondition] = [
-        AirflowDbReachableCondition(airflow_component=airflow_cmd),
-    ]
-    if _is_sidecar_health_monitoring_enabled():
-        conditions.append(
-            SidecarHealthCondition(
-                airflow_component=airflow_cmd,
-                container_start_time=CONTAINER_START_TIME,
-                port=_get_sidecar_health_port(),
-            ),
-        )
-    return conditions
-def run_airflow_command(cmd: str, environ: Dict[str, str]):
-    """
-    Run the given Airflow command in a subprocess.
-
-    :param cmd - The command to run, e.g. "worker".
-    :param environ: A dictionary containing the environment variables.
-    """
-    match cmd:
-        case "scheduler":
-            conditions = _create_airflow_process_conditions('scheduler')
-            subprocesses = _create_airflow_scheduler_subprocesses(environ, conditions)
-            # Schedulers, triggers, and DAG processors are all essential processes and
-            # if any fails, we want to exit the container and let it restart.
-            run_subprocesses(subprocesses)
-        case "worker":
-            run_subprocesses(_create_airflow_worker_subprocesses(environ))
-        case "webserver":
-            run_subprocesses(_create_airflow_webserver_subprocesses(environ))
-        # Hybrid runs the scheduler and celery worker processes is a single container.
-        case "hybrid":
-            # The Sidecar healthcheck is currently limited to one healthcheck per port
-            # so the hybrid container can only include healthchecks for one subprocess.
-            # Only the worker healcheck conditions are enabled to monitor container health, so
-            # we pass an empty list of conditions to the scheduler process and make worker
-            # process essential.
-            scheduler_subprocesses = _create_airflow_scheduler_subprocesses(environ, [])
-
-            # Since both scheduler and workers are launched together as essential
-            # the default patience interval for worker needs to be increased to better
-            # allow for in-flight tasks to complete in case of scheduler failure.
-            try:
-                worker_patience_interval_seconds = os.getenv('MWAA__HYBRID_CONTAINER__SIGTERM_PATIENCE_INTERVAL', None)
-                if worker_patience_interval_seconds is not None:
-                    worker_patience_interval = timedelta(seconds=int(worker_patience_interval_seconds))
-                else:
-                    worker_patience_interval = HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT
-            except (ValueError, TypeError):
-                worker_patience_interval = HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT
-
-            worker_subprocesses = _create_airflow_worker_subprocesses(environ,
-                                                                   sigterm_patience_interval=worker_patience_interval)
-            run_subprocesses(scheduler_subprocesses + worker_subprocesses)
-
-        case _:
-            raise ValueError(f"Unexpected command: {cmd}")
-
-
 async def main() -> None:
     """Start execution of the script."""
     try:
@@ -690,65 +179,12 @@ async def main() -> None:
             f"Invalid arguments: {sys.argv}. Please provide one argument with one of"
             f'the values: {", ".join(AVAILABLE_COMMANDS)}. Error was {e}.'
         )
-
+    _configure_root_logger(command)
     logger.info(f"Warming a Docker container for an Airflow {command}.")
 
     # Get executor type
     executor_type = os.environ.get("MWAA__CORE__EXECUTOR_TYPE", "CeleryExecutor")
-
-    # Add the necessary environment variables.
-    mwaa_essential_airflow_config = get_essential_airflow_config(executor_type)
-    mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
-    mwaa_essential_airflow_environ = get_essential_environ(command)
-    mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = get_user_airflow_config()
-
-    startup_script_environ = execute_startup_script(
-        command,
-        {
-            **os.environ,
-            **mwaa_opinionated_airflow_config,
-            **mwaa_opinionated_airflow_environ,
-            **user_airflow_config,
-            **mwaa_essential_airflow_environ,
-            **mwaa_essential_airflow_config,
-        },
-    )
-
-    if command == "test-startup-script":
-        print("Finished testing startup script")
-        return
-
-    environ = {
-        **os.environ,
-        # Custom configuration and environment variables that we think are good, but
-        # allow the user to override.
-        **mwaa_opinionated_airflow_config,
-        **mwaa_opinionated_airflow_environ,
-        # What the user defined in the startup script.
-        **startup_script_environ,
-        # What the user passed via Airflow config secrets (specified by the
-        # MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS environment variable.)
-        **user_airflow_config,
-        # The MWAA__x__y environment variables that are passed to the container are
-        # considered protected environment variables that cannot be overridden at
-        # runtime to avoid breaking the functionality of the container.
-        **{
-            key: value
-            for (key, value) in os.environ.items()
-            if _is_protected_os_environ(key)
-        },
-        # Essential variables that our setup will not function properly without, hence
-        # it always has the highest priority.
-        **mwaa_essential_airflow_config,
-        **mwaa_essential_airflow_environ,
-    }
-
-    # IMPORTANT NOTE: The level for this should stay "DEBUG" to avoid logging customer
-    # custom environment variables, which potentially contains sensitive credentials,
-    # to stdout which, in this case of Fargate hosting (like in Amazon MWAA), ends up
-    # being captured and sent to the service hosting.
-    logger.debug(f"Environment variables: %s", environ)
+    environ = setup_environment_variables(command, executor_type)
 
     await install_user_requirements(command, environ)
 
@@ -766,32 +202,7 @@ async def main() -> None:
     if executor_type.lower() == "celeryexecutor":
         create_queue()
 
-    # Export the environment variables to .bashrc and .bash_profile to enable
-    # users to run a shell on the container and have the necessary environment
-    # variables set for using airflow CLI.
-    export_env_variables(environ)
-
-    match command:
-        case "shell":
-            os.execlpe("/bin/bash", "/bin/bash", environ)
-        case "spy":
-            while True:
-                time.sleep(1)
-        # Disabling the "resetdb" command for now, as it is pretty risky to have such
-        # a destructive command adjacent to other commands used in production; a simple
-        # code mistake can result in wiping out production databases. Instead, testing
-        # commands like this should be in a completely isolated boundary, with
-        # protection mechanism to ensure they are not accidentally executed in
-        # production.
-        # case "resetdb":
-        #     # Perform the resetdb functionality
-        #     await airflow_db_reset(environ)
-        #     # After resetting the db, initialize it again
-        #     await airflow_db_init(environ)
-        case "scheduler" | "webserver" | "worker" | "hybrid":
-            run_airflow_command(command, environ)
-        case _:
-            raise ValueError(f"Invalid command: {command}")
+    execute_command(command, environ, CONTAINER_START_TIME)
 
 
 if __name__ == "__main__":

--- a/images/airflow/2.10.1/python/mwaa/execute_command.py
+++ b/images/airflow/2.10.1/python/mwaa/execute_command.py
@@ -1,0 +1,331 @@
+"""
+Command execution module for Amazon MWAA environments.
+
+This module provides functionality to execute Airflow commands with proper
+environment configuration and timing management. It handles various Airflow
+commands including scheduler, webserver, worker, and hybrid modes within
+the MWAA execution environment.
+"""
+# Python imports
+from datetime import timedelta
+from functools import cache
+from typing import List, Dict, Optional, Callable
+import logging
+import os
+import time
+
+# Our imports
+from mwaa.celery.task_monitor import WorkerTaskMonitor
+from mwaa.logging.config import (
+    DAG_PROCESSOR_LOGGER_NAME,
+    LOGGING_CONFIG,
+    SCHEDULER_LOGGER_NAME,
+    TRIGGERER_LOGGER_NAME,
+    WEBSERVER_LOGGER_NAME,
+    WORKER_LOGGER_NAME,
+)
+from mwaa.subprocess.conditions import (
+    SIDECAR_DEFAULT_HEALTH_PORT,
+    AirflowDbReachableCondition,
+    TaskMonitoringCondition,
+    ProcessCondition,
+    SidecarHealthCondition,
+    TimeoutCondition,
+)
+from mwaa.subprocess.subprocess import Subprocess, run_subprocesses
+from mwaa.utils.cmd import run_command
+from mwaa.utils.dblock import with_db_lock
+
+
+logger = logging.getLogger("mwaa.entrypoint")
+
+
+# Hybrid container runs both scheduler and worker as essential subprocesses.
+# Therefore the default worker patience is increased to mitigate task
+# failures due to scheduler failure.
+HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT = timedelta(seconds=130)
+
+@with_db_lock(4321)
+async def airflow_db_reset(environ: dict[str, str]):
+    """
+    Reset Airflow metadata database.
+
+    This function resets the Airflow metadata database. It is called when the `resetdb`
+    command is specified.
+
+    :param environ: A dictionary containing the environment variables.
+    """
+    logger.info("Resetting Airflow metadata database.")
+    await run_command("airflow db reset --yes", env=environ)
+
+def _create_airflow_subprocess(
+    args: List[str],
+    environ: Dict[str, str],
+    logger_name: str,
+    friendly_name: str,
+    conditions: List[ProcessCondition] = [],
+    on_sigterm: Optional[Callable[[], None]] = None,
+    sigterm_patience_interval: timedelta | None = None
+):
+    """
+    Create a subprocess for an Airflow command.
+
+    Notice that while this function creates the sub-process, it will not start it.
+    So, the caller is responsible for starting it.
+
+    :param args - The arguments to pass to the Airflow CLI.
+    :param environ - A dictionary containing the environment variables.
+    :param logger_name - The name of the logger to use for capturing the generated logs.
+
+    :returns The created subprocess.
+    """
+    logger: logging.Logger = logging.getLogger(logger_name)
+    kwargs = {
+            "cmd": ["airflow", *args],
+            "env": environ,
+            "process_logger": logger,
+            "friendly_name": friendly_name,
+            "conditions": conditions,
+            "on_sigterm": on_sigterm,
+            "is_essential": True
+    }
+    if sigterm_patience_interval is not None:
+        kwargs['sigterm_patience_interval'] = sigterm_patience_interval
+    return Subprocess(
+        **kwargs
+    )
+
+
+@cache
+def _is_sidecar_health_monitoring_enabled():
+    enabled = (
+        os.environ.get(
+            "MWAA__HEALTH_MONITORING__ENABLE_SIDECAR_HEALTH_MONITORING", "false"
+        ).lower()
+        == "true"
+    )
+    if enabled:
+        logger.info("Sidecar health monitoring is enabled.")
+    else:
+        logger.info("Sidecar health monitoring is NOT enabled.")
+    return enabled
+
+
+def _get_sidecar_health_port():
+    try:
+        return int(
+            os.environ.get(
+                "MWAA__HEALTH_MONITORING__SIDECAR_HEALTH_PORT",
+                SIDECAR_DEFAULT_HEALTH_PORT,
+            )
+        )
+    except:
+        return SIDECAR_DEFAULT_HEALTH_PORT
+
+
+def _create_airflow_webserver_subprocesses(environ: Dict[str, str]):
+    return [
+        _create_airflow_subprocess(
+            ["webserver"],
+            environ=environ,
+            logger_name=WEBSERVER_LOGGER_NAME,
+            friendly_name="webserver",
+            conditions=[
+                AirflowDbReachableCondition(airflow_component="webserver"),
+            ],
+        ),
+    ]
+
+
+def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patience_interval: timedelta | None = None):
+    conditions = _create_airflow_process_conditions('worker')
+    # MWAA__CORE__TASK_MONITORING_ENABLED is set to 'true' for workers where we want to monitor count of tasks currently getting
+    # executed on the worker. This will be used to determine if idle worker checks are to be enabled.
+    task_monitoring_enabled = (
+        os.environ.get("MWAA__CORE__TASK_MONITORING_ENABLED", "false").lower() == "true"
+    )
+    # If MWAA__CORE__TERMINATE_IF_IDLE is set to 'true', then as part of the task monitoring if the task count reaches zero, then the
+    # worker will be terminated.
+    terminate_if_idle = (
+        os.environ.get("MWAA__CORE__TERMINATE_IF_IDLE", "false").lower() == "true" and task_monitoring_enabled
+    )
+    # If MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED is set to 'true', then as part of the task monitoring, the monitor will expect certain
+    # signals to be sent from MWAA. These signals will represent MWAA service side events such as start of an environment update.
+    mwaa_signal_handling_enabled = (
+        os.environ.get("MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED", "false").lower() == "true" and task_monitoring_enabled
+    )
+
+
+    mwaa_worker_idleness_verification_interval = int(environ.get("MWAA__CORE__WORKER_IDLENESS_VERIFICATION_INTERVAL",
+                                                                    "20"))
+
+    if task_monitoring_enabled:
+        logger.info(f"Worker task monitoring is enabled with idleness verification interval: "
+                    f"{mwaa_worker_idleness_verification_interval}")
+        # Initializing the monitor responsible for performing idle worker checks if enabled.
+        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled, mwaa_worker_idleness_verification_interval)
+    else:
+        logger.info("Worker task monitoring is NOT enabled.")
+        worker_task_monitor = None
+
+    if worker_task_monitor:
+        conditions.append(TaskMonitoringCondition(worker_task_monitor, terminate_if_idle))
+
+    def on_sigterm() -> None:
+        # When a SIGTERM is caught, we pause the Airflow Task consumption and wait 5 seconds in order
+        # for any in-flight messages in the SQS broker layer to be processed and
+        # corresponding Airflow task instance to be created. Once that is done, we can
+        # start gracefully shutting down the worker. Without this, the SQS broker may
+        # consume messages from the queue, terminate before creating the corresponding
+        # Airflow task instance and abandon SQS messages in-flight.
+        if worker_task_monitor:
+            worker_task_monitor.pause_task_consumption()
+            time.sleep(5)
+
+    # Finally, return the worker subprocesses.
+    return [
+            _create_airflow_subprocess(
+                ["celery", "worker"],
+                environ=environ,
+                logger_name=WORKER_LOGGER_NAME,
+                friendly_name="worker",
+                conditions=conditions,
+                on_sigterm=on_sigterm,
+                sigterm_patience_interval=sigterm_patience_interval
+            )
+        ]
+
+
+def _create_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: List):
+    """
+    Get the scheduler subproceses: scheduler, dag-processor, and triggerer.
+
+    :param environ: A dictionary containing the environment variables.
+    :param conditions: A list of subprocess conditions.
+    :returns: Scheduler subprocesses.
+    """
+    return [
+            _create_airflow_subprocess(
+                [airflow_cmd],
+                environ=environ,
+                logger_name=logger_name,
+                friendly_name=friendly_name,
+                conditions=conditions if airflow_cmd == "scheduler" else [],
+            )
+            for airflow_cmd, logger_name, friendly_name in [
+                ("scheduler", SCHEDULER_LOGGER_NAME, "scheduler"),
+                ("dag-processor", DAG_PROCESSOR_LOGGER_NAME, "dag-processor"),
+                ("triggerer", TRIGGERER_LOGGER_NAME, "triggerer"),
+            ]
+        ]
+
+
+def _create_airflow_process_conditions(airflow_cmd: str):
+    """
+    Get conditions for the given Airflow command.
+
+    :param airflow_cmd: The command to get conditions for, e.g. "scheduler"
+    :returns: A list of conditions for the given Airflow command.
+    """
+    conditions: List[ProcessCondition] = [
+        AirflowDbReachableCondition(airflow_component=airflow_cmd),
+    ]
+    if _is_sidecar_health_monitoring_enabled():
+        conditions.append(
+            SidecarHealthCondition(
+                airflow_component=airflow_cmd,
+                container_start_time=CONTAINER_START_TIME,
+                port=_get_sidecar_health_port(),
+            ),
+        )
+    return conditions
+
+
+def _run_airflow_command(cmd: str, environ: Dict[str, str]):
+    """
+    Run the given Airflow command in a subprocess.
+
+    :param cmd - The command to run, e.g. "worker".
+    :param environ: A dictionary containing the environment variables.
+    """
+
+    match cmd:
+        case "scheduler":
+            conditions = _create_airflow_process_conditions('scheduler')
+            subprocesses = _create_airflow_scheduler_subprocesses(environ, conditions)
+            # Schedulers, triggers, and DAG processors are all essential processes and
+            # if any fails, we want to exit the container and let it restart.
+            run_subprocesses(subprocesses)
+        case "worker":
+            run_subprocesses(_create_airflow_worker_subprocesses(environ))
+        case "webserver":
+            run_subprocesses(_create_airflow_webserver_subprocesses(environ))
+        # Hybrid runs the scheduler and celery worker processes is a single container.
+        case "hybrid":
+            # The Sidecar healthcheck is currently limited to one healthcheck per port
+            # so the hybrid container can only include healthchecks for one subprocess.
+            # Only the worker healcheck conditions are enabled to monitor container health, so
+            # we pass an empty list of conditions to the scheduler process and make worker
+            # process essential.
+            scheduler_subprocesses = _create_airflow_scheduler_subprocesses(environ, [])
+
+            # Since both scheduler and workers are launched together as essential
+            # the default patience interval for worker needs to be increased to better
+            # allow for in-flight tasks to complete in case of scheduler failure.
+            try:
+                worker_patience_interval_seconds = os.getenv('MWAA__HYBRID_CONTAINER__SIGTERM_PATIENCE_INTERVAL', None)
+                if worker_patience_interval_seconds is not None:
+                    worker_patience_interval = timedelta(seconds=int(worker_patience_interval_seconds))
+                else:
+                    worker_patience_interval = HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT
+            except (ValueError, TypeError):
+                worker_patience_interval = HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT
+
+            worker_subprocesses = _create_airflow_worker_subprocesses(environ,
+                                                                   sigterm_patience_interval=worker_patience_interval)
+            run_subprocesses(scheduler_subprocesses + worker_subprocesses)
+
+        case _:
+            raise ValueError(f"Unexpected command: {cmd}")
+
+
+def execute_command(command: str, env: Dict[str, str], container_start_time: float):
+    """Execute the specified Airflow command with the given environment configuration.
+
+    This function sets up the container start time and executes the provided Airflow
+    command with the specified environment variables.
+
+    Args:
+        command (str): The Airflow command to execute.
+        env (Dict[str, str]): Dictionary of environment variables to be used.
+        container_start_time (float): The timestamp when the container was started.
+
+    Returns:
+        None
+
+    Global Variables:
+        CONTAINER_START_TIME: Updates the global container start time.
+    """
+    global CONTAINER_START_TIME
+    CONTAINER_START_TIME = container_start_time
+    match command:
+        case "shell":
+            os.execlpe("/bin/bash", "/bin/bash", env)
+        case "spy":
+            while True:
+                time.sleep(1)
+        # Disabling the "resetdb" command for now, as it is pretty risky to have such
+        # a destructive command adjacent to other commands used in production; a simple
+        # code mistake can result in wiping out production databases. Instead, testing
+        # commands like this should be in a completely isolated boundary, with
+        # protection mechanism to ensure they are not accidentally executed in
+        # production.
+        # case "resetdb":
+        #     # Perform the resetdb functionality
+        #     await airflow_db_reset(environ)
+        #     # After resetting the db, initialize it again
+        #     await airflow_db_init(environ)
+        case "scheduler" | "webserver" | "worker" | "hybrid":
+            _run_airflow_command(command, env)
+        case _:
+            raise ValueError(f"Invalid command: {command}")

--- a/images/airflow/2.10.1/python/mwaa/logging/config.py
+++ b/images/airflow/2.10.1/python/mwaa/logging/config.py
@@ -33,10 +33,16 @@ from airflow.config_templates.airflow_local_settings import (
 from mwaa.logging import cloudwatch_handlers
 from mwaa.utils import qualified_name
 
+CONSOLE_LOG_LEVEL = os.environ.get('AIRFLOW_CONSOLE_LOG_LEVEL', 'INFO')
 # We adopt the default logging configuration from Airflow and do the necessary changes
 # to setup logging with CloudWatch Logs.
 LOGGING_CONFIG = {
     **DEFAULT_LOGGING_CONFIG,
+    'root': {
+        'handlers': ['console'],
+        'level': CONSOLE_LOG_LEVEL,
+        'filters': ['mask_secrets'],
+    }
 }
 
 
@@ -183,7 +189,7 @@ def _configure():
             comp,
             log_group_arn=log_group_arn,
             log_stream_name_prefix=comp.lower(),
-            log_level=log_level,
+            log_level="DEBUG",  # Customer Log Level handled at root logger
             logging_enabled=logging_enabled,
         )
         _configure_subprocesses_logging(

--- a/images/airflow/2.10.1/python/mwaa/utils/user_requirements.py
+++ b/images/airflow/2.10.1/python/mwaa/utils/user_requirements.py
@@ -1,0 +1,112 @@
+"""
+User requirements handling module for Amazon MWAA.
+
+This module manages user-defined Python package requirements and their
+installation process in Amazon MWAA environments. It handles requirement
+file parsing, validation, and package installation procedures.
+"""
+# Python imports
+from datetime import timedelta
+import logging
+import os
+import re
+
+# Our imports
+from mwaa.logging.config import MWAA_LOGGERS
+from mwaa.logging.loggers import CompositeLogger
+from mwaa.subprocess.subprocess import Subprocess
+from mwaa.subprocess.conditions import TimeoutCondition
+from mwaa.utils.encoding import auto_decode
+
+MWAA_DOCS_REQUIREMENTS_GUIDE = "https://docs.aws.amazon.com/mwaa/latest/userguide/working-dags-dependencies.html#working-dags-dependencies-test-create"
+
+USER_REQUIREMENTS_MAX_INSTALL_TIME = timedelta(minutes=9)
+
+logger = logging.getLogger("mwaa.entrypoint")
+
+
+def _read_requirements_file(requirements_file: str) -> str:
+    with open(requirements_file, "rb") as f:
+        return auto_decode(f.read())
+
+
+def _requirements_has_constraints(requirements_file: str):
+    content = _read_requirements_file(requirements_file)
+    for line in content.splitlines():
+        # Notice that this regex check will also match lines with commented out
+        # constraints flag. This is intentional as a mechanism for users who want to
+        # avoid enforcing the default Airflow constraints, yet don't want to provide a
+        # constraints file.
+        if re.search(r"-c |--constraint ", line):
+            return True
+    return False
+
+
+async def install_user_requirements(cmd: str, environ: dict[str, str]):
+    """
+    Install user requirements.
+
+    User requirements should be placed in a requirements.txt file and the environment
+    variable `MWAA__CORE__REQUIREMENTS_PATH` should be set to the location of that file.
+    In a Docker Compose setup, you would usually want to create a volume that maps a
+    requirements.txt file in the host machine somewhere in the container, and then set
+    the `MWAA__CORE__REQUIREMENTS_PATH` accordingly.
+
+    :param environ: A dictionary containing the environment variables.
+    """
+    requirements_file = environ.get("MWAA__CORE__REQUIREMENTS_PATH")
+    logger.info(f"MWAA__CORE__REQUIREMENTS_PATH = {requirements_file}")
+    if requirements_file and os.path.isfile(requirements_file):
+        logger.info(f"Installing user requirements from {requirements_file}...")
+        # For hybrid worker/scheduler containers we publish the requirement install logs
+        # to the worker CloudWatch log group.
+        logger_prefix = "worker" if cmd == "hybrid" else cmd;
+        subprocess_logger = CompositeLogger(
+            "requirements_composite_logging",  # name can be anything unused.
+            # We use a set to avoid double logging to console if the user doesn't
+            # use CloudWatch for logging.
+            *set(
+                [
+                    logging.getLogger(MWAA_LOGGERS.get(f"{logger_prefix}_requirements")),
+                    logger,
+                ]
+            ),
+        )
+
+        extra_args = []
+        try:
+            if not _requirements_has_constraints(requirements_file):
+                subprocess_logger.warning(
+                    "WARNING: Constraints should be specified for requirements.txt. "
+                    f"Please see {MWAA_DOCS_REQUIREMENTS_GUIDE}"
+                )
+                subprocess_logger.warning("Forcing local constraints")
+                extra_args = ["-c", os.environ["AIRFLOW_CONSTRAINTS_FILE"]]
+        except Exception as e:
+            subprocess_logger.warning(f"Unable to scan requirements file: {e}")
+            subprocess_logger.warning(
+                "Cannot determine whether the requirements.txt file has constraints "
+                "or not; forcing local constraints."
+            )
+            extra_args = ["-c", os.environ["AIRFLOW_CONSTRAINTS_FILE"]]
+
+        pip_process = Subprocess(
+            cmd=["safe-pip-install", "-r", requirements_file, *extra_args],
+            env=environ,
+            process_logger=subprocess_logger,
+            conditions=[
+                TimeoutCondition(USER_REQUIREMENTS_MAX_INSTALL_TIME),
+            ],
+            friendly_name=f"{logger_prefix}_requirements",
+        )
+        pip_process.start()
+        if pip_process.process and pip_process.process.returncode != 0:
+            subprocess_logger.error(
+                "ERROR: pip installation exited with a non-zero error code. This could "
+                "be the result of package conflict. Notice that MWAA enforces a list "
+                "of critical packages, e.g. Airflow, Celery, among others, whose "
+                "version cannot be overridden by the customer as that can break our "
+                "setup. Please double check your requirements.txt file."
+            )
+    else:
+        logger.info("No user requirements to install.")

--- a/images/airflow/2.10.1/requirements.txt
+++ b/images/airflow/2.10.1/requirements.txt
@@ -25,5 +25,7 @@ pyright
 ruff
 sqlalchemy-stubs
 pytest
+pytest-asyncio
 pytest-cov
+pytest-mock
 diff-cover

--- a/images/airflow/2.10.3/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.10.3/python/mwaa/config/setup_environment.py
@@ -1,0 +1,272 @@
+"""
+Environment configuration module for Amazon MWAA.
+
+This module handles the setup and configuration of environment variables
+and settings required for running Apache Airflow in Amazon MWAA (Managed
+Workflows for Apache Airflow) environments.
+"""
+# Python imports
+from datetime import timedelta
+from typing import Dict
+import json
+import logging
+import os
+import shlex
+import time
+
+# Our imports
+from mwaa.config.airflow import (
+    get_essential_airflow_config,
+    get_opinionated_airflow_config,
+    get_user_airflow_config
+)
+from mwaa.logging.config import MWAA_LOGGERS
+from mwaa.config.environ import get_essential_environ, get_opinionated_environ
+from mwaa.subprocess.subprocess import Subprocess
+from mwaa.subprocess.conditions import TimeoutCondition
+
+
+
+logger = logging.getLogger("mwaa.entrypoint")
+
+STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL = timedelta(seconds=5)
+STARTUP_SCRIPT_MAX_EXECUTION_TIME = (
+    timedelta(minutes=5) - STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL
+)
+
+def _execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]:
+    """
+    Execute user startup script.
+
+    :param cmd - The MWAA command the container is running, e.g. "worker", "scheduler". This is used for logging
+    purposes so the logs of the execution of the startup script get sent to the correct place.
+    :param environ: A dictionary containing the environment variables.
+    """
+    startup_script_path = os.environ.get("MWAA__CORE__STARTUP_SCRIPT_PATH", "")
+    if not startup_script_path:
+        logger.info("MWAA__CORE__STARTUP_SCRIPT_PATH is not provided.")
+        return {}
+
+    EXECUTE_USER_STARTUP_SCRIPT_PATH = "execute-user-startup-script"
+    POST_STARTUP_SCRIPT_VERIFICATION_PATH = "post-startup-script-verification"
+    # For hybrid worker/scheduler containers we publish the startup script logs
+    # to the worker CloudWatch log group.
+    PROCESS_LOGGER_PREFIX = "worker" if cmd == "hybrid" else cmd;
+    PROCESS_LOGGER = logging.getLogger(MWAA_LOGGERS.get(f"{PROCESS_LOGGER_PREFIX}_startup"))
+
+    if os.path.isfile(startup_script_path):
+        logger.info("Executing customer startup script.")
+
+        start_time = time.time()  # Capture start time
+        startup_script_process = Subprocess(
+            cmd=["/bin/bash", EXECUTE_USER_STARTUP_SCRIPT_PATH],
+            env=environ,
+            process_logger=PROCESS_LOGGER,
+            conditions=[
+                TimeoutCondition(STARTUP_SCRIPT_MAX_EXECUTION_TIME),
+            ],
+            friendly_name=f"{PROCESS_LOGGER_PREFIX}_startup",
+            sigterm_patience_interval=STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL,
+        )
+        startup_script_process.start()
+        end_time = time.time()
+        duration = end_time - start_time
+        PROCESS_LOGGER.info(f"Startup script execution time: {duration:.2f} seconds.")
+
+        logger.info("Executing post startup script verification.")
+        verification_process = Subprocess(
+            cmd=["/bin/bash", POST_STARTUP_SCRIPT_VERIFICATION_PATH],
+            env=environ,
+            process_logger=PROCESS_LOGGER,
+            conditions=[
+                TimeoutCondition(STARTUP_SCRIPT_MAX_EXECUTION_TIME),
+            ],
+            friendly_name=f"{PROCESS_LOGGER_PREFIX}_startup",
+        )
+        verification_process.start()
+
+        customer_env_vars_path = "/tmp/customer_env_vars.json"
+        if os.path.isfile(customer_env_vars_path):
+            try:
+                with open(customer_env_vars_path, "r") as f:
+                    customer_env_dict = json.load(f)
+                logger.info("Successfully read the customer's environment variables.")
+                return customer_env_dict
+            except Exception as e:
+                logger.error(f"Error reading the customer's environment variables: {e}")
+                PROCESS_LOGGER.error(
+                    "[ERROR] Failed to load environment variables from startup script. "
+                    "Please verify your startup script configuration."
+                )
+                raise Exception(f"Failed to read customer's environment variables from startup script: {e}")
+
+        else:
+            logger.error(
+                "An unexpected error occurred: the file containing the customer-defined "
+                "environment variables could not be located. If the customer's startup "
+                "script defines environment variables, this error message indicates that "
+                "those variables won't be exported to the Airflow tasks."
+            )
+            PROCESS_LOGGER.error(
+                "[ERROR] An unexpected error occurred: Failed to locate environment variables file from startup script.")
+            raise Exception(
+                "Failed to access customer environment variables file: Service was unable to create or locate /tmp/customer_env_vars.json")
+
+    else:
+        logger.info(f"No startup script found at {startup_script_path}.")
+        return {}
+
+def _export_env_variables(environ: dict[str, str]):
+    """
+    Export the environment variables to .bashrc and .bash_profile.
+
+    For Airflow to function properly, a bunch of environment variables needs to be
+    defined, which we do in the entrypoint. However, during development, a need might
+    arise for bashing into the Docker container and doing some debugging, e.g. running
+    a bunch of Airflow CLI commands. This won't be possible if the necessary environment
+    variables are not defined, which is the case unless we have them defined in the
+    .bashrc/.bash_profile files. This function does exactly that.
+
+    :param environ: A dictionary containing the environment variables to export.
+    """
+    # Get the home directory of the current user
+    home_dir = os.path.expanduser("~")
+    bashrc_path = os.path.join(home_dir, ".bashrc")
+    bash_profile_path = os.path.join(home_dir, ".bash_profile")
+
+    # Environment variables to append
+    env_vars_to_append = [
+        f"export {key}={shlex.quote(value)}\n" for key, value in environ.items()
+    ]
+
+    # Append to .bashrc
+    with open(bashrc_path, "a") as bashrc:
+        bashrc.writelines(env_vars_to_append)
+
+    # Append to .bash_profile
+    with open(bash_profile_path, "a") as bash_profile:
+        bash_profile.writelines(env_vars_to_append)
+
+def _is_protected_os_environ(key: str) -> bool:
+    # Protected environment variables
+    protected_vars = [
+        # Environment ID and name are set by MWAA for
+        # informational purposes, and shouldn't be overridden by the customer.
+        "AIRFLOW_ENV_ID",
+        "AIRFLOW_ENV_NAME",
+        # Airflow home directory cannot be overridden
+        # as this will break MWAA setup.
+        "AIRFLOW_HOME",
+        # This is an internal MWAA identifier and
+        # shouldn't be modified by users.
+        "AIRFLOW_TASK_REVISION_ID",
+        # Airflow version is managed by MWAA and
+        # shouldn't be overridden manually.
+        "AIRFLOW_VERSION",
+        # The following two are needed by the IAM
+        # plugin and shouldn't be overridden.
+        "AIRFLOW__AWS_MWAA__REDIRECT_URL",
+        "JWT_PUBLIC_KEY",
+        # This is set to match the endpoint created
+        # by MWAA and shouldn't be overridden.
+        "AIRFLOW__WEBSERVER__BASE_URL",
+        # Default AWS region set by MWAA and used for AWS services.
+        "AWS_DEFAULT_REGION",
+        # AWS_REGION has a broader scope that is used by not just MWAA but
+        # by the AWS SDK in general if the default region is not set.
+        "AWS_REGION",
+        # This identifies the customer account associated
+        # with the MWAA environment.
+        "CUSTOMER_ACCOUNT_ID",
+        # These following are set by or needed for Fargate and
+        # shouldn't be modified by the user.
+        "ECS_AGENT_URI",
+        "ECS_CONTAINER_METADATA_URI",
+        "ECS_CONTAINER_METADATA_URI_V4",
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        "AWS_EXECUTION_ENV",
+        # We don't allow the customer to override the PYTHONPATH, as this can break our
+        # Python setup easily.
+        "PYTHONPATH",
+        # We disable Python buffering as we want to make
+        # sure all print statements are sent to us immediately
+        # so we can control when to send them to CloudWatch Logs.
+        "PYTHONUNBUFFERED",
+        # This is used to validate the version of Watchtower installed
+        # which we don't allow the customer to override.
+        "WATCHTOWER_VERSION",
+    ]
+
+    # Check whether this is an MWAA configuration or a protected variable
+    return key.startswith("MWAA__") or key in protected_vars
+
+def setup_environment_variables(command: str, executor_type: str) -> Dict:
+    """Set up and return environment variables for Airflow execution.
+
+            Configures the necessary environment variables based on the provided command
+            and executor type for running Airflow tasks.
+
+            Args:
+                command (str): The Airflow command to be executed.
+                executor_type (str): The type of executor to be used (e.g., 'Local', 'Celery').
+
+            Returns:
+                Dict: A dictionary containing all configured environment variables
+                      required for the Airflow execution.
+    """
+    # Add the necessary environment variables.
+    mwaa_essential_airflow_config = get_essential_airflow_config(executor_type)
+    mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
+    mwaa_essential_airflow_environ = get_essential_environ(command)
+    mwaa_opinionated_airflow_environ = get_opinionated_environ()
+    user_airflow_config = get_user_airflow_config()
+
+
+    startup_script_environ = _execute_startup_script(
+        command,
+        {
+            **os.environ,
+            **mwaa_opinionated_airflow_config,
+            **mwaa_opinionated_airflow_environ,
+            **user_airflow_config,
+            **mwaa_essential_airflow_environ,
+            **mwaa_essential_airflow_config,
+        },
+    )
+    environ = {
+        **os.environ,
+        # Custom configuration and environment variables that we think are good, but
+        # allow the user to override.
+        **mwaa_opinionated_airflow_config,
+        **mwaa_opinionated_airflow_environ,
+        # What the user defined in the startup script.
+        **startup_script_environ,
+        # What the user passed via Airflow config secrets (specified by the
+        # MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS environment variable.)
+        **user_airflow_config,
+        # The MWAA__x__y environment variables that are passed to the container are
+        # considered protected environment variables that cannot be overridden at
+        # runtime to avoid breaking the functionality of the container.
+        **{
+            key: value
+            for (key, value) in os.environ.items()
+            if _is_protected_os_environ(key)
+        },
+        # Essential variables that our setup will not function properly without, hence
+        # it always has the highest priority.
+        **mwaa_essential_airflow_config,
+        **mwaa_essential_airflow_environ,
+    }
+
+    # IMPORTANT NOTE: The level for this should stay "DEBUG" to avoid logging customer
+    # custom environment variables, which potentially contains sensitive credentials,
+    # to stdout which, in this case of Fargate hosting (like in Amazon MWAA), ends up
+    # being captured and sent to the service hosting.
+    logger.debug(f"Environment variables: %s", environ)
+
+    # Export the environment variables to .bashrc and .bash_profile to enable
+    # users to run a shell on the container and have the necessary environment
+    # variables set for using airflow CLI.
+    _export_env_variables(environ)
+
+    return environ

--- a/images/airflow/2.10.3/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.3/python/mwaa/entrypoint.py
@@ -12,28 +12,15 @@ after setting up the necessary configurations.
 # is setup, its `logger` object will not have the right setup.
 # ruff: noqa: E402
 # fmt: off
+from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 import logging.config
-from mwaa.logging.config import (
-    DAG_PROCESSOR_LOGGER_NAME,
-    LOGGING_CONFIG,
-    SCHEDULER_LOGGER_NAME,
-    TRIGGERER_LOGGER_NAME,
-    WEBSERVER_LOGGER_NAME,
-    WORKER_LOGGER_NAME,
-)
-logging.config.dictConfig(LOGGING_CONFIG)
+logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
 # fmt: on
 
 # Python imports
-from datetime import timedelta
-from functools import cache
-from typing import Callable, Dict, List, Optional
 import asyncio
-import json
 import logging
 import os
-import re
-import shlex
 import sys
 import time
 
@@ -42,38 +29,46 @@ import boto3
 from botocore.exceptions import ClientError
 
 # Our imports
-from mwaa.celery.task_monitor import WorkerTaskMonitor
-from mwaa.config.airflow import (
-    get_essential_airflow_config,
-    get_opinionated_airflow_config,
-    get_user_airflow_config,
-)
-from mwaa.config.environ import get_essential_environ, get_opinionated_environ
+from mwaa.execute_command import execute_command
+from mwaa.config.setup_environment import setup_environment_variables
 from mwaa.config.sqs import (
     get_sqs_queue_name,
     should_create_queue,
 )
-from mwaa.logging.config import MWAA_LOGGERS
-from mwaa.logging.loggers import CompositeLogger
-from mwaa.subprocess.conditions import (
-    SIDECAR_DEFAULT_HEALTH_PORT,
-    AirflowDbReachableCondition,
-    TaskMonitoringCondition,
-    ProcessCondition,
-    SidecarHealthCondition,
-    TimeoutCondition,
-)
-from mwaa.subprocess.subprocess import Subprocess, run_subprocesses
 from mwaa.utils.cmd import run_command
 from mwaa.utils.dblock import with_db_lock
-from mwaa.utils.encoding import auto_decode
-
+from mwaa.utils.user_requirements import install_user_requirements
 
 # Usually, we pass the `__name__` variable instead as that defaults to the
 # module path, i.e. `mwaa.entrypoint` in this case. However, since this is
 # the entrypoint script, `__name__` will have the value of `__main__`, hence
 # we hard-code the module path.
 logger = logging.getLogger("mwaa.entrypoint")
+
+
+def _setup_console_log_level(command: str):
+    # Set up console log level environment variable based on command
+    component_mapping = {
+        'scheduler': 'MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL',
+        'worker': 'MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL',
+        'webserver': 'MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_LEVEL'
+    }
+
+    if command in component_mapping:
+        source_var = component_mapping[command]
+        os.environ['AIRFLOW_CONSOLE_LOG_LEVEL'] = os.environ[source_var]
+    else:
+        os.environ['AIRFLOW_CONSOLE_LOG_LEVEL'] = 'INFO'
+
+
+def _configure_root_logger(command: str):
+    _setup_console_log_level(command)
+    # Doing a local import because we can't import
+    # LOGGING_CONFIG before setting AIRFLOW_CONSOLE_LOG_LEVEL
+    # as it will lead to root logger's log level set to default value
+    from mwaa.logging.config import LOGGING_CONFIG
+    logging.config.dictConfig(LOGGING_CONFIG)
+
 
 # TODO Fix the "type: ignore"s in this file.
 
@@ -88,22 +83,11 @@ AVAILABLE_COMMANDS = [
     "test-requirements",
     "test-startup-script",
 ]
-MWAA_DOCS_REQUIREMENTS_GUIDE = "https://docs.aws.amazon.com/mwaa/latest/userguide/working-dags-dependencies.html#working-dags-dependencies-test-create"
-STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL = timedelta(seconds=5)
-STARTUP_SCRIPT_MAX_EXECUTION_TIME = (
-    timedelta(minutes=5) - STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL
-)
-USER_REQUIREMENTS_MAX_INSTALL_TIME = timedelta(minutes=9)
 
 # Save the start time of the container. This is used later to with the sidecar
 # monitoring because we need to have a grace period before we start reporting timeouts
 # related to sidecar endpoint not reporting health messages.
 CONTAINER_START_TIME = time.time()
-
-# Hybrid container runs both scheduler and worker as essential subprocesses.
-# Therefore the default worker patience is increased to mitigate task
-# failures due to scheduler failure.
-HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT = timedelta(seconds=130)
 
 
 async def airflow_db_init(environ: dict[str, str]):
@@ -117,20 +101,6 @@ async def airflow_db_init(environ: dict[str, str]):
     :param environ: A dictionary containing the environment variables.
     """
     await run_command("python3 -m mwaa.database.migrate", env=environ)
-
-
-@with_db_lock(4321)
-async def airflow_db_reset(environ: dict[str, str]):
-    """
-    Reset Airflow metadata database.
-
-    This function resets the Airflow metadata database. It is called when the `resetdb`
-    command is specified.
-
-    :param environ: A dictionary containing the environment variables.
-    """
-    logger.info("Resetting Airflow metadata database.")
-    await run_command("airflow db reset --yes", env=environ)
 
 
 @with_db_lock(5678)
@@ -192,487 +162,6 @@ def create_queue() -> None:
             raise e
 
 
-def _read_requirements_file(requirements_file: str) -> str:
-    with open(requirements_file, "rb") as f:
-        return auto_decode(f.read())
-
-
-def _requirements_has_constraints(requirements_file: str):
-    content = _read_requirements_file(requirements_file)
-    for line in content.splitlines():
-        # Notice that this regex check will also match lines with commented out
-        # constraints flag. This is intentional as a mechanism for users who want to
-        # avoid enforcing the default Airflow constraints, yet don't want to provide a
-        # constraints file.
-        if re.search(r"-c |--constraint ", line):
-            return True
-    return False
-
-
-async def install_user_requirements(cmd: str, environ: dict[str, str]):
-    """
-    Install user requirements.
-
-    User requirements should be placed in a requirements.txt file and the environment
-    variable `MWAA__CORE__REQUIREMENTS_PATH` should be set to the location of that file.
-    In a Docker Compose setup, you would usually want to create a volume that maps a
-    requirements.txt file in the host machine somewhere in the container, and then set
-    the `MWAA__CORE__REQUIREMENTS_PATH` accordingly.
-
-    :param environ: A dictionary containing the environment variables.
-    """
-    requirements_file = environ.get("MWAA__CORE__REQUIREMENTS_PATH")
-    logger.info(f"MWAA__CORE__REQUIREMENTS_PATH = {requirements_file}")
-    if requirements_file and os.path.isfile(requirements_file):
-        logger.info(f"Installing user requirements from {requirements_file}...")
-        # For hybrid worker/scheduler containers we publish the requirement install logs
-        # to the worker CloudWatch log group.
-        logger_prefix = "worker" if cmd == "hybrid" else cmd;
-        subprocess_logger = CompositeLogger(
-            "requirements_composite_logging",  # name can be anything unused.
-            # We use a set to avoid double logging to console if the user doesn't
-            # use CloudWatch for logging.
-            *set(
-                [
-                    logging.getLogger(MWAA_LOGGERS.get(f"{logger_prefix}_requirements")),
-                    logger,
-                ]
-            ),
-        )
-
-        extra_args = []
-        try:
-            if not _requirements_has_constraints(requirements_file):
-                subprocess_logger.warning(
-                    "WARNING: Constraints should be specified for requirements.txt. "
-                    f"Please see {MWAA_DOCS_REQUIREMENTS_GUIDE}"
-                )
-                subprocess_logger.warning("Forcing local constraints")
-                extra_args = ["-c", os.environ["AIRFLOW_CONSTRAINTS_FILE"]]
-        except Exception as e:
-            subprocess_logger.warning(f"Unable to scan requirements file: {e}")
-            subprocess_logger.warning(
-                "Cannot determine whether the requirements.txt file has constraints "
-                "or not; forcing local constraints."
-            )
-            extra_args = ["-c", os.environ["AIRFLOW_CONSTRAINTS_FILE"]]
-
-        pip_process = Subprocess(
-            cmd=["safe-pip-install", "-r", requirements_file, *extra_args],
-            env=environ,
-            process_logger=subprocess_logger,
-            conditions=[
-                TimeoutCondition(USER_REQUIREMENTS_MAX_INSTALL_TIME),
-            ],
-            friendly_name=f"{logger_prefix}_requirements",
-        )
-        pip_process.start()
-        if pip_process.process and pip_process.process.returncode != 0:
-            subprocess_logger.error(
-                "ERROR: pip installation exited with a non-zero error code. This could "
-                "be the result of package conflict. Notice that MWAA enforces a list "
-                "of critical packages, e.g. Airflow, Celery, among others, whose "
-                "version cannot be overridden by the customer as that can break our "
-                "setup. Please double check your requirements.txt file."
-            )
-    else:
-        logger.info("No user requirements to install.")
-
-
-def execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]:
-    """
-    Execute user startup script.
-
-    :param cmd - The MWAA command the container is running, e.g. "worker", "scheduler". This is used for logging
-    purposes so the logs of the execution of the startup script get sent to the correct place.
-    :param environ: A dictionary containing the environment variables.
-    """
-    startup_script_path = os.environ.get("MWAA__CORE__STARTUP_SCRIPT_PATH", "")
-    if not startup_script_path:
-        logger.info("MWAA__CORE__STARTUP_SCRIPT_PATH is not provided.")
-        return {}
-
-    EXECUTE_USER_STARTUP_SCRIPT_PATH = "execute-user-startup-script"
-    POST_STARTUP_SCRIPT_VERIFICATION_PATH = "post-startup-script-verification"
-    # For hybrid worker/scheduler containers we publish the startup script logs
-    # to the worker CloudWatch log group.
-    PROCESS_LOGGER_PREFIX = "worker" if cmd == "hybrid" else cmd;
-    PROCESS_LOGGER = logging.getLogger(MWAA_LOGGERS.get(f"{PROCESS_LOGGER_PREFIX}_startup"))
-
-    if os.path.isfile(startup_script_path):
-        logger.info("Executing customer startup script.")
-
-        start_time = time.time()  # Capture start time
-        startup_script_process = Subprocess(
-            cmd=["/bin/bash", EXECUTE_USER_STARTUP_SCRIPT_PATH],
-            env=environ,
-            process_logger=PROCESS_LOGGER,
-            conditions=[
-                TimeoutCondition(STARTUP_SCRIPT_MAX_EXECUTION_TIME),
-            ],
-            friendly_name=f"{PROCESS_LOGGER_PREFIX}_startup",
-            sigterm_patience_interval=STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL,
-        )
-        startup_script_process.start()
-        end_time = time.time()
-        duration = end_time - start_time
-        PROCESS_LOGGER.info(f"Startup script execution time: {duration:.2f} seconds.")
-
-        logger.info("Executing post startup script verification.")
-        verification_process = Subprocess(
-            cmd=["/bin/bash", POST_STARTUP_SCRIPT_VERIFICATION_PATH],
-            env=environ,
-            process_logger=PROCESS_LOGGER,
-            conditions=[
-                TimeoutCondition(STARTUP_SCRIPT_MAX_EXECUTION_TIME),
-            ],
-            friendly_name=f"{PROCESS_LOGGER_PREFIX}_startup",
-        )
-        verification_process.start()
-
-        customer_env_vars_path = "/tmp/customer_env_vars.json"
-        if os.path.isfile(customer_env_vars_path):
-            try:
-                with open(customer_env_vars_path, "r") as f:
-                    customer_env_dict = json.load(f)
-                logger.info("Successfully read the customer's environment variables.")
-                return customer_env_dict
-            except Exception as e:
-                logger.error(f"Error reading the customer's environment variables: {e}")
-                PROCESS_LOGGER.error(
-                    "[ERROR] Failed to load environment variables from startup script. "
-                    "Please verify your startup script configuration."
-                )
-                raise Exception(f"Failed to read customer's environment variables from startup script: {e}")
-
-        else:
-            logger.error(
-                "An unexpected error occurred: the file containing the customer-defined "
-                "environment variables could not be located. If the customer's startup "
-                "script defines environment variables, this error message indicates that "
-                "those variables won't be exported to the Airflow tasks."
-            )
-            PROCESS_LOGGER.error("[ERROR] An unexpected error occurred: Failed to locate environment variables file from startup script.")
-            raise Exception("Failed to access customer environment variables file: Service was unable to create or locate /tmp/customer_env_vars.json")
-
-    else:
-        logger.info(f"No startup script found at {startup_script_path}.")
-        return {}
-
-
-def export_env_variables(environ: dict[str, str]):
-    """
-    Export the environment variables to .bashrc and .bash_profile.
-
-    For Airflow to function properly, a bunch of environment variables needs to be
-    defined, which we do in the entrypoint. However, during development, a need might
-    arise for bashing into the Docker container and doing some debugging, e.g. running
-    a bunch of Airflow CLI commands. This won't be possible if the necessary environment
-    variables are not defined, which is the case unless we have them defined in the
-    .bashrc/.bash_profile files. This function does exactly that.
-
-    :param environ: A dictionary containing the environment variables to export.
-    """
-    # Get the home directory of the current user
-    home_dir = os.path.expanduser("~")
-    bashrc_path = os.path.join(home_dir, ".bashrc")
-    bash_profile_path = os.path.join(home_dir, ".bash_profile")
-
-    # Environment variables to append
-    env_vars_to_append = [
-        f"export {key}={shlex.quote(value)}\n" for key, value in environ.items()
-    ]
-
-    # Append to .bashrc
-    with open(bashrc_path, "a") as bashrc:
-        bashrc.writelines(env_vars_to_append)
-
-    # Append to .bash_profile
-    with open(bash_profile_path, "a") as bash_profile:
-        bash_profile.writelines(env_vars_to_append)
-
-
-def create_airflow_subprocess(
-    args: List[str],
-    environ: Dict[str, str],
-    logger_name: str,
-    friendly_name: str,
-    conditions: List[ProcessCondition] = [],
-    on_sigterm: Optional[Callable[[], None]] = None,
-    sigterm_patience_interval: timedelta | None = None
-):
-    """
-    Create a subprocess for an Airflow command.
-
-    Notice that while this function creates the sub-process, it will not start it.
-    So, the caller is responsible for starting it.
-
-    :param args - The arguments to pass to the Airflow CLI.
-    :param environ - A dictionary containing the environment variables.
-    :param logger_name - The name of the logger to use for capturing the generated logs.
-
-    :returns The created subprocess.
-    """
-    logger: logging.Logger = logging.getLogger(logger_name)
-    kwargs = {
-            "cmd": ["airflow", *args],
-            "env": environ,
-            "process_logger": logger,
-            "friendly_name": friendly_name,
-            "conditions": conditions,
-            "on_sigterm": on_sigterm,
-            "is_essential": True
-    }
-    if sigterm_patience_interval is not None:
-        kwargs['sigterm_patience_interval'] = sigterm_patience_interval
-    return Subprocess(
-        **kwargs
-    )
-
-
-def _is_protected_os_environ(key: str) -> bool:
-    # Protected environment variables
-    protected_vars = [
-        # Environment ID and name are set by MWAA for
-        # informational purposes, and shouldn't be overridden by the customer.
-        "AIRFLOW_ENV_ID",
-        "AIRFLOW_ENV_NAME",
-        # Airflow home directory cannot be overridden
-        # as this will break MWAA setup.
-        "AIRFLOW_HOME",
-        # This is an internal MWAA identifier and
-        # shouldn't be modified by users.
-        "AIRFLOW_TASK_REVISION_ID",
-        # Airflow version is managed by MWAA and
-        # shouldn't be overridden manually.
-        "AIRFLOW_VERSION",
-        # The following two are needed by the IAM
-        # plugin and shouldn't be overridden.
-        "AIRFLOW__AWS_MWAA__REDIRECT_URL",
-        "JWT_PUBLIC_KEY",
-        # This is set to match the endpoint created
-        # by MWAA and shouldn't be overridden.
-        "AIRFLOW__WEBSERVER__BASE_URL",
-        # Default AWS region set by MWAA and used for AWS services.
-        "AWS_DEFAULT_REGION",
-        # AWS_REGION has a broader scope that is used by not just MWAA but
-        # by the AWS SDK in general if the default region is not set.
-        "AWS_REGION",
-        # This identifies the customer account associated
-        # with the MWAA environment.
-        "CUSTOMER_ACCOUNT_ID",
-        # These following are set by or needed for Fargate and
-        # shouldn't be modified by the user.
-        "ECS_AGENT_URI",
-        "ECS_CONTAINER_METADATA_URI",
-        "ECS_CONTAINER_METADATA_URI_V4",
-        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
-        "AWS_EXECUTION_ENV",
-        # We don't allow the customer to override the PYTHONPATH, as this can break our
-        # Python setup easily.
-        "PYTHONPATH",
-        # We disable Python buffering as we want to make
-        # sure all print statements are sent to us immediately
-        # so we can control when to send them to CloudWatch Logs.
-        "PYTHONUNBUFFERED",
-        # This is used to validate the version of Watchtower installed
-        # which we don't allow the customer to override.
-        "WATCHTOWER_VERSION",
-    ]
-
-    # Check whether this is an MWAA configuration or a protected variable
-    return key.startswith("MWAA__") or key in protected_vars
-
-
-@cache
-def _is_sidecar_health_monitoring_enabled():
-    enabled = (
-        os.environ.get(
-            "MWAA__HEALTH_MONITORING__ENABLE_SIDECAR_HEALTH_MONITORING", "false"
-        ).lower()
-        == "true"
-    )
-    if enabled:
-        logger.info("Sidecar health monitoring is enabled.")
-    else:
-        logger.info("Sidecar health monitoring is NOT enabled.")
-    return enabled
-
-
-def _get_sidecar_health_port():
-    try:
-        return int(
-            os.environ.get(
-                "MWAA__HEALTH_MONITORING__SIDECAR_HEALTH_PORT",
-                SIDECAR_DEFAULT_HEALTH_PORT,
-            )
-        )
-    except:
-        return SIDECAR_DEFAULT_HEALTH_PORT
-
-
-def _create_airflow_webserver_subprocesses(environ: Dict[str, str]):
-    return [
-        create_airflow_subprocess(
-            ["webserver"],
-            environ=environ,
-            logger_name=WEBSERVER_LOGGER_NAME,
-            friendly_name="webserver",
-            conditions=[
-                AirflowDbReachableCondition(airflow_component="webserver"),
-            ],
-        ),
-    ]
-
-
-def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patience_interval: timedelta | None = None):
-    conditions = _create_airflow_process_conditions('worker')
-    # MWAA__CORE__TASK_MONITORING_ENABLED is set to 'true' for workers where we want to monitor count of tasks currently getting
-    # executed on the worker. This will be used to determine if idle worker checks are to be enabled.
-    task_monitoring_enabled = (
-        os.environ.get("MWAA__CORE__TASK_MONITORING_ENABLED", "false").lower() == "true"
-    )
-    # If MWAA__CORE__TERMINATE_IF_IDLE is set to 'true', then as part of the task monitoring if the task count reaches zero, then the
-    # worker will be terminated.
-    terminate_if_idle = (
-        os.environ.get("MWAA__CORE__TERMINATE_IF_IDLE", "false").lower() == "true" and task_monitoring_enabled
-    )
-    # If MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED is set to 'true', then as part of the task monitoring, the monitor will expect certain
-    # signals to be sent from MWAA. These signals will represent MWAA service side events such as start of an environment update.
-    mwaa_signal_handling_enabled = (
-        os.environ.get("MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED", "false").lower() == "true" and task_monitoring_enabled
-    )
-
-    mwaa_worker_idleness_verification_interval = int(environ.get("MWAA__CORE__WORKER_IDLENESS_VERIFICATION_INTERVAL",
-                                                               "20"))
-
-    if task_monitoring_enabled:
-        logger.info(f"Worker task monitoring is enabled with idleness verification interval: "
-                    f"{mwaa_worker_idleness_verification_interval}")
-        # Initializing the monitor responsible for performing idle worker checks if enabled.
-        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled, mwaa_worker_idleness_verification_interval)
-    else:
-        logger.info("Worker task monitoring is NOT enabled.")
-        worker_task_monitor = None
-
-    if worker_task_monitor:
-        conditions.append(TaskMonitoringCondition(worker_task_monitor, terminate_if_idle))
-
-    def on_sigterm() -> None:
-        # When a SIGTERM is caught, we pause the Airflow Task consumption and wait 5 seconds in order
-        # for any in-flight messages in the SQS broker layer to be processed and
-        # corresponding Airflow task instance to be created. Once that is done, we can
-        # start gracefully shutting down the worker. Without this, the SQS broker may
-        # consume messages from the queue, terminate before creating the corresponding
-        # Airflow task instance and abandon SQS messages in-flight.
-        if worker_task_monitor:
-            worker_task_monitor.pause_task_consumption()
-            time.sleep(5)
-
-    # Finally, return the worker subprocesses.
-    return [
-            create_airflow_subprocess(
-                ["celery", "worker"],
-                environ=environ,
-                logger_name=WORKER_LOGGER_NAME,
-                friendly_name="worker",
-                conditions=conditions,
-                on_sigterm=on_sigterm,
-                sigterm_patience_interval=sigterm_patience_interval
-            )
-        ]
-
-
-def _create_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: List):
-    """
-    Get the scheduler subproceses: scheduler, dag-processor, and triggerer.
-
-    :param environ: A dictionary containing the environment variables.
-    :param conditions: A list of subprocess conditions.
-    :returns: Scheduler subprocesses.
-    """
-    return [
-            create_airflow_subprocess(
-                [airflow_cmd],
-                environ=environ,
-                logger_name=logger_name,
-                friendly_name=friendly_name,
-                conditions=conditions if airflow_cmd == "scheduler" else [],
-            )
-            for airflow_cmd, logger_name, friendly_name in [
-                ("scheduler", SCHEDULER_LOGGER_NAME, "scheduler"),
-                ("dag-processor", DAG_PROCESSOR_LOGGER_NAME, "dag-processor"),
-                ("triggerer", TRIGGERER_LOGGER_NAME, "triggerer"),
-            ]
-        ]
-
-
-def _create_airflow_process_conditions(airflow_cmd: str):
-    """
-    Get conditions for the given Airflow command.
-
-    :param airflow_cmd: The command to get conditions for, e.g. "scheduler"
-    :returns: A list of conditions for the given Airflow command.
-    """
-    conditions: List[ProcessCondition] = [
-        AirflowDbReachableCondition(airflow_component=airflow_cmd),
-    ]
-    if _is_sidecar_health_monitoring_enabled():
-        conditions.append(
-            SidecarHealthCondition(
-                airflow_component=airflow_cmd,
-                container_start_time=CONTAINER_START_TIME,
-                port=_get_sidecar_health_port(),
-            ),
-        )
-    return conditions
-def run_airflow_command(cmd: str, environ: Dict[str, str]):
-    """
-    Run the given Airflow command in a subprocess.
-
-    :param cmd - The command to run, e.g. "worker".
-    :param environ: A dictionary containing the environment variables.
-    """
-    match cmd:
-        case "scheduler":
-            conditions = _create_airflow_process_conditions('scheduler')
-            subprocesses = _create_airflow_scheduler_subprocesses(environ, conditions)
-            # Schedulers, triggers, and DAG processors are all essential processes and
-            # if any fails, we want to exit the container and let it restart.
-            run_subprocesses(subprocesses)
-        case "worker":
-            run_subprocesses(_create_airflow_worker_subprocesses(environ))
-        case "webserver":
-            run_subprocesses(_create_airflow_webserver_subprocesses(environ))
-        # Hybrid runs the scheduler and celery worker processes is a single container.
-        case "hybrid":
-            # The Sidecar healthcheck is currently limited to one healthcheck per port
-            # so the hybrid container can only include healthchecks for one subprocess.
-            # Only the worker healcheck conditions are enabled to monitor container health, so
-            # we pass an empty list of conditions to the scheduler process and make worker
-            # process essential.
-            scheduler_subprocesses = _create_airflow_scheduler_subprocesses(environ, [])
-
-            # Since both scheduler and workers are launched together as essential
-            # the default patience interval for worker needs to be increased to better
-            # allow for in-flight tasks to complete in case of scheduler failure.
-            try:
-                worker_patience_interval_seconds = os.getenv('MWAA__HYBRID_CONTAINER__SIGTERM_PATIENCE_INTERVAL', None)
-                if worker_patience_interval_seconds is not None:
-                    worker_patience_interval = timedelta(seconds=int(worker_patience_interval_seconds))
-                else:
-                    worker_patience_interval = HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT
-            except (ValueError, TypeError):
-                worker_patience_interval = HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT
-
-            worker_subprocesses = _create_airflow_worker_subprocesses(environ,
-                                                                   sigterm_patience_interval=worker_patience_interval)
-            run_subprocesses(scheduler_subprocesses + worker_subprocesses)
-
-        case _:
-            raise ValueError(f"Unexpected command: {cmd}")
-
-
 async def main() -> None:
     """Start execution of the script."""
     try:
@@ -690,65 +179,12 @@ async def main() -> None:
             f"Invalid arguments: {sys.argv}. Please provide one argument with one of"
             f'the values: {", ".join(AVAILABLE_COMMANDS)}. Error was {e}.'
         )
-
+    _configure_root_logger(command)
     logger.info(f"Warming a Docker container for an Airflow {command}.")
 
     # Get executor type
     executor_type = os.environ.get("MWAA__CORE__EXECUTOR_TYPE", "CeleryExecutor")
-
-    # Add the necessary environment variables.
-    mwaa_essential_airflow_config = get_essential_airflow_config(executor_type)
-    mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
-    mwaa_essential_airflow_environ = get_essential_environ(command)
-    mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = get_user_airflow_config()
-
-    startup_script_environ = execute_startup_script(
-        command,
-        {
-            **os.environ,
-            **mwaa_opinionated_airflow_config,
-            **mwaa_opinionated_airflow_environ,
-            **user_airflow_config,
-            **mwaa_essential_airflow_environ,
-            **mwaa_essential_airflow_config,
-        },
-    )
-
-    if command == "test-startup-script":
-        print("Finished testing startup script")
-        return
-
-    environ = {
-        **os.environ,
-        # Custom configuration and environment variables that we think are good, but
-        # allow the user to override.
-        **mwaa_opinionated_airflow_config,
-        **mwaa_opinionated_airflow_environ,
-        # What the user defined in the startup script.
-        **startup_script_environ,
-        # What the user passed via Airflow config secrets (specified by the
-        # MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS environment variable.)
-        **user_airflow_config,
-        # The MWAA__x__y environment variables that are passed to the container are
-        # considered protected environment variables that cannot be overridden at
-        # runtime to avoid breaking the functionality of the container.
-        **{
-            key: value
-            for (key, value) in os.environ.items()
-            if _is_protected_os_environ(key)
-        },
-        # Essential variables that our setup will not function properly without, hence
-        # it always has the highest priority.
-        **mwaa_essential_airflow_config,
-        **mwaa_essential_airflow_environ,
-    }
-
-    # IMPORTANT NOTE: The level for this should stay "DEBUG" to avoid logging customer
-    # custom environment variables, which potentially contains sensitive credentials,
-    # to stdout which, in this case of Fargate hosting (like in Amazon MWAA), ends up
-    # being captured and sent to the service hosting.
-    logger.debug(f"Environment variables: %s", environ)
+    environ = setup_environment_variables(command, executor_type)
 
     await install_user_requirements(command, environ)
 
@@ -766,32 +202,7 @@ async def main() -> None:
     if executor_type.lower() == "celeryexecutor":
         create_queue()
 
-    # Export the environment variables to .bashrc and .bash_profile to enable
-    # users to run a shell on the container and have the necessary environment
-    # variables set for using airflow CLI.
-    export_env_variables(environ)
-
-    match command:
-        case "shell":
-            os.execlpe("/bin/bash", "/bin/bash", environ)
-        case "spy":
-            while True:
-                time.sleep(1)
-        # Disabling the "resetdb" command for now, as it is pretty risky to have such
-        # a destructive command adjacent to other commands used in production; a simple
-        # code mistake can result in wiping out production databases. Instead, testing
-        # commands like this should be in a completely isolated boundary, with
-        # protection mechanism to ensure they are not accidentally executed in
-        # production.
-        # case "resetdb":
-        #     # Perform the resetdb functionality
-        #     await airflow_db_reset(environ)
-        #     # After resetting the db, initialize it again
-        #     await airflow_db_init(environ)
-        case "scheduler" | "webserver" | "worker" | "hybrid":
-            run_airflow_command(command, environ)
-        case _:
-            raise ValueError(f"Invalid command: {command}")
+    execute_command(command, environ, CONTAINER_START_TIME)
 
 
 if __name__ == "__main__":

--- a/images/airflow/2.10.3/python/mwaa/execute_command.py
+++ b/images/airflow/2.10.3/python/mwaa/execute_command.py
@@ -1,0 +1,331 @@
+"""
+Command execution module for Amazon MWAA environments.
+
+This module provides functionality to execute Airflow commands with proper
+environment configuration and timing management. It handles various Airflow
+commands including scheduler, webserver, worker, and hybrid modes within
+the MWAA execution environment.
+"""
+# Python imports
+from datetime import timedelta
+from functools import cache
+from typing import List, Dict, Optional, Callable
+import logging
+import os
+import time
+
+# Our imports
+from mwaa.celery.task_monitor import WorkerTaskMonitor
+from mwaa.logging.config import (
+    DAG_PROCESSOR_LOGGER_NAME,
+    LOGGING_CONFIG,
+    SCHEDULER_LOGGER_NAME,
+    TRIGGERER_LOGGER_NAME,
+    WEBSERVER_LOGGER_NAME,
+    WORKER_LOGGER_NAME,
+)
+from mwaa.subprocess.conditions import (
+    SIDECAR_DEFAULT_HEALTH_PORT,
+    AirflowDbReachableCondition,
+    TaskMonitoringCondition,
+    ProcessCondition,
+    SidecarHealthCondition,
+    TimeoutCondition,
+)
+from mwaa.subprocess.subprocess import Subprocess, run_subprocesses
+from mwaa.utils.cmd import run_command
+from mwaa.utils.dblock import with_db_lock
+
+
+logger = logging.getLogger("mwaa.entrypoint")
+
+
+# Hybrid container runs both scheduler and worker as essential subprocesses.
+# Therefore the default worker patience is increased to mitigate task
+# failures due to scheduler failure.
+HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT = timedelta(seconds=130)
+
+@with_db_lock(4321)
+async def airflow_db_reset(environ: dict[str, str]):
+    """
+    Reset Airflow metadata database.
+
+    This function resets the Airflow metadata database. It is called when the `resetdb`
+    command is specified.
+
+    :param environ: A dictionary containing the environment variables.
+    """
+    logger.info("Resetting Airflow metadata database.")
+    await run_command("airflow db reset --yes", env=environ)
+
+def _create_airflow_subprocess(
+    args: List[str],
+    environ: Dict[str, str],
+    logger_name: str,
+    friendly_name: str,
+    conditions: List[ProcessCondition] = [],
+    on_sigterm: Optional[Callable[[], None]] = None,
+    sigterm_patience_interval: timedelta | None = None
+):
+    """
+    Create a subprocess for an Airflow command.
+
+    Notice that while this function creates the sub-process, it will not start it.
+    So, the caller is responsible for starting it.
+
+    :param args - The arguments to pass to the Airflow CLI.
+    :param environ - A dictionary containing the environment variables.
+    :param logger_name - The name of the logger to use for capturing the generated logs.
+
+    :returns The created subprocess.
+    """
+    logger: logging.Logger = logging.getLogger(logger_name)
+    kwargs = {
+            "cmd": ["airflow", *args],
+            "env": environ,
+            "process_logger": logger,
+            "friendly_name": friendly_name,
+            "conditions": conditions,
+            "on_sigterm": on_sigterm,
+            "is_essential": True
+    }
+    if sigterm_patience_interval is not None:
+        kwargs['sigterm_patience_interval'] = sigterm_patience_interval
+    return Subprocess(
+        **kwargs
+    )
+
+
+@cache
+def _is_sidecar_health_monitoring_enabled():
+    enabled = (
+        os.environ.get(
+            "MWAA__HEALTH_MONITORING__ENABLE_SIDECAR_HEALTH_MONITORING", "false"
+        ).lower()
+        == "true"
+    )
+    if enabled:
+        logger.info("Sidecar health monitoring is enabled.")
+    else:
+        logger.info("Sidecar health monitoring is NOT enabled.")
+    return enabled
+
+
+def _get_sidecar_health_port():
+    try:
+        return int(
+            os.environ.get(
+                "MWAA__HEALTH_MONITORING__SIDECAR_HEALTH_PORT",
+                SIDECAR_DEFAULT_HEALTH_PORT,
+            )
+        )
+    except:
+        return SIDECAR_DEFAULT_HEALTH_PORT
+
+
+def _create_airflow_webserver_subprocesses(environ: Dict[str, str]):
+    return [
+        _create_airflow_subprocess(
+            ["webserver"],
+            environ=environ,
+            logger_name=WEBSERVER_LOGGER_NAME,
+            friendly_name="webserver",
+            conditions=[
+                AirflowDbReachableCondition(airflow_component="webserver"),
+            ],
+        ),
+    ]
+
+
+def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patience_interval: timedelta | None = None):
+    conditions = _create_airflow_process_conditions('worker')
+    # MWAA__CORE__TASK_MONITORING_ENABLED is set to 'true' for workers where we want to monitor count of tasks currently getting
+    # executed on the worker. This will be used to determine if idle worker checks are to be enabled.
+    task_monitoring_enabled = (
+        os.environ.get("MWAA__CORE__TASK_MONITORING_ENABLED", "false").lower() == "true"
+    )
+    # If MWAA__CORE__TERMINATE_IF_IDLE is set to 'true', then as part of the task monitoring if the task count reaches zero, then the
+    # worker will be terminated.
+    terminate_if_idle = (
+        os.environ.get("MWAA__CORE__TERMINATE_IF_IDLE", "false").lower() == "true" and task_monitoring_enabled
+    )
+    # If MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED is set to 'true', then as part of the task monitoring, the monitor will expect certain
+    # signals to be sent from MWAA. These signals will represent MWAA service side events such as start of an environment update.
+    mwaa_signal_handling_enabled = (
+        os.environ.get("MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED", "false").lower() == "true" and task_monitoring_enabled
+    )
+
+
+    mwaa_worker_idleness_verification_interval = int(environ.get("MWAA__CORE__WORKER_IDLENESS_VERIFICATION_INTERVAL",
+                                                                    "20"))
+
+    if task_monitoring_enabled:
+        logger.info(f"Worker task monitoring is enabled with idleness verification interval: "
+                    f"{mwaa_worker_idleness_verification_interval}")
+        # Initializing the monitor responsible for performing idle worker checks if enabled.
+        worker_task_monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled, mwaa_worker_idleness_verification_interval)
+    else:
+        logger.info("Worker task monitoring is NOT enabled.")
+        worker_task_monitor = None
+
+    if worker_task_monitor:
+        conditions.append(TaskMonitoringCondition(worker_task_monitor, terminate_if_idle))
+
+    def on_sigterm() -> None:
+        # When a SIGTERM is caught, we pause the Airflow Task consumption and wait 5 seconds in order
+        # for any in-flight messages in the SQS broker layer to be processed and
+        # corresponding Airflow task instance to be created. Once that is done, we can
+        # start gracefully shutting down the worker. Without this, the SQS broker may
+        # consume messages from the queue, terminate before creating the corresponding
+        # Airflow task instance and abandon SQS messages in-flight.
+        if worker_task_monitor:
+            worker_task_monitor.pause_task_consumption()
+            time.sleep(5)
+
+    # Finally, return the worker subprocesses.
+    return [
+            _create_airflow_subprocess(
+                ["celery", "worker"],
+                environ=environ,
+                logger_name=WORKER_LOGGER_NAME,
+                friendly_name="worker",
+                conditions=conditions,
+                on_sigterm=on_sigterm,
+                sigterm_patience_interval=sigterm_patience_interval
+            )
+        ]
+
+
+def _create_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: List):
+    """
+    Get the scheduler subproceses: scheduler, dag-processor, and triggerer.
+
+    :param environ: A dictionary containing the environment variables.
+    :param conditions: A list of subprocess conditions.
+    :returns: Scheduler subprocesses.
+    """
+    return [
+            _create_airflow_subprocess(
+                [airflow_cmd],
+                environ=environ,
+                logger_name=logger_name,
+                friendly_name=friendly_name,
+                conditions=conditions if airflow_cmd == "scheduler" else [],
+            )
+            for airflow_cmd, logger_name, friendly_name in [
+                ("scheduler", SCHEDULER_LOGGER_NAME, "scheduler"),
+                ("dag-processor", DAG_PROCESSOR_LOGGER_NAME, "dag-processor"),
+                ("triggerer", TRIGGERER_LOGGER_NAME, "triggerer"),
+            ]
+        ]
+
+
+def _create_airflow_process_conditions(airflow_cmd: str):
+    """
+    Get conditions for the given Airflow command.
+
+    :param airflow_cmd: The command to get conditions for, e.g. "scheduler"
+    :returns: A list of conditions for the given Airflow command.
+    """
+    conditions: List[ProcessCondition] = [
+        AirflowDbReachableCondition(airflow_component=airflow_cmd),
+    ]
+    if _is_sidecar_health_monitoring_enabled():
+        conditions.append(
+            SidecarHealthCondition(
+                airflow_component=airflow_cmd,
+                container_start_time=CONTAINER_START_TIME,
+                port=_get_sidecar_health_port(),
+            ),
+        )
+    return conditions
+
+
+def _run_airflow_command(cmd: str, environ: Dict[str, str]):
+    """
+    Run the given Airflow command in a subprocess.
+
+    :param cmd - The command to run, e.g. "worker".
+    :param environ: A dictionary containing the environment variables.
+    """
+
+    match cmd:
+        case "scheduler":
+            conditions = _create_airflow_process_conditions('scheduler')
+            subprocesses = _create_airflow_scheduler_subprocesses(environ, conditions)
+            # Schedulers, triggers, and DAG processors are all essential processes and
+            # if any fails, we want to exit the container and let it restart.
+            run_subprocesses(subprocesses)
+        case "worker":
+            run_subprocesses(_create_airflow_worker_subprocesses(environ))
+        case "webserver":
+            run_subprocesses(_create_airflow_webserver_subprocesses(environ))
+        # Hybrid runs the scheduler and celery worker processes is a single container.
+        case "hybrid":
+            # The Sidecar healthcheck is currently limited to one healthcheck per port
+            # so the hybrid container can only include healthchecks for one subprocess.
+            # Only the worker healcheck conditions are enabled to monitor container health, so
+            # we pass an empty list of conditions to the scheduler process and make worker
+            # process essential.
+            scheduler_subprocesses = _create_airflow_scheduler_subprocesses(environ, [])
+
+            # Since both scheduler and workers are launched together as essential
+            # the default patience interval for worker needs to be increased to better
+            # allow for in-flight tasks to complete in case of scheduler failure.
+            try:
+                worker_patience_interval_seconds = os.getenv('MWAA__HYBRID_CONTAINER__SIGTERM_PATIENCE_INTERVAL', None)
+                if worker_patience_interval_seconds is not None:
+                    worker_patience_interval = timedelta(seconds=int(worker_patience_interval_seconds))
+                else:
+                    worker_patience_interval = HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT
+            except (ValueError, TypeError):
+                worker_patience_interval = HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT
+
+            worker_subprocesses = _create_airflow_worker_subprocesses(environ,
+                                                                   sigterm_patience_interval=worker_patience_interval)
+            run_subprocesses(scheduler_subprocesses + worker_subprocesses)
+
+        case _:
+            raise ValueError(f"Unexpected command: {cmd}")
+
+
+def execute_command(command: str, env: Dict[str, str], container_start_time: float):
+    """Execute the specified Airflow command with the given environment configuration.
+
+    This function sets up the container start time and executes the provided Airflow
+    command with the specified environment variables.
+
+    Args:
+        command (str): The Airflow command to execute.
+        env (Dict[str, str]): Dictionary of environment variables to be used.
+        container_start_time (float): The timestamp when the container was started.
+
+    Returns:
+        None
+
+    Global Variables:
+        CONTAINER_START_TIME: Updates the global container start time.
+    """
+    global CONTAINER_START_TIME
+    CONTAINER_START_TIME = container_start_time
+    match command:
+        case "shell":
+            os.execlpe("/bin/bash", "/bin/bash", env)
+        case "spy":
+            while True:
+                time.sleep(1)
+        # Disabling the "resetdb" command for now, as it is pretty risky to have such
+        # a destructive command adjacent to other commands used in production; a simple
+        # code mistake can result in wiping out production databases. Instead, testing
+        # commands like this should be in a completely isolated boundary, with
+        # protection mechanism to ensure they are not accidentally executed in
+        # production.
+        # case "resetdb":
+        #     # Perform the resetdb functionality
+        #     await airflow_db_reset(environ)
+        #     # After resetting the db, initialize it again
+        #     await airflow_db_init(environ)
+        case "scheduler" | "webserver" | "worker" | "hybrid":
+            _run_airflow_command(command, env)
+        case _:
+            raise ValueError(f"Invalid command: {command}")

--- a/images/airflow/2.10.3/python/mwaa/logging/config.py
+++ b/images/airflow/2.10.3/python/mwaa/logging/config.py
@@ -33,10 +33,16 @@ from airflow.config_templates.airflow_local_settings import (
 from mwaa.logging import cloudwatch_handlers
 from mwaa.utils import qualified_name
 
+CONSOLE_LOG_LEVEL = os.environ.get('AIRFLOW_CONSOLE_LOG_LEVEL', 'INFO')
 # We adopt the default logging configuration from Airflow and do the necessary changes
 # to setup logging with CloudWatch Logs.
 LOGGING_CONFIG = {
     **DEFAULT_LOGGING_CONFIG,
+    'root': {
+        'handlers': ['console'],
+        'level': CONSOLE_LOG_LEVEL,
+        'filters': ['mask_secrets'],
+    }
 }
 
 
@@ -183,7 +189,7 @@ def _configure():
             comp,
             log_group_arn=log_group_arn,
             log_stream_name_prefix=comp.lower(),
-            log_level=log_level,
+            log_level="DEBUG",  # Customer Log Level handled at root logger
             logging_enabled=logging_enabled,
         )
         _configure_subprocesses_logging(

--- a/images/airflow/2.10.3/python/mwaa/utils/user_requirements.py
+++ b/images/airflow/2.10.3/python/mwaa/utils/user_requirements.py
@@ -1,0 +1,112 @@
+"""
+User requirements handling module for Amazon MWAA.
+
+This module manages user-defined Python package requirements and their
+installation process in Amazon MWAA environments. It handles requirement
+file parsing, validation, and package installation procedures.
+"""
+# Python imports
+from datetime import timedelta
+import logging
+import os
+import re
+
+# Our imports
+from mwaa.logging.config import MWAA_LOGGERS
+from mwaa.logging.loggers import CompositeLogger
+from mwaa.subprocess.subprocess import Subprocess
+from mwaa.subprocess.conditions import TimeoutCondition
+from mwaa.utils.encoding import auto_decode
+
+MWAA_DOCS_REQUIREMENTS_GUIDE = "https://docs.aws.amazon.com/mwaa/latest/userguide/working-dags-dependencies.html#working-dags-dependencies-test-create"
+
+USER_REQUIREMENTS_MAX_INSTALL_TIME = timedelta(minutes=9)
+
+logger = logging.getLogger("mwaa.entrypoint")
+
+
+def _read_requirements_file(requirements_file: str) -> str:
+    with open(requirements_file, "rb") as f:
+        return auto_decode(f.read())
+
+
+def _requirements_has_constraints(requirements_file: str):
+    content = _read_requirements_file(requirements_file)
+    for line in content.splitlines():
+        # Notice that this regex check will also match lines with commented out
+        # constraints flag. This is intentional as a mechanism for users who want to
+        # avoid enforcing the default Airflow constraints, yet don't want to provide a
+        # constraints file.
+        if re.search(r"-c |--constraint ", line):
+            return True
+    return False
+
+
+async def install_user_requirements(cmd: str, environ: dict[str, str]):
+    """
+    Install user requirements.
+
+    User requirements should be placed in a requirements.txt file and the environment
+    variable `MWAA__CORE__REQUIREMENTS_PATH` should be set to the location of that file.
+    In a Docker Compose setup, you would usually want to create a volume that maps a
+    requirements.txt file in the host machine somewhere in the container, and then set
+    the `MWAA__CORE__REQUIREMENTS_PATH` accordingly.
+
+    :param environ: A dictionary containing the environment variables.
+    """
+    requirements_file = environ.get("MWAA__CORE__REQUIREMENTS_PATH")
+    logger.info(f"MWAA__CORE__REQUIREMENTS_PATH = {requirements_file}")
+    if requirements_file and os.path.isfile(requirements_file):
+        logger.info(f"Installing user requirements from {requirements_file}...")
+        # For hybrid worker/scheduler containers we publish the requirement install logs
+        # to the worker CloudWatch log group.
+        logger_prefix = "worker" if cmd == "hybrid" else cmd;
+        subprocess_logger = CompositeLogger(
+            "requirements_composite_logging",  # name can be anything unused.
+            # We use a set to avoid double logging to console if the user doesn't
+            # use CloudWatch for logging.
+            *set(
+                [
+                    logging.getLogger(MWAA_LOGGERS.get(f"{logger_prefix}_requirements")),
+                    logger,
+                ]
+            ),
+        )
+
+        extra_args = []
+        try:
+            if not _requirements_has_constraints(requirements_file):
+                subprocess_logger.warning(
+                    "WARNING: Constraints should be specified for requirements.txt. "
+                    f"Please see {MWAA_DOCS_REQUIREMENTS_GUIDE}"
+                )
+                subprocess_logger.warning("Forcing local constraints")
+                extra_args = ["-c", os.environ["AIRFLOW_CONSTRAINTS_FILE"]]
+        except Exception as e:
+            subprocess_logger.warning(f"Unable to scan requirements file: {e}")
+            subprocess_logger.warning(
+                "Cannot determine whether the requirements.txt file has constraints "
+                "or not; forcing local constraints."
+            )
+            extra_args = ["-c", os.environ["AIRFLOW_CONSTRAINTS_FILE"]]
+
+        pip_process = Subprocess(
+            cmd=["safe-pip-install", "-r", requirements_file, *extra_args],
+            env=environ,
+            process_logger=subprocess_logger,
+            conditions=[
+                TimeoutCondition(USER_REQUIREMENTS_MAX_INSTALL_TIME),
+            ],
+            friendly_name=f"{logger_prefix}_requirements",
+        )
+        pip_process.start()
+        if pip_process.process and pip_process.process.returncode != 0:
+            subprocess_logger.error(
+                "ERROR: pip installation exited with a non-zero error code. This could "
+                "be the result of package conflict. Notice that MWAA enforces a list "
+                "of critical packages, e.g. Airflow, Celery, among others, whose "
+                "version cannot be overridden by the customer as that can break our "
+                "setup. Please double check your requirements.txt file."
+            )
+    else:
+        logger.info("No user requirements to install.")

--- a/images/airflow/2.10.3/requirements.txt
+++ b/images/airflow/2.10.3/requirements.txt
@@ -25,5 +25,7 @@ pyright
 ruff
 sqlalchemy-stubs
 pytest
+pytest-asyncio
 pytest-cov
+pytest-mock
 diff-cover

--- a/tests/images/airflow/2.10.1/python/mwaa/config/test_setup_environment_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/config/test_setup_environment_2_10_1.py
@@ -1,0 +1,267 @@
+# test_setup_environment.py
+import pytest
+import json
+import os
+from unittest.mock import patch, mock_open, MagicMock
+from datetime import timedelta
+from mwaa.config.setup_environment import (
+    setup_environment_variables,
+    _execute_startup_script,
+    _export_env_variables,
+    _is_protected_os_environ,
+)
+from mwaa.subprocess.subprocess import Subprocess  # Add this import
+
+
+@pytest.fixture
+def mock_environ(monkeypatch):
+    """Fixture for mocking os.environ"""
+    test_environ = {
+        "AIRFLOW_ENV_ID": "test-env-id",
+        "AIRFLOW_ENV_NAME": "test-env",
+        "AIRFLOW_HOME": "/usr/local/airflow",
+        "AWS_DEFAULT_REGION": "us-east-1",
+        "PYTHONPATH": "/usr/local/airflow/dags",
+        "MWAA__CORE__TEST": "test-value",
+        "MWAA__CORE__STARTUP_SCRIPT_PATH": "../../2.10.1/startup/startup.sh",
+        "MWAA__CORE__TESTING_MODE": "true"
+    }
+    monkeypatch.setattr(os, "environ", test_environ)
+    return test_environ
+
+
+@pytest.fixture
+def mock_config_functions(monkeypatch):
+    """Fixture for mocking all configuration related functions"""
+    mock_functions = {
+        "get_essential_airflow_config": MagicMock(return_value={"ESSENTIAL_CONFIG": "value1"}),
+        "get_opinionated_airflow_config": MagicMock(return_value={"OP_CONFIG": "value2"}),
+        "get_essential_environ": MagicMock(return_value={"ESSENTIAL_ENV": "value3"}),
+        "get_opinionated_environ": MagicMock(return_value={"OP_ENV": "value4"}),
+        "get_user_airflow_config": MagicMock(return_value={"USER_CONFIG": "value5"})
+    }
+
+    for func_name, mock_func in mock_functions.items():
+        monkeypatch.setattr(f"mwaa.config.setup_environment.{func_name}", mock_func)
+
+    return mock_functions
+
+
+@pytest.fixture
+def temp_home_dir(tmp_path):
+    """Fixture for creating temporary home directory with .bashrc and .bash_profile"""
+    bashrc = tmp_path / ".bashrc"
+    bash_profile = tmp_path / ".bash_profile"
+    bashrc.touch()
+    bash_profile.touch()
+    return tmp_path
+
+
+# ------------------------
+# Environment Configuration Tests
+# ------------------------
+
+@pytest.mark.parametrize(
+    "key,expected",
+    [
+        ("MWAA__CORE__TEST", True),
+        ("AIRFLOW_ENV_ID", True),
+        ("AWS_DEFAULT_REGION", True),
+        ("CUSTOM_VAR", False),
+        ("PYTHONPATH", True),
+        ("RANDOM_VAR", False),
+        ("MWAA__CUSTOM__VAR", True),
+    ]
+)
+def test_is_protected_os_environ(key, expected):
+    """Test protected environment variable checking"""
+    assert _is_protected_os_environ(key) == expected
+
+
+def test_export_env_variables(temp_home_dir):
+    """Test environment variable export to shell files"""
+    test_environ = {
+        "TEST_VAR1": "value1",
+        "TEST_VAR2": "value2 with space",
+        "TEST_VAR3": "value3!@#$"
+    }
+
+    with patch("os.path.expanduser", return_value=str(temp_home_dir)):
+        _export_env_variables(test_environ)
+
+    # Verify both files
+    for filename in [".bashrc", ".bash_profile"]:
+        file_path = temp_home_dir / filename
+        content = file_path.read_text()
+
+        assert 'export TEST_VAR1=value1\n' in content
+        assert "export TEST_VAR2='value2 with space'\n" in content
+        assert "export TEST_VAR3='value3!@#$'\n" in content
+
+
+def test_setup_environment_variables(mock_environ, mock_config_functions):
+    """Test complete environment variable setup"""
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script, \
+            patch("mwaa.config.setup_environment._export_env_variables") as mock_export:
+        mock_execute_script.return_value = {"STARTUP_VAR": "value6"}
+
+        result = setup_environment_variables("worker", "Local")
+
+        # Verify all configurations are present and correctly merged
+        assert result["ESSENTIAL_CONFIG"] == "value1"
+        assert result["OP_CONFIG"] == "value2"
+        assert result["ESSENTIAL_ENV"] == "value3"
+        assert result["OP_ENV"] == "value4"
+        assert result["USER_CONFIG"] == "value5"
+        assert result["STARTUP_VAR"] == "value6"
+
+        # Verify protected variables are preserved
+        assert result["AIRFLOW_ENV_ID"] == "test-env-id"
+        assert result["AIRFLOW_HOME"] == "/usr/local/airflow"
+        assert result["AWS_DEFAULT_REGION"] == "us-east-1"
+
+        # Verify export was called
+        mock_export.assert_called_once_with(result)
+
+
+# ------------------------
+# Startup Script Tests
+# ------------------------
+
+def test_no_startup_script_path():
+    """Test when MWAA__CORE__STARTUP_SCRIPT_PATH is not set"""
+    with patch.dict(os.environ, {}, clear=True):
+        result = _execute_startup_script("worker", {})
+        assert result == {}
+
+
+def test_startup_script_not_found():
+    """Test when startup script file doesn't exist"""
+    with patch.dict(os.environ, {"MWAA__CORE__STARTUP_SCRIPT_PATH": "/nonexistent/path"}), \
+            patch('os.path.isfile', return_value=False):
+        result = _execute_startup_script("worker", {})
+        assert result == {}
+
+
+def test_uses_mocked_env(mock_environ):
+    """Ensure environment variables are correctly set"""
+    assert mock_environ["MWAA__CORE__TESTING_MODE"] == "true"
+
+
+@pytest.mark.parametrize("cmd,expected_logger", [
+    ("worker", "worker_startup"),
+    ("scheduler", "scheduler_startup"),
+    ("hybrid", "worker_startup")
+])
+def test_startup_script_execution(cmd, expected_logger, mock_environ):
+    """Test successful startup script execution with different commands"""
+    customer_env = {"CUSTOM_VAR": "value"}
+
+    with patch('os.path.isfile', return_value=True), \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess:
+        # Configure mock subprocess
+        mock_process = MagicMock()
+        mock_process.start.return_value = 0
+        MockSubprocess.return_value = mock_process
+
+        with patch('builtins.open', mock_open(read_data='{"CUSTOM_VAR": "value"}')):
+            result = _execute_startup_script(cmd, mock_environ)
+
+            assert result == customer_env
+            # Verify Subprocess was instantiated twice (for script and verification)
+            assert MockSubprocess.call_count == 2
+            # Verify start was called on each instance
+            assert mock_process.start.call_count == 2
+
+
+def test_failed_env_vars_reading(mock_environ):
+    """Test when reading customer environment variables fails"""
+    with patch('os.path.isfile', return_value=True), \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess, \
+            patch('builtins.open') as mock_file:
+        # Configure mock subprocess
+        mock_process = MagicMock()
+        mock_process.start.return_value = 0
+        MockSubprocess.return_value = mock_process
+
+        # Configure file mock to raise exception
+        mock_file.side_effect = Exception("Failed to read file")
+
+        with pytest.raises(Exception) as exc_info:
+            _execute_startup_script("worker", mock_environ)
+
+        assert ("Failed to read customer's environment variables from startup script: "
+                "Failed to read file") in str(exc_info.value)
+
+
+
+def test_missing_customer_env_vars_file(mock_environ):
+    """Test when customer environment variables file is not created"""
+    with patch('os.path.isfile') as mock_isfile, \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess:
+        # Configure mock subprocess
+        mock_process = MagicMock()
+        mock_process.start.return_value = 0
+        MockSubprocess.return_value = mock_process
+
+        # First True for startup script, second False for env vars file
+        mock_isfile.side_effect = [True, False]
+
+        with pytest.raises(Exception) as exc_info:
+            _execute_startup_script("worker", mock_environ)
+
+        assert ("Failed to access customer environment variables file: Service was unable "
+                "to create or locate /tmp/customer_env_vars.json") in str(exc_info.value)
+        assert MockSubprocess.call_count == 2
+
+
+@pytest.mark.parametrize("subprocess_error", [
+    Exception("Process failed"),
+    TimeoutError("Process timed out")
+])
+def test_subprocess_execution_errors(subprocess_error, mock_environ):
+    """Test handling of subprocess execution errors"""
+    with patch('os.path.isfile', return_value=True), \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess:
+        # Configure mock subprocess to raise error
+        mock_process = MagicMock()
+        mock_process.start.side_effect = subprocess_error
+        MockSubprocess.return_value = mock_process
+
+        with pytest.raises(type(subprocess_error)) as exc_info:
+            _execute_startup_script("worker", mock_environ)
+
+        assert str(subprocess_error) == str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "command,executor_type",
+    [
+        ("worker", "Local"),
+        ("scheduler", "Celery"),
+        ("webserver", "Local"),
+        ("hybrid", "Celery")
+    ]
+)
+def test_setup_environment_variables_different_commands(
+        command,
+        executor_type,
+        mock_environ,
+        mock_config_functions
+):
+    """Test environment setup with different commands and executor types"""
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script:
+        mock_execute_script.return_value = {}
+
+        result = setup_environment_variables(command, executor_type)
+
+        # Verify essential configurations are present
+        assert "ESSENTIAL_CONFIG" in result
+        assert "ESSENTIAL_ENV" in result
+
+        # Verify the execute_startup_script was called correctly
+        mock_execute_script.assert_called_once()
+        args, _ = mock_execute_script.call_args
+        assert args[0] == command
+        # Verify the environment dict was passed (without checking exact contents)
+        assert isinstance(args[1], dict)

--- a/tests/images/airflow/2.10.1/python/mwaa/test_entrypoint_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/test_entrypoint_2_10_1.py
@@ -1,101 +1,236 @@
-import os
+# test_entrypoint.py
 import pytest
+import asyncio
+import os
+import sys
+from unittest.mock import patch, MagicMock, call, AsyncMock
+from datetime import datetime
+from botocore.exceptions import ClientError
+
 import mwaa.entrypoint as entrypoint
+from mwaa.entrypoint import (
+    _setup_console_log_level,
+    _configure_root_logger,
+    airflow_db_init,
+    create_airflow_user,
+    create_queue,
+    main
+)
 
-from unittest.mock import patch, mock_open, MagicMock
 
-# # ------------------------
-# # Fixtures
-# # ------------------------
+# ------------------------
+# Fixtures
+# ------------------------
 @pytest.fixture
-def mock_environ():
-    return {
-        "MWAA__CORE__STARTUP_SCRIPT_PATH": "../../2.10.1/startup/startup.sh",
+def mock_environ(monkeypatch):
+    """Basic environment variables fixture"""
+    env_vars = {
+        "MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL": "INFO",
+        "MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL": "INFO",
+        "MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_LEVEL": "INFO",
+        "MWAA__CORE__EXECUTOR_TYPE": "CeleryExecutor",
+        "MWAA__CORE__AUTH_TYPE": "testing",
+        "MWAA__CORE__CREATED_AT": "Mon Sep 11 00:00:00 UTC 2024",
+        "MWAA__CORE__TESTING_MODE": "true",
+        # Database configuration
+        "MWAA__DB__POSTGRES_HOST": "localhost",
+        "MWAA__DB__POSTGRES_PORT": "5432",
+        "MWAA__DB__POSTGRES_DB": "airflow",
+        "MWAA__DB__POSTGRES_USER": "airflow",
+        "MWAA__DB__POSTGRES_PASSWORD": "airflow",
+        "MWAA__DB__POSTGRES_SSLMODE": "disable",
+        "PYTHONPATH": os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     }
+    monkeypatch.setattr(os, "environ", env_vars)
+    return env_vars
+
+
+@pytest.fixture
+def mock_boto3_client():
+    """Mock boto3 client for SQS operations"""
+    with patch('boto3.client') as mock_client:
+        yield mock_client
+
+
+@pytest.fixture
+def mock_db_utils():
+    """Mock database utilities"""
+    with patch('mwaa.utils.dblock.create_engine') as mock_engine, \
+            patch('mwaa.utils.dblock.get_db_connection_string', return_value='postgresql://localhost/airflow'):
+        engine = MagicMock()
+        mock_engine.return_value = engine
+        yield engine
+
 
 # ------------------------
 # Test Cases
 # ------------------------
-def test_no_startup_script_path():
-    """Test when MWAA__CORE__STARTUP_SCRIPT_PATH is not set"""
-    with patch.dict(os.environ, {}, clear=True):
-        result = entrypoint.execute_startup_script("worker", {})
-        assert result == {}
 
-
-def test_startup_script_not_found():
-    """Test when startup script file doesn't exist"""
-    with patch.dict(os.environ, {"MWAA__CORE__STARTUP_SCRIPT_PATH": "/nonexistent/path"}), \
-            patch('os.path.isfile', return_value=False):
-        result = entrypoint.execute_startup_script("worker", {})
-        assert result == {}
-
-
-def test_uses_mocked_env():
-    """Ensure environment variables are correctly set"""
-    assert "true" in os.environ["MWAA__CORE__TESTING_MODE"]
-
-
-@pytest.mark.parametrize("cmd,expected_logger", [
-    ("worker", "worker_startup"),
-    ("scheduler", "scheduler_startup"),
-    ("hybrid", "worker_startup")
+@pytest.mark.parametrize("command,expected_level", [
+    ("scheduler", "INFO"),
+    ("worker", "INFO"),
+    ("webserver", "INFO"),
+    ("unknown", "INFO"),
 ])
-def test_startup_script_execution(cmd, expected_logger, mock_environ):
-    """Test successful startup script execution with different commands"""
-    customer_env = {"CUSTOM_VAR": "value"}
-
-    with patch('os.path.isfile', return_value=True), \
-            patch('mwaa.entrypoint.Subprocess') as mock_subprocess, \
-            patch('builtins.open', mock_open(read_data='{"CUSTOM_VAR": "value"}')):
-        mock_process = MagicMock()
-        mock_subprocess.return_value = mock_process
-
-        result = entrypoint.execute_startup_script(cmd, mock_environ)
-        assert result == customer_env
+def test_setup_console_log_level(command, expected_level, mock_environ):
+    """Test console log level setup"""
+    with patch.dict(os.environ, mock_environ, clear=True):
+        _setup_console_log_level(command)
+        assert os.environ['AIRFLOW_CONSOLE_LOG_LEVEL'] == expected_level
 
 
-def test_failed_env_vars_reading(mock_environ):
-    """Test when reading customer environment variables fails"""
-    with patch('os.path.isfile', return_value=True), \
-            patch('mwaa.entrypoint.Subprocess') as mock_subprocess, \
-            patch('builtins.open', mock_open()) as mock_file:
-        mock_file.side_effect = Exception("Failed to read file")
-        mock_process = MagicMock()
-        mock_subprocess.return_value = mock_process
-
-        with pytest.raises(Exception) as exc_info:
-            entrypoint.execute_startup_script("worker", mock_environ)
-
-        assert "Failed to read customer's environment variables" in str(exc_info.value)
+def test_configure_root_logger(mock_environ):
+    """Test root logger configuration"""
+    with patch('logging.config.dictConfig') as mock_dict_config, \
+            patch.dict(os.environ, mock_environ, clear=True):
+        _configure_root_logger("scheduler")
+        mock_dict_config.assert_called_once()
 
 
-def test_missing_customer_env_vars_file(mock_environ):
-    """Test when customer environment variables file is not created"""
-    with patch('os.path.isfile') as mock_isfile, \
-            patch('mwaa.entrypoint.Subprocess') as mock_subprocess:
-        mock_isfile.side_effect = [True, False]
-        mock_process = MagicMock()
-        mock_subprocess.return_value = mock_process
+@pytest.mark.asyncio
+async def test_airflow_db_init(mock_db_utils):
+    """Test Airflow database initialization"""
+    environ = {"PYTHONPATH": os.environ.get("PYTHONPATH", "")}
 
-        with pytest.raises(Exception) as exc_info:
-            entrypoint.execute_startup_script("worker", mock_environ)
+    async def mock_run_command(cmd, env=None):
+        return 0
 
-        assert ("Failed to access customer environment variables file: Service was unable "
-                "to create or locate /tmp/customer_env_vars.json") in str(exc_info.value)
+    with patch('mwaa.entrypoint.run_command', side_effect=mock_run_command) as mock_cmd:
+        await airflow_db_init(environ)
+        mock_cmd.assert_called_once_with(
+            "python3 -m mwaa.database.migrate",
+            env=environ
+        )
 
 
-@pytest.mark.parametrize("subprocess_error", [
-    Exception("Process failed"),
-    TimeoutError("Process timed out")
-])
-def test_subprocess_execution_errors(subprocess_error, mock_environ):
-    """Test handling of subprocess execution errors"""
-    with patch('os.path.isfile', return_value=True), \
-            patch('mwaa.entrypoint.Subprocess') as mock_subprocess:
-        mock_process = MagicMock()
-        mock_process.start.side_effect = subprocess_error
-        mock_subprocess.return_value = mock_process
 
-        with pytest.raises(Exception):
-            entrypoint.execute_startup_script("worker", mock_environ)
+@pytest.fixture
+def mock_run_command():
+    """Mock run_command with AsyncMock"""
+
+    async def mock_run(*args, **kwargs):
+        if 'stdout_logging_method' in kwargs in args[0]:
+            kwargs['stdout_logging_method']("128")
+        return 0
+
+    with patch('mwaa.entrypoint.run_command') as mock:
+        mock.side_effect = mock_run
+        yield mock
+
+
+@pytest.mark.asyncio
+async def test_create_airflow_user(mock_db_utils, mock_environ):
+    """Test Airflow user creation"""
+
+    async def mock_run_command(cmd, env=None):
+        return 0
+
+    with patch('mwaa.entrypoint.run_command', side_effect=mock_run_command) as mock_cmd:
+        await create_airflow_user(mock_environ)
+        assert mock_cmd.called
+        assert "airflow users create" in mock_cmd.call_args[0][0]
+
+
+def test_create_queue_when_not_required(mock_environ, mock_db_utils):
+    """Test queue creation when not required"""
+    with patch('mwaa.entrypoint.should_create_queue', return_value=False):
+        create_queue()
+
+
+def test_create_existing_queue(mock_environ, mock_db_utils, mock_boto3_client):
+    """Test handling of existing queue"""
+    with patch('mwaa.entrypoint.should_create_queue', return_value=True), \
+            patch('mwaa.entrypoint.get_sqs_queue_name', return_value='test-queue'):
+        mock_sqs = MagicMock()
+        mock_boto3_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.return_value = {"QueueUrl": "test-url"}
+
+        create_queue()
+
+        mock_sqs.get_queue_url.assert_called_once_with(QueueName='test-queue')
+        mock_sqs.create_queue.assert_not_called()
+
+
+def test_create_new_queue(mock_environ, mock_db_utils, mock_boto3_client):
+    """Test creation of new queue"""
+    with patch('mwaa.entrypoint.should_create_queue', return_value=True), \
+            patch('mwaa.entrypoint.get_sqs_queue_name', return_value='test-queue'):
+        mock_sqs = MagicMock()
+        mock_boto3_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.side_effect = ClientError(
+            {'Error': {'Message': 'The specified queue does not exist.'}},
+            'GetQueueUrl'
+        )
+
+        create_queue()
+
+        mock_sqs.create_queue.assert_called_once_with(QueueName='test-queue')
+
+
+@pytest.mark.asyncio
+async def test_main_valid_command(mock_environ, mock_db_utils):
+    """Test main function with valid command"""
+    test_args = ['script.py', 'scheduler']
+
+    async def mock_run_command(cmd, env=None):
+        return 0
+
+    with patch.dict(os.environ, mock_environ), \
+            patch.object(sys, 'argv', test_args), \
+            patch('mwaa.entrypoint.run_command', side_effect=mock_run_command), \
+            patch('mwaa.entrypoint.setup_environment_variables') as mock_setup_env, \
+            patch('mwaa.entrypoint.install_user_requirements') as mock_install_req, \
+            patch('mwaa.entrypoint.create_queue') as mock_create_queue, \
+            patch('mwaa.entrypoint.execute_command') as mock_execute:
+        mock_setup_env.return_value = mock_environ
+        mock_install_req.return_value = None
+
+        await main()
+
+        mock_setup_env.assert_called_once()
+        mock_install_req.assert_called_once()
+        mock_create_queue.assert_called_once()
+        mock_execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_main_invalid_command():
+    """Test main function with invalid command"""
+    test_args = ['script.py', 'invalid']
+    with patch.object(sys, 'argv', test_args):
+        with pytest.raises(SystemExit):
+            await main()
+
+
+@pytest.mark.asyncio
+async def test_main_test_requirements(mock_environ, mock_db_utils):
+    """Test main function with test-requirements command"""
+    test_args = ['script.py', 'test-requirements']
+    with patch.dict(os.environ, mock_environ), \
+            patch.object(sys, 'argv', test_args), \
+            patch('mwaa.entrypoint.setup_environment_variables') as mock_setup_env, \
+            patch('mwaa.entrypoint.install_user_requirements') as mock_install_req:
+        mock_setup_env.return_value = mock_environ
+
+        await main()
+
+        mock_setup_env.assert_called_once()
+        mock_install_req.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_main_missing_arguments():
+    """Test main function with missing arguments"""
+    test_args = ['script.py']
+    with patch.object(sys, 'argv', test_args):
+        with pytest.raises(SystemExit):
+            await main()
+
+
+def test_import_guard():
+    """Test import guard functionality"""
+    with patch.dict(os.environ, {'MWAA__CORE__TESTING_MODE': 'false'}, clear=True), \
+            patch('sys.exit') as mock_exit:
+        import importlib
+        importlib.reload(entrypoint)
+        mock_exit.assert_called_once_with(1)

--- a/tests/images/airflow/2.10.1/python/mwaa/test_execute_command_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/test_execute_command_2_10_1.py
@@ -1,0 +1,148 @@
+import pytest
+import os
+from unittest.mock import patch, MagicMock, mock_open
+
+# Set CONTAINER_START_TIME before importing the module
+TEST_CONTAINER_START_TIME = 1234567890.0
+with patch.dict('os.environ', {'CONTAINER_START_TIME': str(TEST_CONTAINER_START_TIME)}):
+    from mwaa.execute_command import (
+        execute_command,
+        HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT
+    )
+
+
+# ------------------------
+# Fixtures
+# ------------------------
+@pytest.fixture
+def mock_environ():
+    """Basic environment variables fixture"""
+    return {
+        "AIRFLOW_HOME": "/usr/local/airflow",
+        "MWAA__CORE__TASK_MONITORING_ENABLED": "false",
+        "MWAA__CORE__TERMINATE_IF_IDLE": "false",
+        "MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED": "false",
+        "MWAA__HEALTH_MONITORING__ENABLE_SIDECAR_HEALTH_MONITORING": "false",
+        "MWAA__HYBRID_CONTAINER__SIGTERM_PATIENCE_INTERVAL": "150",
+        "MWAA__DB__POSTGRES_HOST": "localhost",
+        "MWAA__DB__POSTGRES_PORT": "5432",
+        "MWAA__DB__POSTGRES_DB": "airflow",
+        "MWAA__DB__POSTGRES_SSLMODE": "disable"
+    }
+
+
+@pytest.fixture
+def mock_subprocess():
+    """Mock Subprocess"""
+    process = MagicMock()
+    process.start.return_value = 0
+    process.process = MagicMock()
+    process.process.returncode = 0
+
+    with patch('mwaa.subprocess.subprocess.Subprocess', return_value=process) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_run_subprocesses():
+    """Mock run_subprocesses"""
+    with patch('mwaa.execute_command.run_subprocesses') as mock:
+        yield mock
+
+def remove_celery_state():
+    try:
+        os.remove("/celery_state_")
+    except FileNotFoundError:
+        pass
+
+
+@pytest.fixture
+def mock_file_operations():
+    """Mock file-related operations"""
+    with patch("os.path.exists", return_value=False), \
+         patch("builtins.open", mock_open()), \
+         patch("os.remove"):
+        yield
+
+
+# ------------------------
+# Test Cases
+# ------------------------
+
+def test_execute_command_shell(mock_environ):
+    """Test shell command execution"""
+    with patch('os.execlpe') as mock_exec:
+        execute_command("shell", mock_environ, TEST_CONTAINER_START_TIME)
+        mock_exec.assert_called_once_with("/bin/bash", "/bin/bash", mock_environ)
+
+
+def test_execute_command_spy(mock_environ):
+    """Test spy command execution"""
+    with patch('time.sleep', side_effect=KeyboardInterrupt) as mock_sleep:
+        with pytest.raises(KeyboardInterrupt):
+            execute_command("spy", mock_environ, TEST_CONTAINER_START_TIME)
+        mock_sleep.assert_called_once_with(1)
+
+
+@pytest.mark.parametrize("command,expected_subprocesses", [
+    ("scheduler", 3),  # scheduler, dag-processor, triggerer
+    ("worker", 1),  # celery worker
+    ("webserver", 1),  # webserver
+    ("hybrid", 4),  # scheduler, dag-processor, triggerer, worker
+])
+def test_execute_command_airflow_components(command, expected_subprocesses, mock_environ, mock_run_subprocesses):
+    """Test execution of different Airflow components"""
+    execute_command(command, mock_environ, TEST_CONTAINER_START_TIME)
+    assert mock_run_subprocesses.called
+    subprocess_calls = mock_run_subprocesses.call_args[0][0]
+    assert len(subprocess_calls) == expected_subprocesses
+
+
+def test_execute_command_invalid(mock_environ):
+    """Test invalid command execution"""
+    with pytest.raises(ValueError, match="Invalid command"):
+        execute_command("invalid", mock_environ, TEST_CONTAINER_START_TIME)
+
+
+def test_execute_command_worker_idle_termination(mock_environ, mock_run_subprocesses):
+    """Test worker with idle termination enabled"""
+    with patch.dict(os.environ, {"MWAA__CORE__TERMINATE_IF_IDLE": "true"}):
+        execute_command("worker", mock_environ, TEST_CONTAINER_START_TIME)
+    mock_run_subprocesses.assert_called()
+
+
+def test_execute_command_worker_signal_handling(mock_environ, mock_run_subprocesses):
+    """Test worker with signal handling enabled"""
+    with patch.dict(os.environ, {"MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED": "true"}):
+        execute_command("worker", mock_environ, TEST_CONTAINER_START_TIME)
+    mock_run_subprocesses.assert_called()
+
+
+def test_execute_command_container_start_time(mock_environ, mock_run_subprocesses):
+    """Test container start time is properly set"""
+    test_time = 9876543210.0
+    execute_command("scheduler", mock_environ, test_time)
+    from mwaa.execute_command import CONTAINER_START_TIME
+    assert CONTAINER_START_TIME == test_time
+
+
+@patch('mwaa.celery.task_monitor.WorkerTaskMonitor')
+@patch('multiprocessing.shared_memory.SharedMemory')
+def test_execute_command_task_monitoring_enabled(mock_shared_memory, mock_worker_monitor, mock_environ,
+                                                 mock_run_subprocesses):
+    """Test execute_command when task monitoring is enabled in environment variables"""
+    # Setup the mocks
+    mock_worker_instance = MagicMock()
+    mock_worker_monitor.return_value = mock_worker_instance
+
+    mock_shared_memory_instance = MagicMock()
+    mock_shared_memory.return_value = mock_shared_memory_instance
+
+    with patch.dict(os.environ, {"MWAA__CORE__TASK_MONITORING_ENABLED": "true"}, clear=True):
+        execute_command("worker", mock_environ, TEST_CONTAINER_START_TIME)
+
+    # Verify run_subprocesses was called
+    mock_run_subprocesses.assert_called()
+
+
+

--- a/tests/images/airflow/2.10.1/python/mwaa/utils/test_user_requirements_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/utils/test_user_requirements_2_10_1.py
@@ -1,0 +1,198 @@
+# test_user_requirements.py
+import pytest
+import os
+from unittest.mock import patch, mock_open, MagicMock
+from datetime import timedelta
+
+from mwaa.utils.user_requirements import (
+    install_user_requirements,
+    _read_requirements_file,
+    _requirements_has_constraints,
+    USER_REQUIREMENTS_MAX_INSTALL_TIME
+)
+
+
+# ------------------------
+# Fixtures
+# ------------------------
+@pytest.fixture
+def mock_environ():
+    """Basic environment variables fixture"""
+    return {
+        "MWAA__CORE__REQUIREMENTS_PATH": "/path/to/requirements.txt",
+        "AIRFLOW_CONSTRAINTS_FILE": "/path/to/constraints.txt",
+        "MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL": "INFO",
+        "MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL": "INFO",
+    }
+
+
+@pytest.fixture
+def mock_subprocess():
+    """Mock Subprocess class"""
+    subprocess_instance = MagicMock()
+    subprocess_instance.process = MagicMock()
+    subprocess_instance.process.returncode = 0
+    subprocess_instance.start = MagicMock(return_value=0)
+
+    with patch('mwaa.utils.user_requirements.Subprocess', return_value=subprocess_instance) as mock:
+        yield mock, subprocess_instance
+
+
+@pytest.fixture
+def mock_composite_logger():
+    """Mock CompositeLogger"""
+    logger_instance = MagicMock()
+    with patch('mwaa.utils.user_requirements.CompositeLogger', return_value=logger_instance) as mock:
+        yield mock, logger_instance
+
+
+# ------------------------
+# Test Cases
+# ------------------------
+
+def test_read_requirements_file():
+    """Test reading requirements file"""
+    content = "package1==1.0.0\npackage2>=2.0.0"
+    with patch('builtins.open', mock_open(read_data=content.encode())):
+        result = _read_requirements_file("requirements.txt")
+        assert result == content
+
+
+@pytest.mark.parametrize("content,expected", [
+    ("package1==1.0.0\n-c constraints.txt", True),
+    ("package1==1.0.0\npackage2>=2.0.0", False),
+    ("# -c constraints.txt\npackage1==1.0.0", True),
+])
+def test_requirements_has_constraints(content, expected):
+    """Test constraint detection in requirements file"""
+    with patch('mwaa.utils.user_requirements._read_requirements_file', return_value=content):
+        assert _requirements_has_constraints("requirements.txt") == expected
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_no_file(mock_environ):
+    """Test when no requirements file is specified"""
+    with patch.dict(os.environ, {}, clear=True):
+        await install_user_requirements("worker", {})
+        # Should complete without error
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_with_constraints(mock_environ):
+    """Test installation with constraints"""
+    requirements_content = "package1==1.0.0\n-c constraints.txt"
+
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value=requirements_content), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+        mock_process = MagicMock()
+        mock_process.process = MagicMock()
+        mock_subprocess.return_value = mock_process
+
+        await install_user_requirements("worker", mock_environ)
+
+        mock_subprocess.assert_called_once()
+        call_args = mock_subprocess.call_args[1]
+        assert call_args['cmd'] == ['safe-pip-install', '-r', mock_environ['MWAA__CORE__REQUIREMENTS_PATH']]
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_without_constraints(mock_environ):
+    """Test installation without constraints"""
+    requirements_content = "package1==1.0.0"
+
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value=requirements_content), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+        mock_process = MagicMock()
+        mock_process.process = MagicMock()
+        mock_subprocess.return_value = mock_process
+
+        await install_user_requirements("worker", mock_environ)
+
+        mock_subprocess.assert_called_once()
+        call_args = mock_subprocess.call_args[1]
+        assert '-c' in call_args['cmd']
+        assert mock_environ['AIRFLOW_CONSTRAINTS_FILE'] in call_args['cmd']
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_installation_error(mock_environ):
+    """Test handling of installation errors"""
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value="package1==1.0.0"), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess, \
+            patch('mwaa.utils.user_requirements.CompositeLogger') as mock_logger:
+        mock_process = MagicMock()
+        mock_process.process = MagicMock()
+        mock_process.process.returncode = 1
+        mock_subprocess.return_value = mock_process
+
+        logger_instance = MagicMock()
+        mock_logger.return_value = logger_instance
+
+        await install_user_requirements("worker", mock_environ)
+        logger_instance.error.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_hybrid_mode(mock_environ):
+    """Test installation in hybrid mode"""
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value="package1==1.0.0"), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+        mock_process = MagicMock()
+        mock_subprocess.return_value = mock_process
+
+        await install_user_requirements("hybrid", mock_environ)
+
+        assert mock_subprocess.call_args[1]['friendly_name'] == "worker_requirements"
+
+
+@pytest.mark.asyncio
+async def test_subprocess_timeout_configuration(mock_environ):
+    """Test subprocess timeout configuration"""
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value="package1==1.0.0"), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+        await install_user_requirements("worker", mock_environ)
+
+        conditions = mock_subprocess.call_args[1]['conditions']
+        timeout_condition = next(c for c in conditions if hasattr(c, 'timeout'))
+        assert timeout_condition.timeout == USER_REQUIREMENTS_MAX_INSTALL_TIME
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_file_read_error(mock_environ):
+    """Test handling of file read errors"""
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', side_effect=Exception("Read error")), \
+            patch('mwaa.utils.user_requirements.CompositeLogger') as mock_logger:
+        logger_instance = MagicMock()
+        mock_logger.return_value = logger_instance
+
+        await install_user_requirements("worker", mock_environ)
+        logger_instance.warning.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_command_types(mock_environ):
+    """Test different command types"""
+    commands = ["worker", "scheduler", "webserver"]
+    for cmd in commands:
+        with patch.dict(os.environ, mock_environ, clear=True), \
+                patch('os.path.isfile', return_value=True), \
+                patch('mwaa.utils.user_requirements._read_requirements_file', return_value="package1==1.0.0"), \
+                patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+            mock_process = MagicMock()
+            mock_subprocess.return_value = mock_process
+
+            await install_user_requirements(cmd, mock_environ)
+
+            assert mock_subprocess.call_args[1]['friendly_name'] == f"{cmd}_requirements"

--- a/tests/images/airflow/2.10.3/python/mwaa/config/test_setup_environment_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/config/test_setup_environment_2_10_3.py
@@ -1,0 +1,267 @@
+# test_setup_environment.py
+import pytest
+import json
+import os
+from unittest.mock import patch, mock_open, MagicMock
+from datetime import timedelta
+from mwaa.config.setup_environment import (
+    setup_environment_variables,
+    _execute_startup_script,
+    _export_env_variables,
+    _is_protected_os_environ,
+)
+from mwaa.subprocess.subprocess import Subprocess  # Add this import
+
+
+@pytest.fixture
+def mock_environ(monkeypatch):
+    """Fixture for mocking os.environ"""
+    test_environ = {
+        "AIRFLOW_ENV_ID": "test-env-id",
+        "AIRFLOW_ENV_NAME": "test-env",
+        "AIRFLOW_HOME": "/usr/local/airflow",
+        "AWS_DEFAULT_REGION": "us-east-1",
+        "PYTHONPATH": "/usr/local/airflow/dags",
+        "MWAA__CORE__TEST": "test-value",
+        "MWAA__CORE__STARTUP_SCRIPT_PATH": "../../2.10.3/startup/startup.sh",
+        "MWAA__CORE__TESTING_MODE": "true"
+    }
+    monkeypatch.setattr(os, "environ", test_environ)
+    return test_environ
+
+
+@pytest.fixture
+def mock_config_functions(monkeypatch):
+    """Fixture for mocking all configuration related functions"""
+    mock_functions = {
+        "get_essential_airflow_config": MagicMock(return_value={"ESSENTIAL_CONFIG": "value1"}),
+        "get_opinionated_airflow_config": MagicMock(return_value={"OP_CONFIG": "value2"}),
+        "get_essential_environ": MagicMock(return_value={"ESSENTIAL_ENV": "value3"}),
+        "get_opinionated_environ": MagicMock(return_value={"OP_ENV": "value4"}),
+        "get_user_airflow_config": MagicMock(return_value={"USER_CONFIG": "value5"})
+    }
+
+    for func_name, mock_func in mock_functions.items():
+        monkeypatch.setattr(f"mwaa.config.setup_environment.{func_name}", mock_func)
+
+    return mock_functions
+
+
+@pytest.fixture
+def temp_home_dir(tmp_path):
+    """Fixture for creating temporary home directory with .bashrc and .bash_profile"""
+    bashrc = tmp_path / ".bashrc"
+    bash_profile = tmp_path / ".bash_profile"
+    bashrc.touch()
+    bash_profile.touch()
+    return tmp_path
+
+
+# ------------------------
+# Environment Configuration Tests
+# ------------------------
+
+@pytest.mark.parametrize(
+    "key,expected",
+    [
+        ("MWAA__CORE__TEST", True),
+        ("AIRFLOW_ENV_ID", True),
+        ("AWS_DEFAULT_REGION", True),
+        ("CUSTOM_VAR", False),
+        ("PYTHONPATH", True),
+        ("RANDOM_VAR", False),
+        ("MWAA__CUSTOM__VAR", True),
+    ]
+)
+def test_is_protected_os_environ(key, expected):
+    """Test protected environment variable checking"""
+    assert _is_protected_os_environ(key) == expected
+
+
+def test_export_env_variables(temp_home_dir):
+    """Test environment variable export to shell files"""
+    test_environ = {
+        "TEST_VAR1": "value1",
+        "TEST_VAR2": "value2 with space",
+        "TEST_VAR3": "value3!@#$"
+    }
+
+    with patch("os.path.expanduser", return_value=str(temp_home_dir)):
+        _export_env_variables(test_environ)
+
+    # Verify both files
+    for filename in [".bashrc", ".bash_profile"]:
+        file_path = temp_home_dir / filename
+        content = file_path.read_text()
+
+        assert 'export TEST_VAR1=value1\n' in content
+        assert "export TEST_VAR2='value2 with space'\n" in content
+        assert "export TEST_VAR3='value3!@#$'\n" in content
+
+
+def test_setup_environment_variables(mock_environ, mock_config_functions):
+    """Test complete environment variable setup"""
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script, \
+            patch("mwaa.config.setup_environment._export_env_variables") as mock_export:
+        mock_execute_script.return_value = {"STARTUP_VAR": "value6"}
+
+        result = setup_environment_variables("worker", "Local")
+
+        # Verify all configurations are present and correctly merged
+        assert result["ESSENTIAL_CONFIG"] == "value1"
+        assert result["OP_CONFIG"] == "value2"
+        assert result["ESSENTIAL_ENV"] == "value3"
+        assert result["OP_ENV"] == "value4"
+        assert result["USER_CONFIG"] == "value5"
+        assert result["STARTUP_VAR"] == "value6"
+
+        # Verify protected variables are preserved
+        assert result["AIRFLOW_ENV_ID"] == "test-env-id"
+        assert result["AIRFLOW_HOME"] == "/usr/local/airflow"
+        assert result["AWS_DEFAULT_REGION"] == "us-east-1"
+
+        # Verify export was called
+        mock_export.assert_called_once_with(result)
+
+
+# ------------------------
+# Startup Script Tests
+# ------------------------
+
+def test_no_startup_script_path():
+    """Test when MWAA__CORE__STARTUP_SCRIPT_PATH is not set"""
+    with patch.dict(os.environ, {}, clear=True):
+        result = _execute_startup_script("worker", {})
+        assert result == {}
+
+
+def test_startup_script_not_found():
+    """Test when startup script file doesn't exist"""
+    with patch.dict(os.environ, {"MWAA__CORE__STARTUP_SCRIPT_PATH": "/nonexistent/path"}), \
+            patch('os.path.isfile', return_value=False):
+        result = _execute_startup_script("worker", {})
+        assert result == {}
+
+
+def test_uses_mocked_env(mock_environ):
+    """Ensure environment variables are correctly set"""
+    assert mock_environ["MWAA__CORE__TESTING_MODE"] == "true"
+
+
+@pytest.mark.parametrize("cmd,expected_logger", [
+    ("worker", "worker_startup"),
+    ("scheduler", "scheduler_startup"),
+    ("hybrid", "worker_startup")
+])
+def test_startup_script_execution(cmd, expected_logger, mock_environ):
+    """Test successful startup script execution with different commands"""
+    customer_env = {"CUSTOM_VAR": "value"}
+
+    with patch('os.path.isfile', return_value=True), \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess:
+        # Configure mock subprocess
+        mock_process = MagicMock()
+        mock_process.start.return_value = 0
+        MockSubprocess.return_value = mock_process
+
+        with patch('builtins.open', mock_open(read_data='{"CUSTOM_VAR": "value"}')):
+            result = _execute_startup_script(cmd, mock_environ)
+
+            assert result == customer_env
+            # Verify Subprocess was instantiated twice (for script and verification)
+            assert MockSubprocess.call_count == 2
+            # Verify start was called on each instance
+            assert mock_process.start.call_count == 2
+
+
+def test_failed_env_vars_reading(mock_environ):
+    """Test when reading customer environment variables fails"""
+    with patch('os.path.isfile', return_value=True), \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess, \
+            patch('builtins.open') as mock_file:
+        # Configure mock subprocess
+        mock_process = MagicMock()
+        mock_process.start.return_value = 0
+        MockSubprocess.return_value = mock_process
+
+        # Configure file mock to raise exception
+        mock_file.side_effect = Exception("Failed to read file")
+
+        with pytest.raises(Exception) as exc_info:
+            _execute_startup_script("worker", mock_environ)
+
+        assert ("Failed to read customer's environment variables from startup script: "
+                "Failed to read file") in str(exc_info.value)
+
+
+
+def test_missing_customer_env_vars_file(mock_environ):
+    """Test when customer environment variables file is not created"""
+    with patch('os.path.isfile') as mock_isfile, \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess:
+        # Configure mock subprocess
+        mock_process = MagicMock()
+        mock_process.start.return_value = 0
+        MockSubprocess.return_value = mock_process
+
+        # First True for startup script, second False for env vars file
+        mock_isfile.side_effect = [True, False]
+
+        with pytest.raises(Exception) as exc_info:
+            _execute_startup_script("worker", mock_environ)
+
+        assert ("Failed to access customer environment variables file: Service was unable "
+                "to create or locate /tmp/customer_env_vars.json") in str(exc_info.value)
+        assert MockSubprocess.call_count == 2
+
+
+@pytest.mark.parametrize("subprocess_error", [
+    Exception("Process failed"),
+    TimeoutError("Process timed out")
+])
+def test_subprocess_execution_errors(subprocess_error, mock_environ):
+    """Test handling of subprocess execution errors"""
+    with patch('os.path.isfile', return_value=True), \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess:
+        # Configure mock subprocess to raise error
+        mock_process = MagicMock()
+        mock_process.start.side_effect = subprocess_error
+        MockSubprocess.return_value = mock_process
+
+        with pytest.raises(type(subprocess_error)) as exc_info:
+            _execute_startup_script("worker", mock_environ)
+
+        assert str(subprocess_error) == str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "command,executor_type",
+    [
+        ("worker", "Local"),
+        ("scheduler", "Celery"),
+        ("webserver", "Local"),
+        ("hybrid", "Celery")
+    ]
+)
+def test_setup_environment_variables_different_commands(
+        command,
+        executor_type,
+        mock_environ,
+        mock_config_functions
+):
+    """Test environment setup with different commands and executor types"""
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script:
+        mock_execute_script.return_value = {}
+
+        result = setup_environment_variables(command, executor_type)
+
+        # Verify essential configurations are present
+        assert "ESSENTIAL_CONFIG" in result
+        assert "ESSENTIAL_ENV" in result
+
+        # Verify the execute_startup_script was called correctly
+        mock_execute_script.assert_called_once()
+        args, _ = mock_execute_script.call_args
+        assert args[0] == command
+        # Verify the environment dict was passed (without checking exact contents)
+        assert isinstance(args[1], dict)

--- a/tests/images/airflow/2.10.3/python/mwaa/test_entrypoint_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/test_entrypoint_2_10_3.py
@@ -1,101 +1,236 @@
-import os
+# test_entrypoint.py
 import pytest
+import asyncio
+import os
+import sys
+from unittest.mock import patch, MagicMock, call, AsyncMock
+from datetime import datetime
+from botocore.exceptions import ClientError
+
 import mwaa.entrypoint as entrypoint
+from mwaa.entrypoint import (
+    _setup_console_log_level,
+    _configure_root_logger,
+    airflow_db_init,
+    create_airflow_user,
+    create_queue,
+    main
+)
 
-from unittest.mock import patch, mock_open, MagicMock
 
-# # ------------------------
-# # Fixtures
-# # ------------------------
+# ------------------------
+# Fixtures
+# ------------------------
 @pytest.fixture
-def mock_environ():
-    return {
-        "MWAA__CORE__STARTUP_SCRIPT_PATH": "../../2.10.3/startup/startup.sh",
+def mock_environ(monkeypatch):
+    """Basic environment variables fixture"""
+    env_vars = {
+        "MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL": "INFO",
+        "MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL": "INFO",
+        "MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_LEVEL": "INFO",
+        "MWAA__CORE__EXECUTOR_TYPE": "CeleryExecutor",
+        "MWAA__CORE__AUTH_TYPE": "testing",
+        "MWAA__CORE__CREATED_AT": "Mon Sep 11 00:00:00 UTC 2024",
+        "MWAA__CORE__TESTING_MODE": "true",
+        # Database configuration
+        "MWAA__DB__POSTGRES_HOST": "localhost",
+        "MWAA__DB__POSTGRES_PORT": "5432",
+        "MWAA__DB__POSTGRES_DB": "airflow",
+        "MWAA__DB__POSTGRES_USER": "airflow",
+        "MWAA__DB__POSTGRES_PASSWORD": "airflow",
+        "MWAA__DB__POSTGRES_SSLMODE": "disable",
+        "PYTHONPATH": os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     }
+    monkeypatch.setattr(os, "environ", env_vars)
+    return env_vars
+
+
+@pytest.fixture
+def mock_boto3_client():
+    """Mock boto3 client for SQS operations"""
+    with patch('boto3.client') as mock_client:
+        yield mock_client
+
+
+@pytest.fixture
+def mock_db_utils():
+    """Mock database utilities"""
+    with patch('mwaa.utils.dblock.create_engine') as mock_engine, \
+            patch('mwaa.utils.dblock.get_db_connection_string', return_value='postgresql://localhost/airflow'):
+        engine = MagicMock()
+        mock_engine.return_value = engine
+        yield engine
+
 
 # ------------------------
 # Test Cases
 # ------------------------
-def test_no_startup_script_path():
-    """Test when MWAA__CORE__STARTUP_SCRIPT_PATH is not set"""
-    with patch.dict(os.environ, {}, clear=True):
-        result = entrypoint.execute_startup_script("worker", {})
-        assert result == {}
 
-
-def test_startup_script_not_found():
-    """Test when startup script file doesn't exist"""
-    with patch.dict(os.environ, {"MWAA__CORE__STARTUP_SCRIPT_PATH": "/nonexistent/path"}), \
-            patch('os.path.isfile', return_value=False):
-        result = entrypoint.execute_startup_script("worker", {})
-        assert result == {}
-
-
-def test_uses_mocked_env():
-    """Ensure environment variables are correctly set"""
-    assert "true" in os.environ["MWAA__CORE__TESTING_MODE"]
-
-
-@pytest.mark.parametrize("cmd,expected_logger", [
-    ("worker", "worker_startup"),
-    ("scheduler", "scheduler_startup"),
-    ("hybrid", "worker_startup")
+@pytest.mark.parametrize("command,expected_level", [
+    ("scheduler", "INFO"),
+    ("worker", "INFO"),
+    ("webserver", "INFO"),
+    ("unknown", "INFO"),
 ])
-def test_startup_script_execution(cmd, expected_logger, mock_environ):
-    """Test successful startup script execution with different commands"""
-    customer_env = {"CUSTOM_VAR": "value"}
-
-    with patch('os.path.isfile', return_value=True), \
-            patch('mwaa.entrypoint.Subprocess') as mock_subprocess, \
-            patch('builtins.open', mock_open(read_data='{"CUSTOM_VAR": "value"}')):
-        mock_process = MagicMock()
-        mock_subprocess.return_value = mock_process
-
-        result = entrypoint.execute_startup_script(cmd, mock_environ)
-        assert result == customer_env
+def test_setup_console_log_level(command, expected_level, mock_environ):
+    """Test console log level setup"""
+    with patch.dict(os.environ, mock_environ, clear=True):
+        _setup_console_log_level(command)
+        assert os.environ['AIRFLOW_CONSOLE_LOG_LEVEL'] == expected_level
 
 
-def test_failed_env_vars_reading(mock_environ):
-    """Test when reading customer environment variables fails"""
-    with patch('os.path.isfile', return_value=True), \
-            patch('mwaa.entrypoint.Subprocess') as mock_subprocess, \
-            patch('builtins.open', mock_open()) as mock_file:
-        mock_file.side_effect = Exception("Failed to read file")
-        mock_process = MagicMock()
-        mock_subprocess.return_value = mock_process
-
-        with pytest.raises(Exception) as exc_info:
-            entrypoint.execute_startup_script("worker", mock_environ)
-
-        assert "Failed to read customer's environment variables" in str(exc_info.value)
+def test_configure_root_logger(mock_environ):
+    """Test root logger configuration"""
+    with patch('logging.config.dictConfig') as mock_dict_config, \
+            patch.dict(os.environ, mock_environ, clear=True):
+        _configure_root_logger("scheduler")
+        mock_dict_config.assert_called_once()
 
 
-def test_missing_customer_env_vars_file(mock_environ):
-    """Test when customer environment variables file is not created"""
-    with patch('os.path.isfile') as mock_isfile, \
-            patch('mwaa.entrypoint.Subprocess') as mock_subprocess:
-        mock_isfile.side_effect = [True, False]
-        mock_process = MagicMock()
-        mock_subprocess.return_value = mock_process
+@pytest.mark.asyncio
+async def test_airflow_db_init(mock_db_utils):
+    """Test Airflow database initialization"""
+    environ = {"PYTHONPATH": os.environ.get("PYTHONPATH", "")}
 
-        with pytest.raises(Exception) as exc_info:
-            entrypoint.execute_startup_script("worker", mock_environ)
+    async def mock_run_command(cmd, env=None):
+        return 0
 
-        assert ("Failed to access customer environment variables file: Service was unable "
-                "to create or locate /tmp/customer_env_vars.json") in str(exc_info.value)
+    with patch('mwaa.entrypoint.run_command', side_effect=mock_run_command) as mock_cmd:
+        await airflow_db_init(environ)
+        mock_cmd.assert_called_once_with(
+            "python3 -m mwaa.database.migrate",
+            env=environ
+        )
 
 
-@pytest.mark.parametrize("subprocess_error", [
-    Exception("Process failed"),
-    TimeoutError("Process timed out")
-])
-def test_subprocess_execution_errors(subprocess_error, mock_environ):
-    """Test handling of subprocess execution errors"""
-    with patch('os.path.isfile', return_value=True), \
-            patch('mwaa.entrypoint.Subprocess') as mock_subprocess:
-        mock_process = MagicMock()
-        mock_process.start.side_effect = subprocess_error
-        mock_subprocess.return_value = mock_process
 
-        with pytest.raises(Exception):
-            entrypoint.execute_startup_script("worker", mock_environ)
+@pytest.fixture
+def mock_run_command():
+    """Mock run_command with AsyncMock"""
+
+    async def mock_run(*args, **kwargs):
+        if 'stdout_logging_method' in kwargs in args[0]:
+            kwargs['stdout_logging_method']("128")
+        return 0
+
+    with patch('mwaa.entrypoint.run_command') as mock:
+        mock.side_effect = mock_run
+        yield mock
+
+
+@pytest.mark.asyncio
+async def test_create_airflow_user(mock_db_utils, mock_environ):
+    """Test Airflow user creation"""
+
+    async def mock_run_command(cmd, env=None):
+        return 0
+
+    with patch('mwaa.entrypoint.run_command', side_effect=mock_run_command) as mock_cmd:
+        await create_airflow_user(mock_environ)
+        assert mock_cmd.called
+        assert "airflow users create" in mock_cmd.call_args[0][0]
+
+
+def test_create_queue_when_not_required(mock_environ, mock_db_utils):
+    """Test queue creation when not required"""
+    with patch('mwaa.entrypoint.should_create_queue', return_value=False):
+        create_queue()
+
+
+def test_create_existing_queue(mock_environ, mock_db_utils, mock_boto3_client):
+    """Test handling of existing queue"""
+    with patch('mwaa.entrypoint.should_create_queue', return_value=True), \
+            patch('mwaa.entrypoint.get_sqs_queue_name', return_value='test-queue'):
+        mock_sqs = MagicMock()
+        mock_boto3_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.return_value = {"QueueUrl": "test-url"}
+
+        create_queue()
+
+        mock_sqs.get_queue_url.assert_called_once_with(QueueName='test-queue')
+        mock_sqs.create_queue.assert_not_called()
+
+
+def test_create_new_queue(mock_environ, mock_db_utils, mock_boto3_client):
+    """Test creation of new queue"""
+    with patch('mwaa.entrypoint.should_create_queue', return_value=True), \
+            patch('mwaa.entrypoint.get_sqs_queue_name', return_value='test-queue'):
+        mock_sqs = MagicMock()
+        mock_boto3_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.side_effect = ClientError(
+            {'Error': {'Message': 'The specified queue does not exist.'}},
+            'GetQueueUrl'
+        )
+
+        create_queue()
+
+        mock_sqs.create_queue.assert_called_once_with(QueueName='test-queue')
+
+
+@pytest.mark.asyncio
+async def test_main_valid_command(mock_environ, mock_db_utils):
+    """Test main function with valid command"""
+    test_args = ['script.py', 'scheduler']
+
+    async def mock_run_command(cmd, env=None):
+        return 0
+
+    with patch.dict(os.environ, mock_environ), \
+            patch.object(sys, 'argv', test_args), \
+            patch('mwaa.entrypoint.run_command', side_effect=mock_run_command), \
+            patch('mwaa.entrypoint.setup_environment_variables') as mock_setup_env, \
+            patch('mwaa.entrypoint.install_user_requirements') as mock_install_req, \
+            patch('mwaa.entrypoint.create_queue') as mock_create_queue, \
+            patch('mwaa.entrypoint.execute_command') as mock_execute:
+        mock_setup_env.return_value = mock_environ
+        mock_install_req.return_value = None
+
+        await main()
+
+        mock_setup_env.assert_called_once()
+        mock_install_req.assert_called_once()
+        mock_create_queue.assert_called_once()
+        mock_execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_main_invalid_command():
+    """Test main function with invalid command"""
+    test_args = ['script.py', 'invalid']
+    with patch.object(sys, 'argv', test_args):
+        with pytest.raises(SystemExit):
+            await main()
+
+
+@pytest.mark.asyncio
+async def test_main_test_requirements(mock_environ, mock_db_utils):
+    """Test main function with test-requirements command"""
+    test_args = ['script.py', 'test-requirements']
+    with patch.dict(os.environ, mock_environ), \
+            patch.object(sys, 'argv', test_args), \
+            patch('mwaa.entrypoint.setup_environment_variables') as mock_setup_env, \
+            patch('mwaa.entrypoint.install_user_requirements') as mock_install_req:
+        mock_setup_env.return_value = mock_environ
+
+        await main()
+
+        mock_setup_env.assert_called_once()
+        mock_install_req.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_main_missing_arguments():
+    """Test main function with missing arguments"""
+    test_args = ['script.py']
+    with patch.object(sys, 'argv', test_args):
+        with pytest.raises(SystemExit):
+            await main()
+
+
+def test_import_guard():
+    """Test import guard functionality"""
+    with patch.dict(os.environ, {'MWAA__CORE__TESTING_MODE': 'false'}, clear=True), \
+            patch('sys.exit') as mock_exit:
+        import importlib
+        importlib.reload(entrypoint)
+        mock_exit.assert_called_once_with(1)

--- a/tests/images/airflow/2.10.3/python/mwaa/test_execute_command_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/test_execute_command_2_10_3.py
@@ -1,0 +1,148 @@
+import pytest
+import os
+from unittest.mock import patch, MagicMock, mock_open
+
+# Set CONTAINER_START_TIME before importing the module
+TEST_CONTAINER_START_TIME = 1234567890.0
+with patch.dict('os.environ', {'CONTAINER_START_TIME': str(TEST_CONTAINER_START_TIME)}):
+    from mwaa.execute_command import (
+        execute_command,
+        HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT
+    )
+
+
+# ------------------------
+# Fixtures
+# ------------------------
+@pytest.fixture
+def mock_environ():
+    """Basic environment variables fixture"""
+    return {
+        "AIRFLOW_HOME": "/usr/local/airflow",
+        "MWAA__CORE__TASK_MONITORING_ENABLED": "false",
+        "MWAA__CORE__TERMINATE_IF_IDLE": "false",
+        "MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED": "false",
+        "MWAA__HEALTH_MONITORING__ENABLE_SIDECAR_HEALTH_MONITORING": "false",
+        "MWAA__HYBRID_CONTAINER__SIGTERM_PATIENCE_INTERVAL": "150",
+        "MWAA__DB__POSTGRES_HOST": "localhost",
+        "MWAA__DB__POSTGRES_PORT": "5432",
+        "MWAA__DB__POSTGRES_DB": "airflow",
+        "MWAA__DB__POSTGRES_SSLMODE": "disable"
+    }
+
+
+@pytest.fixture
+def mock_subprocess():
+    """Mock Subprocess"""
+    process = MagicMock()
+    process.start.return_value = 0
+    process.process = MagicMock()
+    process.process.returncode = 0
+
+    with patch('mwaa.subprocess.subprocess.Subprocess', return_value=process) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_run_subprocesses():
+    """Mock run_subprocesses"""
+    with patch('mwaa.execute_command.run_subprocesses') as mock:
+        yield mock
+
+def remove_celery_state():
+    try:
+        os.remove("/celery_state_")
+    except FileNotFoundError:
+        pass
+
+
+@pytest.fixture
+def mock_file_operations():
+    """Mock file-related operations"""
+    with patch("os.path.exists", return_value=False), \
+         patch("builtins.open", mock_open()), \
+         patch("os.remove"):
+        yield
+
+
+# ------------------------
+# Test Cases
+# ------------------------
+
+def test_execute_command_shell(mock_environ):
+    """Test shell command execution"""
+    with patch('os.execlpe') as mock_exec:
+        execute_command("shell", mock_environ, TEST_CONTAINER_START_TIME)
+        mock_exec.assert_called_once_with("/bin/bash", "/bin/bash", mock_environ)
+
+
+def test_execute_command_spy(mock_environ):
+    """Test spy command execution"""
+    with patch('time.sleep', side_effect=KeyboardInterrupt) as mock_sleep:
+        with pytest.raises(KeyboardInterrupt):
+            execute_command("spy", mock_environ, TEST_CONTAINER_START_TIME)
+        mock_sleep.assert_called_once_with(1)
+
+
+@pytest.mark.parametrize("command,expected_subprocesses", [
+    ("scheduler", 3),  # scheduler, dag-processor, triggerer
+    ("worker", 1),  # celery worker
+    ("webserver", 1),  # webserver
+    ("hybrid", 4),  # scheduler, dag-processor, triggerer, worker
+])
+def test_execute_command_airflow_components(command, expected_subprocesses, mock_environ, mock_run_subprocesses):
+    """Test execution of different Airflow components"""
+    execute_command(command, mock_environ, TEST_CONTAINER_START_TIME)
+    assert mock_run_subprocesses.called
+    subprocess_calls = mock_run_subprocesses.call_args[0][0]
+    assert len(subprocess_calls) == expected_subprocesses
+
+
+def test_execute_command_invalid(mock_environ):
+    """Test invalid command execution"""
+    with pytest.raises(ValueError, match="Invalid command"):
+        execute_command("invalid", mock_environ, TEST_CONTAINER_START_TIME)
+
+
+def test_execute_command_worker_idle_termination(mock_environ, mock_run_subprocesses):
+    """Test worker with idle termination enabled"""
+    with patch.dict(os.environ, {"MWAA__CORE__TERMINATE_IF_IDLE": "true"}):
+        execute_command("worker", mock_environ, TEST_CONTAINER_START_TIME)
+    mock_run_subprocesses.assert_called()
+
+
+def test_execute_command_worker_signal_handling(mock_environ, mock_run_subprocesses):
+    """Test worker with signal handling enabled"""
+    with patch.dict(os.environ, {"MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED": "true"}):
+        execute_command("worker", mock_environ, TEST_CONTAINER_START_TIME)
+    mock_run_subprocesses.assert_called()
+
+
+def test_execute_command_container_start_time(mock_environ, mock_run_subprocesses):
+    """Test container start time is properly set"""
+    test_time = 9876543210.0
+    execute_command("scheduler", mock_environ, test_time)
+    from mwaa.execute_command import CONTAINER_START_TIME
+    assert CONTAINER_START_TIME == test_time
+
+
+@patch('mwaa.celery.task_monitor.WorkerTaskMonitor')
+@patch('multiprocessing.shared_memory.SharedMemory')
+def test_execute_command_task_monitoring_enabled(mock_shared_memory, mock_worker_monitor, mock_environ,
+                                                 mock_run_subprocesses):
+    """Test execute_command when task monitoring is enabled in environment variables"""
+    # Setup the mocks
+    mock_worker_instance = MagicMock()
+    mock_worker_monitor.return_value = mock_worker_instance
+
+    mock_shared_memory_instance = MagicMock()
+    mock_shared_memory.return_value = mock_shared_memory_instance
+
+    with patch.dict(os.environ, {"MWAA__CORE__TASK_MONITORING_ENABLED": "true"}, clear=True):
+        execute_command("worker", mock_environ, TEST_CONTAINER_START_TIME)
+
+    # Verify run_subprocesses was called
+    mock_run_subprocesses.assert_called()
+
+
+

--- a/tests/images/airflow/2.10.3/python/mwaa/utils/test_user_requirements_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/utils/test_user_requirements_2_10_3.py
@@ -1,0 +1,198 @@
+# test_user_requirements.py
+import pytest
+import os
+from unittest.mock import patch, mock_open, MagicMock
+from datetime import timedelta
+
+from mwaa.utils.user_requirements import (
+    install_user_requirements,
+    _read_requirements_file,
+    _requirements_has_constraints,
+    USER_REQUIREMENTS_MAX_INSTALL_TIME
+)
+
+
+# ------------------------
+# Fixtures
+# ------------------------
+@pytest.fixture
+def mock_environ():
+    """Basic environment variables fixture"""
+    return {
+        "MWAA__CORE__REQUIREMENTS_PATH": "/path/to/requirements.txt",
+        "AIRFLOW_CONSTRAINTS_FILE": "/path/to/constraints.txt",
+        "MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL": "INFO",
+        "MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL": "INFO",
+    }
+
+
+@pytest.fixture
+def mock_subprocess():
+    """Mock Subprocess class"""
+    subprocess_instance = MagicMock()
+    subprocess_instance.process = MagicMock()
+    subprocess_instance.process.returncode = 0
+    subprocess_instance.start = MagicMock(return_value=0)
+
+    with patch('mwaa.utils.user_requirements.Subprocess', return_value=subprocess_instance) as mock:
+        yield mock, subprocess_instance
+
+
+@pytest.fixture
+def mock_composite_logger():
+    """Mock CompositeLogger"""
+    logger_instance = MagicMock()
+    with patch('mwaa.utils.user_requirements.CompositeLogger', return_value=logger_instance) as mock:
+        yield mock, logger_instance
+
+
+# ------------------------
+# Test Cases
+# ------------------------
+
+def test_read_requirements_file():
+    """Test reading requirements file"""
+    content = "package1==1.0.0\npackage2>=2.0.0"
+    with patch('builtins.open', mock_open(read_data=content.encode())):
+        result = _read_requirements_file("requirements.txt")
+        assert result == content
+
+
+@pytest.mark.parametrize("content,expected", [
+    ("package1==1.0.0\n-c constraints.txt", True),
+    ("package1==1.0.0\npackage2>=2.0.0", False),
+    ("# -c constraints.txt\npackage1==1.0.0", True),
+])
+def test_requirements_has_constraints(content, expected):
+    """Test constraint detection in requirements file"""
+    with patch('mwaa.utils.user_requirements._read_requirements_file', return_value=content):
+        assert _requirements_has_constraints("requirements.txt") == expected
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_no_file(mock_environ):
+    """Test when no requirements file is specified"""
+    with patch.dict(os.environ, {}, clear=True):
+        await install_user_requirements("worker", {})
+        # Should complete without error
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_with_constraints(mock_environ):
+    """Test installation with constraints"""
+    requirements_content = "package1==1.0.0\n-c constraints.txt"
+
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value=requirements_content), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+        mock_process = MagicMock()
+        mock_process.process = MagicMock()
+        mock_subprocess.return_value = mock_process
+
+        await install_user_requirements("worker", mock_environ)
+
+        mock_subprocess.assert_called_once()
+        call_args = mock_subprocess.call_args[1]
+        assert call_args['cmd'] == ['safe-pip-install', '-r', mock_environ['MWAA__CORE__REQUIREMENTS_PATH']]
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_without_constraints(mock_environ):
+    """Test installation without constraints"""
+    requirements_content = "package1==1.0.0"
+
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value=requirements_content), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+        mock_process = MagicMock()
+        mock_process.process = MagicMock()
+        mock_subprocess.return_value = mock_process
+
+        await install_user_requirements("worker", mock_environ)
+
+        mock_subprocess.assert_called_once()
+        call_args = mock_subprocess.call_args[1]
+        assert '-c' in call_args['cmd']
+        assert mock_environ['AIRFLOW_CONSTRAINTS_FILE'] in call_args['cmd']
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_installation_error(mock_environ):
+    """Test handling of installation errors"""
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value="package1==1.0.0"), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess, \
+            patch('mwaa.utils.user_requirements.CompositeLogger') as mock_logger:
+        mock_process = MagicMock()
+        mock_process.process = MagicMock()
+        mock_process.process.returncode = 1
+        mock_subprocess.return_value = mock_process
+
+        logger_instance = MagicMock()
+        mock_logger.return_value = logger_instance
+
+        await install_user_requirements("worker", mock_environ)
+        logger_instance.error.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_hybrid_mode(mock_environ):
+    """Test installation in hybrid mode"""
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value="package1==1.0.0"), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+        mock_process = MagicMock()
+        mock_subprocess.return_value = mock_process
+
+        await install_user_requirements("hybrid", mock_environ)
+
+        assert mock_subprocess.call_args[1]['friendly_name'] == "worker_requirements"
+
+
+@pytest.mark.asyncio
+async def test_subprocess_timeout_configuration(mock_environ):
+    """Test subprocess timeout configuration"""
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value="package1==1.0.0"), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+        await install_user_requirements("worker", mock_environ)
+
+        conditions = mock_subprocess.call_args[1]['conditions']
+        timeout_condition = next(c for c in conditions if hasattr(c, 'timeout'))
+        assert timeout_condition.timeout == USER_REQUIREMENTS_MAX_INSTALL_TIME
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_file_read_error(mock_environ):
+    """Test handling of file read errors"""
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', side_effect=Exception("Read error")), \
+            patch('mwaa.utils.user_requirements.CompositeLogger') as mock_logger:
+        logger_instance = MagicMock()
+        mock_logger.return_value = logger_instance
+
+        await install_user_requirements("worker", mock_environ)
+        logger_instance.warning.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_command_types(mock_environ):
+    """Test different command types"""
+    commands = ["worker", "scheduler", "webserver"]
+    for cmd in commands:
+        with patch.dict(os.environ, mock_environ, clear=True), \
+                patch('os.path.isfile', return_value=True), \
+                patch('mwaa.utils.user_requirements._read_requirements_file', return_value="package1==1.0.0"), \
+                patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+            mock_process = MagicMock()
+            mock_subprocess.return_value = mock_process
+
+            await install_user_requirements(cmd, mock_environ)
+
+            assert mock_subprocess.call_args[1]['friendly_name'] == f"{cmd}_requirements"


### PR DESCRIPTION
*Issue #, if available:*
When using airflow versions 2.9.2 and above customer are unable to see error logs when they set their loglevel to `WARNING` or above. The root cause is that in subprocess.py, the line `self.process_logger.info(line.decode("utf-8"))` overrides the log level coming from airflow stream to INFO in [subprocess.py](https://github.com/aws/amazon-mwaa-docker-images/blob/main/images/airflow/2.9.2/python/mwaa/subprocess/subprocess.py#L217).

*Description of changes:*
- Setting process logger level to `DEBUG` to emit all logs and setting root logger to customer's log level to respect customer's log level.
- Refactoring `entrypoint.py` to resolve circular dependency issue and breaking down its logic into different files so all files have single responsibility such as:
     - `user_requirements.py`: Installing user requirements.
     - `execute_command.py`: Logic for executing all the subprocesses
     - `setup_environment.py`: Running the startup script and setting up environment variables

*Testing*
- Added unit tests for all refactored code. 
- Ran log heavy dag on the refactored image code by using local docker.
- Exported environment variable using startup script and verified that it set correctly.

This PR is for V 2.10.1 and 2.10.3. Fix for v2.9.2 has already reached prod.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
