### PR TITLE
Update essential web server config 3.0.1

### DIFF
--- a/images/airflow/3.0.1/python/mwaa/config/airflow.py
+++ b/images/airflow/3.0.1/python/mwaa/config/airflow.py
@@ -308,7 +308,7 @@ def _get_essential_airflow_webserver_config() -> Dict[str, str]:
             )
 
     return {
-        "AIRFLOW__WEBSERVER__CONFIG_FILE": "/python/mwaa/webserver/webserver_config.py",
+        "AIRFLOW__FAB__CONFIG_FILE": "/python/mwaa/webserver/webserver_config.py",
         **flask_secret_key,
     }
 


### PR DESCRIPTION
*Description of changes:*

`AIRFLOW__WEBSERVER__CONFIG_FILE ` has been removed from [airflow 3 configuration](https://airflow.apache.org/docs/apache-airflow/3.0.1/configurations-ref.html#web-server)

To specify the web server config path, we should rely on `AIRFLOW__FAB__CONFIG_FILE `. See [Fab Config Reference](https://airflow.apache.org/docs/apache-airflow-providers-fab/2.0.2/configurations-ref.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
