### PR TITLE
Enable trufflehog scan for tests (#236)

### DIFF
--- a/quality-checks/trufflehog_scan.sh
+++ b/quality-checks/trufflehog_scan.sh
@@ -29,13 +29,9 @@ check_dir() {
     # shellcheck source=/dev/null
     source "${venv_dir}/bin/activate"
 
-    # Create a temporary exclusion file for TruffleHog
-    EXCLUDE_FILE=$(mktemp)
-    echo "tests/" > "$EXCLUDE_FILE"
-
     # Run TruffleHog to scan for secrets
     echo "Running TruffleHog to scan for secrets..."
-    if ! (trufflehog filesystem --repo_path "${dir}" --entropy=False -x "$EXCLUDE_FILE"); then
+    if ! (trufflehog filesystem --repo_path "${dir}" --entropy=False); then
         echo "TruffleHog detected potential secrets."
         status=1
     else


### PR DESCRIPTION
*Issue* [#236](https://github.com/aws/amazon-mwaa-docker-images/issues/236)

*Description of changes:*
Enable trufflehog scanning for tests folder. 
Removes tests from excluded files to enable scanning.

*Testing*
Trufflescan test and all other quality checks successfully executed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
