### PR TITLE
Rename MWAA__CORE__TARGET_VERSION to MWAA__DB__AIRFLOW_TARGET_VERSION

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.10.1/python/mwaa/database/migrate_with_downgrade.py
@@ -57,7 +57,7 @@ def _migrate_db():
         logging.info("The database is now migrated.")
 
 def _check_downgrade_db():
-    target_version = os.environ.get("MWAA__CORE__TARGET_VERSION", None)
+    target_version = os.environ.get("MWAA__DB__AIRFLOW_TARGET_VERSION", None)
     current_version = os.environ.get("AIRFLOW_VERSION", None)
     if target_version and current_version and Version(target_version) < Version(current_version):
         logging.info(f"Downgrading the database to {target_version}. Downgrading...")

--- a/images/airflow/2.10.3/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.10.3/python/mwaa/database/migrate_with_downgrade.py
@@ -57,7 +57,7 @@ def _migrate_db():
         logging.info("The database is now migrated.")
 
 def _check_downgrade_db():
-    target_version = os.environ.get("MWAA__CORE__TARGET_VERSION", None)
+    target_version = os.environ.get("MWAA__DB__AIRFLOW_TARGET_VERSION", None)
     current_version = os.environ.get("AIRFLOW_VERSION", None)
     if target_version and current_version and Version(target_version) < Version(current_version):
         logging.info(f"Downgrading the database to {target_version}. Downgrading...")

--- a/images/airflow/2.9.2/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.9.2/python/mwaa/database/migrate_with_downgrade.py
@@ -57,7 +57,7 @@ def _migrate_db():
         logging.info("The database is now migrated.")
 
 def _check_downgrade_db():
-    target_version = os.environ.get("MWAA__CORE__TARGET_VERSION", None)
+    target_version = os.environ.get("MWAA__DB__AIRFLOW_TARGET_VERSION", None)
     current_version = os.environ.get("AIRFLOW_VERSION", None)
     if target_version and current_version and Version(target_version) < Version(current_version):
         logging.info(f"Downgrading the database to {target_version}. Downgrading...")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update the naming for the Airflow database migrate target version to `MWAA__DB__AIRFLOW_TARGET_VERSION`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
