### PR TITLE
Updated entrypoint & healthcheck logic  to handle container exists during grace period

### DIFF
--- a/images/airflow/2.10.1/healthcheck.py
+++ b/images/airflow/2.10.1/healthcheck.py
@@ -4,6 +4,7 @@ Module for running healthcheck on airflow processes.
 
 import subprocess
 import sys
+import os
 from enum import Enum
 
 class ExitStatus(Enum):
@@ -67,6 +68,12 @@ def get_airflow_process_command(airflow_component: str):
     exit_with_status(ExitStatus.INVALID_AIRFLOW_COMPONENT)
 
 if __name__ == '__main__':
+
+    # Check if an 'container_unhealthy' marker file is present
+    if os.path.exists("/tmp/container_unhealthy"):
+        print("/tmp/container_unhealthy file found - marking as unhealthy.")
+        exit_with_status(ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY)
+
     if len(sys.argv) != 2:
         print("Usage: python3 healthcheck.py <airflow_component>")
         exit_with_status(ExitStatus.INSUFFICIENT_ARGUMENTS)

--- a/images/airflow/2.10.1/healthcheck.py
+++ b/images/airflow/2.10.1/healthcheck.py
@@ -69,8 +69,8 @@ def get_airflow_process_command(airflow_component: str):
 
 def main():
     # Check if an 'container_unhealthy' marker file is present
-    if os.path.exists("mwaa/container_unhealthy"):
-        print("mwaa/container_unhealthy file found - marking as unhealthy.")
+    if os.path.exists("/tmp/mwaa/container_unhealthy"):
+        print("/tmp/mwaa/container_unhealthy file found - marking as unhealthy.")
         exit_with_status(ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY)
 
     if len(sys.argv) != 2:

--- a/images/airflow/2.10.1/healthcheck.py
+++ b/images/airflow/2.10.1/healthcheck.py
@@ -68,6 +68,9 @@ def get_airflow_process_command(airflow_component: str):
     exit_with_status(ExitStatus.INVALID_AIRFLOW_COMPONENT)
 
 def main():
+    """
+    Main function to check the health of Airflow components.
+    """
     # Check if an 'container_unhealthy' marker file is present
     if os.path.exists("/tmp/mwaa/container_unhealthy"):
         print("/tmp/mwaa/container_unhealthy file found - marking as unhealthy.")

--- a/images/airflow/2.10.1/healthcheck.py
+++ b/images/airflow/2.10.1/healthcheck.py
@@ -67,11 +67,10 @@ def get_airflow_process_command(airflow_component: str):
 
     exit_with_status(ExitStatus.INVALID_AIRFLOW_COMPONENT)
 
-if __name__ == '__main__':
-
+def main():
     # Check if an 'container_unhealthy' marker file is present
-    if os.path.exists("/tmp/container_unhealthy"):
-        print("/tmp/container_unhealthy file found - marking as unhealthy.")
+    if os.path.exists("mwaa/container_unhealthy"):
+        print("mwaa/container_unhealthy file found - marking as unhealthy.")
         exit_with_status(ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY)
 
     if len(sys.argv) != 2:
@@ -87,4 +86,5 @@ if __name__ == '__main__':
         print(f"Airflow process {airflow_component} not found.")
         exit_with_status(ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY)
 
-
+if __name__ == '__main__':
+    main()

--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -69,6 +69,27 @@ def _configure_root_logger(command: str):
     from mwaa.logging.config import LOGGING_CONFIG
     logging.config.dictConfig(LOGGING_CONFIG)
 
+def _mark_as_unhealthy():
+    # Create a health check marker file
+
+    # max of (service grace period or container health check startPeriod) + health check (retries * interval)
+    # 1020 + 10 * 75 = ~1800
+    max_timeout = 1800
+
+    try:
+        open('/mwaa/container_unhealthy', 'w').close()
+        logger.error("Marked container as unhealthy via /mwaa/container_unhealthy")
+    except Exception as file_err:
+        logger.error("Failed to write /mwaa/container_unhealthy: %s", str(file_err))
+
+    container_runtime = time.time() - CONTAINER_START_TIME
+    if container_runtime < max_timeout:
+        logger.info("Container running for %s seconds, still in grace period. Sleeping for %s seconds.", 
+                   int(container_runtime), max_timeout)
+        time.sleep(max_timeout)
+    else:
+        logger.info("Container running for %s seconds, not in grace period. Skipping sleep.",
+                   int(container_runtime))
 
 # TODO Fix the "type: ignore"s in this file.
 
@@ -233,16 +254,7 @@ if __name__ == "__main__":
         asyncio.run(main())
     except Exception as ex:
         logger.error("Fatal error in entrypoint: %s", str(ex), exc_info=True)
-        # Create a health check marker file
-        try:
-            with open("/tmp/container_unhealthy", "w") as f:
-                f.write("Container encountered fatal error\n")
-            logger.error("Marked container as unhealthy via /tmp/container_unhealthy")
-        except Exception as file_err:
-            logger.error("Failed to write /tmp/container_unhealthy: %s", str(file_err))
-        # max of (service grace period or container health check startPeriod) + health check (retries * interval)
-        # 1020 + 10 * 75 = ~1800
-        time.sleep(1800)
+        _mark_as_unhealthy()
 elif os.environ.get("MWAA__CORE__TESTING_MODE", "false") != "true":
     logger.error("This module cannot be imported.")
     sys.exit(1)

--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -229,7 +229,20 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except Exception as ex:
+        logger.error("Fatal error in entrypoint: %s", str(ex), exc_info=True)
+        # Create a health check marker file
+        try:
+            with open("/tmp/container_unhealthy", "w") as f:
+                f.write("Container encountered fatal error\n")
+            logger.error("Marked container as unhealthy via /tmp/container_unhealthy")
+        except Exception as file_err:
+            logger.error("Failed to write /tmp/container_unhealthy: %s", str(file_err))
+        # max of (service grace period or container health check startPeriod) + health check (retries * interval)
+        # 1020 + 10 * 75 = ~1800
+        time.sleep(1800)
 elif os.environ.get("MWAA__CORE__TESTING_MODE", "false") != "true":
     logger.error("This module cannot be imported.")
     sys.exit(1)

--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -73,14 +73,16 @@ def _mark_as_unhealthy():
     # Create a health check marker file
 
     # max of (service grace period or container health check startPeriod) + health check (retries * interval)
-    # 1020 + 10 * 75 = ~1800
-    max_timeout = 1800
+    # 300 + 10 * 75 = ~1075
+    max_timeout = 1100
 
     try:
-        open('/mwaa/container_unhealthy', 'w').close()
-        logger.error("Marked container as unhealthy via /mwaa/container_unhealthy")
+        os.makedirs('/tmp/mwaa', exist_ok=True)
+        open('/tmp/mwaa/container_unhealthy', 'w').close()
+
+        logger.error("Marked container as unhealthy via /tmp/mwaa/container_unhealthy")
     except Exception as file_err:
-        logger.error("Failed to write /mwaa/container_unhealthy: %s", str(file_err))
+        logger.error("Failed to write /tmp/mwaa/container_unhealthy: %s", str(file_err))
 
     container_runtime = time.time() - CONTAINER_START_TIME
     if container_runtime < max_timeout:
@@ -90,6 +92,7 @@ def _mark_as_unhealthy():
     else:
         logger.info("Container running for %s seconds, not in grace period. Skipping sleep.",
                    int(container_runtime))
+
 
 # TODO Fix the "type: ignore"s in this file.
 

--- a/images/airflow/2.10.3/healthcheck.py
+++ b/images/airflow/2.10.3/healthcheck.py
@@ -4,6 +4,7 @@ Module for running healthcheck on airflow processes.
 
 import subprocess
 import sys
+import os
 from enum import Enum
 
 class ExitStatus(Enum):
@@ -67,6 +68,12 @@ def get_airflow_process_command(airflow_component: str):
     exit_with_status(ExitStatus.INVALID_AIRFLOW_COMPONENT)
 
 if __name__ == '__main__':
+
+    # Check if an 'container_unhealthy' marker file is present
+    if os.path.exists("/tmp/container_unhealthy"):
+        print("/tmp/container_unhealthy file found - marking as unhealthy.")
+        exit_with_status(ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY)
+
     if len(sys.argv) != 2:
         print("Usage: python3 healthcheck.py <airflow_component>")
         exit_with_status(ExitStatus.INSUFFICIENT_ARGUMENTS)
@@ -79,5 +86,3 @@ if __name__ == '__main__':
     else:
         print(f"Airflow process {airflow_component} not found.")
         exit_with_status(ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY)
-
-

--- a/images/airflow/2.10.3/healthcheck.py
+++ b/images/airflow/2.10.3/healthcheck.py
@@ -69,8 +69,8 @@ def get_airflow_process_command(airflow_component: str):
 
 def main():
     # Check if an 'container_unhealthy' marker file is present
-    if os.path.exists("mwaa/container_unhealthy"):
-        print("mwaa/container_unhealthy file found - marking as unhealthy.")
+    if os.path.exists("/tmp/mwaa/container_unhealthy"):
+        print("/tmp/mwaa/container_unhealthy file found - marking as unhealthy.")
         exit_with_status(ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY)
 
     if len(sys.argv) != 2:

--- a/images/airflow/2.10.3/healthcheck.py
+++ b/images/airflow/2.10.3/healthcheck.py
@@ -68,6 +68,9 @@ def get_airflow_process_command(airflow_component: str):
     exit_with_status(ExitStatus.INVALID_AIRFLOW_COMPONENT)
 
 def main():
+    """
+    Main function to check the health of Airflow components.
+    """
     # Check if an 'container_unhealthy' marker file is present
     if os.path.exists("/tmp/mwaa/container_unhealthy"):
         print("/tmp/mwaa/container_unhealthy file found - marking as unhealthy.")

--- a/images/airflow/2.10.3/healthcheck.py
+++ b/images/airflow/2.10.3/healthcheck.py
@@ -67,11 +67,10 @@ def get_airflow_process_command(airflow_component: str):
 
     exit_with_status(ExitStatus.INVALID_AIRFLOW_COMPONENT)
 
-if __name__ == '__main__':
-
+def main():
     # Check if an 'container_unhealthy' marker file is present
-    if os.path.exists("/tmp/container_unhealthy"):
-        print("/tmp/container_unhealthy file found - marking as unhealthy.")
+    if os.path.exists("mwaa/container_unhealthy"):
+        print("mwaa/container_unhealthy file found - marking as unhealthy.")
         exit_with_status(ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY)
 
     if len(sys.argv) != 2:
@@ -86,3 +85,6 @@ if __name__ == '__main__':
     else:
         print(f"Airflow process {airflow_component} not found.")
         exit_with_status(ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY)
+
+if __name__ == '__main__':
+    main()

--- a/images/airflow/2.10.3/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.3/python/mwaa/entrypoint.py
@@ -73,16 +73,16 @@ def _mark_as_unhealthy():
     # Create a health check marker file
 
     # max of (service grace period or container health check startPeriod) + health check (retries * interval)
-    # 1020 + 10 * 75 = ~1800
-    max_timeout = 1800
+    # 300 + 10 * 75 = ~1075
+    max_timeout = 1100
 
     try:
-        with open("/tmp/container_unhealthy", "w") as f:
-            f.write("Container encountered fatal error\n")
-        # open('/mwaa/container_unhealthy', 'w').close()
-        logger.error("Marked container as unhealthy via /mwaa/container_unhealthy")
+        os.makedirs('/tmp/mwaa', exist_ok=True)
+        open('/tmp/mwaa/container_unhealthy', 'w').close()
+
+        logger.error("Marked container as unhealthy via /tmp/mwaa/container_unhealthy")
     except Exception as file_err:
-        logger.error("Failed to write /mwaa/container_unhealthy: %s", str(file_err))
+        logger.error("Failed to write /tmp/mwaa/container_unhealthy: %s", str(file_err))
 
     container_runtime = time.time() - CONTAINER_START_TIME
     if container_runtime < max_timeout:

--- a/images/airflow/2.10.3/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.3/python/mwaa/entrypoint.py
@@ -229,7 +229,20 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except Exception as ex:
+        logger.error("Fatal error in entrypoint: %s", str(ex), exc_info=True)
+        # Create a health check marker file
+        try:
+            with open("/tmp/container_unhealthy", "w") as f:
+                f.write("Container encountered fatal error\n")
+            logger.error("Marked container as unhealthy via /tmp/container_unhealthy")
+        except Exception as file_err:
+            logger.error("Failed to write /tmp/container_unhealthy: %s", str(file_err))
+        # max of (service grace period or container health check startPeriod) + health check (retries * interval)
+        # 1020 + 10 * 75 = ~1800
+        time.sleep(1800)
 elif os.environ.get("MWAA__CORE__TESTING_MODE", "false") != "true":
     logger.error("This module cannot be imported.")
     sys.exit(1)

--- a/images/airflow/2.9.2/healthcheck.py
+++ b/images/airflow/2.9.2/healthcheck.py
@@ -4,6 +4,7 @@ Module for running healthcheck on airflow processes.
 
 import subprocess
 import sys
+import os
 from enum import Enum
 
 class ExitStatus(Enum):
@@ -67,6 +68,12 @@ def get_airflow_process_command(airflow_component: str):
     exit_with_status(ExitStatus.INVALID_AIRFLOW_COMPONENT)
 
 if __name__ == '__main__':
+
+    # Check if an 'container_unhealthy' marker file is present
+    if os.path.exists("/tmp/container_unhealthy"):
+        print("/tmp/container_unhealthy file found - marking as unhealthy.")
+        exit_with_status(ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY)
+
     if len(sys.argv) != 2:
         print("Usage: python3 healthcheck.py <airflow_component>")
         exit_with_status(ExitStatus.INSUFFICIENT_ARGUMENTS)
@@ -79,5 +86,3 @@ if __name__ == '__main__':
     else:
         print(f"Airflow process {airflow_component} not found.")
         exit_with_status(ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY)
-
-

--- a/images/airflow/2.9.2/healthcheck.py
+++ b/images/airflow/2.9.2/healthcheck.py
@@ -69,8 +69,8 @@ def get_airflow_process_command(airflow_component: str):
 
 def main():
     # Check if an 'container_unhealthy' marker file is present
-    if os.path.exists("mwaa/container_unhealthy"):
-        print("mwaa/container_unhealthy file found - marking as unhealthy.")
+    if os.path.exists("/tmp/mwaa/container_unhealthy"):
+        print("/tmp/mwaa/container_unhealthy file found - marking as unhealthy.")
         exit_with_status(ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY)
 
     if len(sys.argv) != 2:

--- a/images/airflow/2.9.2/healthcheck.py
+++ b/images/airflow/2.9.2/healthcheck.py
@@ -68,6 +68,9 @@ def get_airflow_process_command(airflow_component: str):
     exit_with_status(ExitStatus.INVALID_AIRFLOW_COMPONENT)
 
 def main():
+    """
+    Main function to check the health of Airflow components.
+    """
     # Check if an 'container_unhealthy' marker file is present
     if os.path.exists("/tmp/mwaa/container_unhealthy"):
         print("/tmp/mwaa/container_unhealthy file found - marking as unhealthy.")

--- a/images/airflow/2.9.2/healthcheck.py
+++ b/images/airflow/2.9.2/healthcheck.py
@@ -67,11 +67,10 @@ def get_airflow_process_command(airflow_component: str):
 
     exit_with_status(ExitStatus.INVALID_AIRFLOW_COMPONENT)
 
-if __name__ == '__main__':
-
+def main():
     # Check if an 'container_unhealthy' marker file is present
-    if os.path.exists("/tmp/container_unhealthy"):
-        print("/tmp/container_unhealthy file found - marking as unhealthy.")
+    if os.path.exists("mwaa/container_unhealthy"):
+        print("mwaa/container_unhealthy file found - marking as unhealthy.")
         exit_with_status(ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY)
 
     if len(sys.argv) != 2:
@@ -86,3 +85,6 @@ if __name__ == '__main__':
     else:
         print(f"Airflow process {airflow_component} not found.")
         exit_with_status(ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY)
+
+if __name__ == '__main__':
+    main()

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -75,14 +75,16 @@ def _mark_as_unhealthy():
     # Create a health check marker file
 
     # max of (service grace period or container health check startPeriod) + health check (retries * interval)
-    # 1020 + 10 * 75 = ~1800
-    max_timeout = 1800
+    # 300 + 10 * 75 = ~1050
+    max_timeout = 1100
 
     try:
-        open('/mwaa/container_unhealthy', 'w').close()
-        logger.error("Marked container as unhealthy via /mwaa/container_unhealthy")
+        os.makedirs('/tmp/mwaa', exist_ok=True)
+        open('/tmp/mwaa/container_unhealthy', 'w').close()
+
+        logger.error("Marked container as unhealthy via /tmp/mwaa/container_unhealthy")
     except Exception as file_err:
-        logger.error("Failed to write /mwaa/container_unhealthy: %s", str(file_err))
+        logger.error("Failed to write /tmp/mwaa/container_unhealthy: %s", str(file_err))
 
     container_runtime = time.time() - CONTAINER_START_TIME
     if container_runtime < max_timeout:

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -71,6 +71,27 @@ def _configure_root_logger(command: str):
     from mwaa.logging.config import LOGGING_CONFIG
     logging.config.dictConfig(LOGGING_CONFIG)
 
+def _mark_as_unhealthy():
+    # Create a health check marker file
+
+    # max of (service grace period or container health check startPeriod) + health check (retries * interval)
+    # 1020 + 10 * 75 = ~1800
+    max_timeout = 1800
+
+    try:
+        open('/mwaa/container_unhealthy', 'w').close()
+        logger.error("Marked container as unhealthy via /mwaa/container_unhealthy")
+    except Exception as file_err:
+        logger.error("Failed to write /mwaa/container_unhealthy: %s", str(file_err))
+
+    container_runtime = time.time() - CONTAINER_START_TIME
+    if container_runtime < max_timeout:
+        logger.info("Container running for %s seconds, still in grace period. Sleeping for %s seconds.", 
+                   int(container_runtime), max_timeout)
+        time.sleep(max_timeout)
+    else:
+        logger.info("Container running for %s seconds, not in grace period. Skipping sleep.",
+                   int(container_runtime))
 
 # TODO Fix the "type: ignore"s in this file.
 
@@ -274,16 +295,8 @@ if __name__ == "__main__":
         asyncio.run(main())
     except Exception as ex:
         logger.error("Fatal error in entrypoint: %s", str(ex), exc_info=True)
-        # Create a health check marker file
-        try:
-            with open("/tmp/container_unhealthy", "w") as f:
-                f.write("Container encountered fatal error\n")
-            logger.error("Marked container as unhealthy via /tmp/container_unhealthy")
-        except Exception as file_err:
-            logger.error("Failed to write /tmp/container_unhealthy: %s", str(file_err))
-        # max of (service grace period or container health check startPeriod) + health check (retries * interval)
-        # 1020 + 10 * 75 = ~1800
-        time.sleep(1800)
+        _mark_as_unhealthy()
+
 elif os.environ.get("MWAA__CORE__TESTING_MODE", "false") != "true":
     logger.error("This module cannot be imported.")
     sys.exit(1)

--- a/tests/images/airflow/2.10.1/python/mwaa/test_entrypoint_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/test_entrypoint_2_10_1.py
@@ -3,8 +3,7 @@ import pytest
 import asyncio
 import os
 import sys
-from unittest.mock import patch, MagicMock, call, AsyncMock
-from datetime import datetime
+from unittest.mock import patch, MagicMock, mock_open, call
 from botocore.exceptions import ClientError
 
 import mwaa.entrypoint as entrypoint
@@ -121,7 +120,6 @@ async def test_airflow_db_migrate(mock_db_utils):
 
 @pytest.fixture
 def mock_run_command():
-    """Mock run_command with AsyncMock"""
 
     async def mock_run(*args, **kwargs):
         if 'stdout_logging_method' in kwargs in args[0]:
@@ -264,3 +262,32 @@ def test_import_guard():
         import importlib
         importlib.reload(entrypoint)
         mock_exit.assert_called_once_with(1)
+
+
+def test_mark_as_unhealthy(mock_environ):
+    """Test basic functionality of _mark_as_unhealthy"""
+    with patch('os.makedirs') as mock_makedirs, \
+         patch('builtins.open', mock_open()) as mock_file, \
+         patch('time.sleep') as mock_sleep:
+        
+        entrypoint._mark_as_unhealthy()
+
+        # Verify directory creation
+        mock_makedirs.assert_called_once_with('/tmp/mwaa', exist_ok=True)
+        
+        # Verify file creation
+        mock_file.assert_called_once_with('/tmp/mwaa/container_unhealthy', 'w')
+        
+        # Verify sleep was called (assuming new container)
+        mock_sleep.assert_called_once_with(1100)
+
+
+def test_mark_as_unhealthy_error(mock_environ):
+    """Test error handling in _mark_as_unhealthy"""
+    with patch('os.makedirs', side_effect=Exception("Directory creation failed")), \
+         patch('time.sleep') as mock_sleep:
+        
+        entrypoint._mark_as_unhealthy()
+        
+        # Verify sleep was still called
+        mock_sleep.assert_called_once_with(1100)

--- a/tests/images/airflow/2.10.1/test_healthcheck.py
+++ b/tests/images/airflow/2.10.1/test_healthcheck.py
@@ -1,0 +1,122 @@
+import os
+import sys
+import pytest
+from unittest.mock import patch, mock_open
+import subprocess
+
+# Add the directory containing healthcheck.py to the Python path
+AIRFLOW_VERSION = "2.10.1"
+HEALTHCHECK_DIR = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "..",
+        "images",
+        "airflow",
+        AIRFLOW_VERSION
+    )
+)
+sys.path.insert(0, HEALTHCHECK_DIR)
+
+from healthcheck import ExitStatus, is_process_running, get_airflow_process_command, exit_with_status
+
+# Mock process output for different scenarios
+MOCK_PS_OUTPUT_WITH_SCHEDULER = """
+USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+airflow    123   0.0  0.2 /usr/local/airflow/.local/bin/airflow scheduler
+root       456   0.0  0.1 /usr/sbin/sshd
+"""
+
+MOCK_PS_OUTPUT_WITH_WORKER = """
+USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+airflow    789   0.0  0.2 MainProcess] -active- (celery worker)
+root       456   0.0  0.1 /usr/sbin/sshd
+"""
+
+MOCK_PS_OUTPUT_EMPTY = """
+USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root       456   0.0  0.1 /usr/sbin/sshd
+"""
+
+@pytest.mark.parametrize("airflow_component,expected_cmd", [
+    ("SCHEDULER", "/usr/local/airflow/.local/bin/airflow scheduler"),
+    ("WORKER", "MainProcess] -active- (celery worker)"),
+    ("STATIC_ADDITIONAL_WORKER", "MainProcess] -active- (celery worker)"),
+    ("DYNAMIC_ADDITIONAL_WORKER", "MainProcess] -active- (celery worker)"),
+    ("ADDITIONAL_WEBSERVER", "/usr/local/airflow/.local/bin/airflow webserver"),
+    ("WEB_SERVER", "/usr/local/airflow/.local/bin/airflow webserver"),
+])
+def test_get_airflow_process_command_valid(airflow_component, expected_cmd):
+    assert get_airflow_process_command(airflow_component) == expected_cmd
+
+def test_get_airflow_process_command_invalid():
+    with pytest.raises(SystemExit) as exc_info:
+        get_airflow_process_command("INVALID_COMPONENT")
+    assert exc_info.value.code == ExitStatus.INVALID_AIRFLOW_COMPONENT.value
+
+@pytest.mark.parametrize("ps_output,cmd_substring,expected_result", [
+    (MOCK_PS_OUTPUT_WITH_SCHEDULER, "/usr/local/airflow/.local/bin/airflow scheduler", True),
+    (MOCK_PS_OUTPUT_WITH_WORKER, "MainProcess] -active- (celery worker)", True),
+    (MOCK_PS_OUTPUT_EMPTY, "/usr/local/airflow/.local/bin/airflow scheduler", False),
+    (MOCK_PS_OUTPUT_EMPTY, "MainProcess] -active- (celery worker)", False),
+])
+def test_is_process_running(ps_output, cmd_substring, expected_result):
+    with patch('subprocess.check_output') as mock_check_output:
+        mock_check_output.return_value = ps_output.encode()
+        assert is_process_running(cmd_substring) == expected_result
+
+def test_is_process_running_subprocess_error():
+    with patch('subprocess.check_output') as mock_check_output:
+        mock_check_output.side_effect = subprocess.SubprocessError()
+        assert not is_process_running("any_command")
+
+@pytest.mark.parametrize("exit_status", [
+    ExitStatus.SUCCESS,
+    ExitStatus.INSUFFICIENT_ARGUMENTS,
+    ExitStatus.INVALID_AIRFLOW_COMPONENT,
+    ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY,
+])
+def test_exit_with_status(exit_status):
+    with pytest.raises(SystemExit) as exc_info:
+        exit_with_status(exit_status)
+    assert exc_info.value.code == exit_status.value
+
+def run_healthcheck(argv, container_unhealthy=False, ps_output=MOCK_PS_OUTPUT_EMPTY):
+    """Helper function to run the main healthcheck logic"""
+    with patch('sys.argv', argv), \
+         patch('os.path.exists') as mock_exists, \
+         patch('subprocess.check_output') as mock_check_output:
+        
+        mock_exists.return_value = container_unhealthy
+        mock_check_output.return_value = ps_output.encode()
+        
+        # Import the module to get access to the main block code
+        import healthcheck
+        
+        # Create a copy of the main block code
+        if container_unhealthy:
+            return ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY
+            
+        if len(argv) != 2:
+            return ExitStatus.INSUFFICIENT_ARGUMENTS
+            
+        airflow_component = argv[1]
+        airflow_cmd_substring = get_airflow_process_command(airflow_component)
+        
+        if is_process_running(airflow_cmd_substring):
+            return ExitStatus.SUCCESS
+        else:
+            return ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY
+
+@pytest.mark.parametrize("argv,container_unhealthy,ps_output,expected_exit_code", [
+    (["script.py", "SCHEDULER"], False, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.SUCCESS),
+    (["script.py", "WORKER"], False, MOCK_PS_OUTPUT_WITH_WORKER, ExitStatus.SUCCESS),
+    (["script.py", "SCHEDULER"], False, MOCK_PS_OUTPUT_EMPTY, ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY),
+    (["script.py"], False, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.INSUFFICIENT_ARGUMENTS),
+    (["script.py", "SCHEDULER"], True, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY),
+])
+def test_main_flow(argv, container_unhealthy, ps_output, expected_exit_code):
+    result = run_healthcheck(argv, container_unhealthy, ps_output)
+    assert result == expected_exit_code

--- a/tests/images/airflow/2.10.1/test_healthcheck.py
+++ b/tests/images/airflow/2.10.1/test_healthcheck.py
@@ -1,8 +1,7 @@
 import os
 import sys
 import pytest
-from unittest.mock import patch, mock_open
-import subprocess
+from unittest.mock import patch
 
 # Add the directory containing healthcheck.py to the Python path
 AIRFLOW_VERSION = "2.10.1"
@@ -20,103 +19,49 @@ HEALTHCHECK_DIR = os.path.abspath(
 )
 sys.path.insert(0, HEALTHCHECK_DIR)
 
-from healthcheck import ExitStatus, is_process_running, get_airflow_process_command, exit_with_status
+from healthcheck import main, ExitStatus
 
-# Mock process output for different scenarios
-MOCK_PS_OUTPUT_WITH_SCHEDULER = """
-USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-airflow    123   0.0  0.2 /usr/local/airflow/.local/bin/airflow scheduler
-root       456   0.0  0.1 /usr/sbin/sshd
-"""
+# Simple mock process outputs
+MOCK_PS_OUTPUT_WITH_PROCESS = "airflow    123   0.0  0.2 /usr/local/airflow/.local/bin/airflow scheduler"
+MOCK_PS_OUTPUT_EMPTY = "root       456   0.0  0.1 /usr/sbin/sshd"
 
-MOCK_PS_OUTPUT_WITH_WORKER = """
-USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-airflow    789   0.0  0.2 MainProcess] -active- (celery worker)
-root       456   0.0  0.1 /usr/sbin/sshd
-"""
+def test_main_success():
+    """Test main function success path"""
+    with patch('sys.argv', ['healthcheck.py', 'SCHEDULER']), \
+         patch('os.path.exists', return_value=False), \
+         patch('subprocess.check_output', return_value=MOCK_PS_OUTPUT_WITH_PROCESS.encode()), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.SUCCESS.value
 
-MOCK_PS_OUTPUT_EMPTY = """
-USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-root       456   0.0  0.1 /usr/sbin/sshd
-"""
+def test_main_unhealthy_container():
+    """Test when container is marked unhealthy"""
+    with patch('sys.argv', ['healthcheck.py', 'SCHEDULER']), \
+         patch('os.path.exists', return_value=True), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY.value
 
-@pytest.mark.parametrize("airflow_component,expected_cmd", [
-    ("SCHEDULER", "/usr/local/airflow/.local/bin/airflow scheduler"),
-    ("WORKER", "MainProcess] -active- (celery worker)"),
-    ("STATIC_ADDITIONAL_WORKER", "MainProcess] -active- (celery worker)"),
-    ("DYNAMIC_ADDITIONAL_WORKER", "MainProcess] -active- (celery worker)"),
-    ("ADDITIONAL_WEBSERVER", "/usr/local/airflow/.local/bin/airflow webserver"),
-    ("WEB_SERVER", "/usr/local/airflow/.local/bin/airflow webserver"),
-])
-def test_get_airflow_process_command_valid(airflow_component, expected_cmd):
-    assert get_airflow_process_command(airflow_component) == expected_cmd
+def test_main_process_not_found():
+    """Test when process is not found"""
+    with patch('sys.argv', ['healthcheck.py', 'SCHEDULER']), \
+         patch('os.path.exists', return_value=False), \
+         patch('subprocess.check_output', return_value=MOCK_PS_OUTPUT_EMPTY.encode()), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY.value
 
-def test_get_airflow_process_command_invalid():
-    with pytest.raises(SystemExit) as exc_info:
-        get_airflow_process_command("INVALID_COMPONENT")
+def test_main_invalid_args():
+    """Test with invalid number of arguments"""
+    with patch('sys.argv', ['healthcheck.py']), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.INSUFFICIENT_ARGUMENTS.value
+
+def test_main_invalid_component():
+    """Test with invalid component name"""
+    with patch('sys.argv', ['healthcheck.py', 'INVALID']), \
+         patch('os.path.exists', return_value=False), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
     assert exc_info.value.code == ExitStatus.INVALID_AIRFLOW_COMPONENT.value
-
-@pytest.mark.parametrize("ps_output,cmd_substring,expected_result", [
-    (MOCK_PS_OUTPUT_WITH_SCHEDULER, "/usr/local/airflow/.local/bin/airflow scheduler", True),
-    (MOCK_PS_OUTPUT_WITH_WORKER, "MainProcess] -active- (celery worker)", True),
-    (MOCK_PS_OUTPUT_EMPTY, "/usr/local/airflow/.local/bin/airflow scheduler", False),
-    (MOCK_PS_OUTPUT_EMPTY, "MainProcess] -active- (celery worker)", False),
-])
-def test_is_process_running(ps_output, cmd_substring, expected_result):
-    with patch('subprocess.check_output') as mock_check_output:
-        mock_check_output.return_value = ps_output.encode()
-        assert is_process_running(cmd_substring) == expected_result
-
-def test_is_process_running_subprocess_error():
-    with patch('subprocess.check_output') as mock_check_output:
-        mock_check_output.side_effect = subprocess.SubprocessError()
-        assert not is_process_running("any_command")
-
-@pytest.mark.parametrize("exit_status", [
-    ExitStatus.SUCCESS,
-    ExitStatus.INSUFFICIENT_ARGUMENTS,
-    ExitStatus.INVALID_AIRFLOW_COMPONENT,
-    ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY,
-])
-def test_exit_with_status(exit_status):
-    with pytest.raises(SystemExit) as exc_info:
-        exit_with_status(exit_status)
-    assert exc_info.value.code == exit_status.value
-
-def run_healthcheck(argv, container_unhealthy=False, ps_output=MOCK_PS_OUTPUT_EMPTY):
-    """Helper function to run the main healthcheck logic"""
-    with patch('sys.argv', argv), \
-         patch('os.path.exists') as mock_exists, \
-         patch('subprocess.check_output') as mock_check_output:
-        
-        mock_exists.return_value = container_unhealthy
-        mock_check_output.return_value = ps_output.encode()
-        
-        # Import the module to get access to the main block code
-        import healthcheck
-        
-        # Create a copy of the main block code
-        if container_unhealthy:
-            return ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY
-            
-        if len(argv) != 2:
-            return ExitStatus.INSUFFICIENT_ARGUMENTS
-            
-        airflow_component = argv[1]
-        airflow_cmd_substring = get_airflow_process_command(airflow_component)
-        
-        if is_process_running(airflow_cmd_substring):
-            return ExitStatus.SUCCESS
-        else:
-            return ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY
-
-@pytest.mark.parametrize("argv,container_unhealthy,ps_output,expected_exit_code", [
-    (["script.py", "SCHEDULER"], False, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.SUCCESS),
-    (["script.py", "WORKER"], False, MOCK_PS_OUTPUT_WITH_WORKER, ExitStatus.SUCCESS),
-    (["script.py", "SCHEDULER"], False, MOCK_PS_OUTPUT_EMPTY, ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY),
-    (["script.py"], False, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.INSUFFICIENT_ARGUMENTS),
-    (["script.py", "SCHEDULER"], True, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY),
-])
-def test_main_flow(argv, container_unhealthy, ps_output, expected_exit_code):
-    result = run_healthcheck(argv, container_unhealthy, ps_output)
-    assert result == expected_exit_code

--- a/tests/images/airflow/2.10.3/python/mwaa/test_entrypoint_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/test_entrypoint_2_10_3.py
@@ -1,10 +1,8 @@
 # test_entrypoint.py
 import pytest
-import asyncio
 import os
 import sys
-from unittest.mock import patch, MagicMock, call, AsyncMock
-from datetime import datetime
+from unittest.mock import patch, MagicMock, mock_open, call
 from botocore.exceptions import ClientError
 
 import mwaa.entrypoint as entrypoint
@@ -121,8 +119,6 @@ async def test_airflow_db_migrate(mock_db_utils):
 
 @pytest.fixture
 def mock_run_command():
-    """Mock run_command with AsyncMock"""
-
     async def mock_run(*args, **kwargs):
         if 'stdout_logging_method' in kwargs in args[0]:
             kwargs['stdout_logging_method']("128")
@@ -264,3 +260,32 @@ def test_import_guard():
         import importlib
         importlib.reload(entrypoint)
         mock_exit.assert_called_once_with(1)
+
+
+def test_mark_as_unhealthy(mock_environ):
+    """Test basic functionality of _mark_as_unhealthy"""
+    with patch('os.makedirs') as mock_makedirs, \
+         patch('builtins.open', mock_open()) as mock_file, \
+         patch('time.sleep') as mock_sleep:
+        
+        entrypoint._mark_as_unhealthy()
+
+        # Verify directory creation
+        mock_makedirs.assert_called_once_with('/tmp/mwaa', exist_ok=True)
+        
+        # Verify file creation
+        mock_file.assert_called_once_with('/tmp/mwaa/container_unhealthy', 'w')
+        
+        # Verify sleep was called (assuming new container)
+        mock_sleep.assert_called_once_with(1100)
+
+
+def test_mark_as_unhealthy_error(mock_environ):
+    """Test error handling in _mark_as_unhealthy"""
+    with patch('os.makedirs', side_effect=Exception("Directory creation failed")), \
+         patch('time.sleep') as mock_sleep:
+        
+        entrypoint._mark_as_unhealthy()
+        
+        # Verify sleep was still called
+        mock_sleep.assert_called_once_with(1100)

--- a/tests/images/airflow/2.10.3/test_healthcheck.py
+++ b/tests/images/airflow/2.10.3/test_healthcheck.py
@@ -1,8 +1,7 @@
 import os
 import sys
 import pytest
-from unittest.mock import patch, mock_open
-import subprocess
+from unittest.mock import patch
 
 # Add the directory containing healthcheck.py to the Python path
 AIRFLOW_VERSION = "2.10.3"
@@ -20,103 +19,49 @@ HEALTHCHECK_DIR = os.path.abspath(
 )
 sys.path.insert(0, HEALTHCHECK_DIR)
 
-from healthcheck import ExitStatus, is_process_running, get_airflow_process_command, exit_with_status
+from healthcheck import main, ExitStatus
 
-# Mock process output for different scenarios
-MOCK_PS_OUTPUT_WITH_SCHEDULER = """
-USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-airflow    123   0.0  0.2 /usr/local/airflow/.local/bin/airflow scheduler
-root       456   0.0  0.1 /usr/sbin/sshd
-"""
+# Simple mock process outputs
+MOCK_PS_OUTPUT_WITH_PROCESS = "airflow    123   0.0  0.2 /usr/local/airflow/.local/bin/airflow scheduler"
+MOCK_PS_OUTPUT_EMPTY = "root       456   0.0  0.1 /usr/sbin/sshd"
 
-MOCK_PS_OUTPUT_WITH_WORKER = """
-USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-airflow    789   0.0  0.2 MainProcess] -active- (celery worker)
-root       456   0.0  0.1 /usr/sbin/sshd
-"""
+def test_main_success():
+    """Test main function success path"""
+    with patch('sys.argv', ['healthcheck.py', 'SCHEDULER']), \
+         patch('os.path.exists', return_value=False), \
+         patch('subprocess.check_output', return_value=MOCK_PS_OUTPUT_WITH_PROCESS.encode()), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.SUCCESS.value
 
-MOCK_PS_OUTPUT_EMPTY = """
-USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-root       456   0.0  0.1 /usr/sbin/sshd
-"""
+def test_main_unhealthy_container():
+    """Test when container is marked unhealthy"""
+    with patch('sys.argv', ['healthcheck.py', 'SCHEDULER']), \
+         patch('os.path.exists', return_value=True), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY.value
 
-@pytest.mark.parametrize("airflow_component,expected_cmd", [
-    ("SCHEDULER", "/usr/local/airflow/.local/bin/airflow scheduler"),
-    ("WORKER", "MainProcess] -active- (celery worker)"),
-    ("STATIC_ADDITIONAL_WORKER", "MainProcess] -active- (celery worker)"),
-    ("DYNAMIC_ADDITIONAL_WORKER", "MainProcess] -active- (celery worker)"),
-    ("ADDITIONAL_WEBSERVER", "/usr/local/airflow/.local/bin/airflow webserver"),
-    ("WEB_SERVER", "/usr/local/airflow/.local/bin/airflow webserver"),
-])
-def test_get_airflow_process_command_valid(airflow_component, expected_cmd):
-    assert get_airflow_process_command(airflow_component) == expected_cmd
+def test_main_process_not_found():
+    """Test when process is not found"""
+    with patch('sys.argv', ['healthcheck.py', 'SCHEDULER']), \
+         patch('os.path.exists', return_value=False), \
+         patch('subprocess.check_output', return_value=MOCK_PS_OUTPUT_EMPTY.encode()), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY.value
 
-def test_get_airflow_process_command_invalid():
-    with pytest.raises(SystemExit) as exc_info:
-        get_airflow_process_command("INVALID_COMPONENT")
+def test_main_invalid_args():
+    """Test with invalid number of arguments"""
+    with patch('sys.argv', ['healthcheck.py']), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.INSUFFICIENT_ARGUMENTS.value
+
+def test_main_invalid_component():
+    """Test with invalid component name"""
+    with patch('sys.argv', ['healthcheck.py', 'INVALID']), \
+         patch('os.path.exists', return_value=False), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
     assert exc_info.value.code == ExitStatus.INVALID_AIRFLOW_COMPONENT.value
-
-@pytest.mark.parametrize("ps_output,cmd_substring,expected_result", [
-    (MOCK_PS_OUTPUT_WITH_SCHEDULER, "/usr/local/airflow/.local/bin/airflow scheduler", True),
-    (MOCK_PS_OUTPUT_WITH_WORKER, "MainProcess] -active- (celery worker)", True),
-    (MOCK_PS_OUTPUT_EMPTY, "/usr/local/airflow/.local/bin/airflow scheduler", False),
-    (MOCK_PS_OUTPUT_EMPTY, "MainProcess] -active- (celery worker)", False),
-])
-def test_is_process_running(ps_output, cmd_substring, expected_result):
-    with patch('subprocess.check_output') as mock_check_output:
-        mock_check_output.return_value = ps_output.encode()
-        assert is_process_running(cmd_substring) == expected_result
-
-def test_is_process_running_subprocess_error():
-    with patch('subprocess.check_output') as mock_check_output:
-        mock_check_output.side_effect = subprocess.SubprocessError()
-        assert not is_process_running("any_command")
-
-@pytest.mark.parametrize("exit_status", [
-    ExitStatus.SUCCESS,
-    ExitStatus.INSUFFICIENT_ARGUMENTS,
-    ExitStatus.INVALID_AIRFLOW_COMPONENT,
-    ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY,
-])
-def test_exit_with_status(exit_status):
-    with pytest.raises(SystemExit) as exc_info:
-        exit_with_status(exit_status)
-    assert exc_info.value.code == exit_status.value
-
-def run_healthcheck(argv, container_unhealthy=False, ps_output=MOCK_PS_OUTPUT_EMPTY):
-    """Helper function to run the main healthcheck logic"""
-    with patch('sys.argv', argv), \
-         patch('os.path.exists') as mock_exists, \
-         patch('subprocess.check_output') as mock_check_output:
-        
-        mock_exists.return_value = container_unhealthy
-        mock_check_output.return_value = ps_output.encode()
-        
-        # Import the module to get access to the main block code
-        import healthcheck
-        
-        # Create a copy of the main block code
-        if container_unhealthy:
-            return ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY
-            
-        if len(argv) != 2:
-            return ExitStatus.INSUFFICIENT_ARGUMENTS
-            
-        airflow_component = argv[1]
-        airflow_cmd_substring = get_airflow_process_command(airflow_component)
-        
-        if is_process_running(airflow_cmd_substring):
-            return ExitStatus.SUCCESS
-        else:
-            return ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY
-
-@pytest.mark.parametrize("argv,container_unhealthy,ps_output,expected_exit_code", [
-    (["script.py", "SCHEDULER"], False, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.SUCCESS),
-    (["script.py", "WORKER"], False, MOCK_PS_OUTPUT_WITH_WORKER, ExitStatus.SUCCESS),
-    (["script.py", "SCHEDULER"], False, MOCK_PS_OUTPUT_EMPTY, ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY),
-    (["script.py"], False, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.INSUFFICIENT_ARGUMENTS),
-    (["script.py", "SCHEDULER"], True, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY),
-])
-def test_main_flow(argv, container_unhealthy, ps_output, expected_exit_code):
-    result = run_healthcheck(argv, container_unhealthy, ps_output)
-    assert result == expected_exit_code

--- a/tests/images/airflow/2.10.3/test_healthcheck.py
+++ b/tests/images/airflow/2.10.3/test_healthcheck.py
@@ -1,0 +1,122 @@
+import os
+import sys
+import pytest
+from unittest.mock import patch, mock_open
+import subprocess
+
+# Add the directory containing healthcheck.py to the Python path
+AIRFLOW_VERSION = "2.10.3"
+HEALTHCHECK_DIR = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "..",
+        "images",
+        "airflow",
+        AIRFLOW_VERSION
+    )
+)
+sys.path.insert(0, HEALTHCHECK_DIR)
+
+from healthcheck import ExitStatus, is_process_running, get_airflow_process_command, exit_with_status
+
+# Mock process output for different scenarios
+MOCK_PS_OUTPUT_WITH_SCHEDULER = """
+USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+airflow    123   0.0  0.2 /usr/local/airflow/.local/bin/airflow scheduler
+root       456   0.0  0.1 /usr/sbin/sshd
+"""
+
+MOCK_PS_OUTPUT_WITH_WORKER = """
+USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+airflow    789   0.0  0.2 MainProcess] -active- (celery worker)
+root       456   0.0  0.1 /usr/sbin/sshd
+"""
+
+MOCK_PS_OUTPUT_EMPTY = """
+USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root       456   0.0  0.1 /usr/sbin/sshd
+"""
+
+@pytest.mark.parametrize("airflow_component,expected_cmd", [
+    ("SCHEDULER", "/usr/local/airflow/.local/bin/airflow scheduler"),
+    ("WORKER", "MainProcess] -active- (celery worker)"),
+    ("STATIC_ADDITIONAL_WORKER", "MainProcess] -active- (celery worker)"),
+    ("DYNAMIC_ADDITIONAL_WORKER", "MainProcess] -active- (celery worker)"),
+    ("ADDITIONAL_WEBSERVER", "/usr/local/airflow/.local/bin/airflow webserver"),
+    ("WEB_SERVER", "/usr/local/airflow/.local/bin/airflow webserver"),
+])
+def test_get_airflow_process_command_valid(airflow_component, expected_cmd):
+    assert get_airflow_process_command(airflow_component) == expected_cmd
+
+def test_get_airflow_process_command_invalid():
+    with pytest.raises(SystemExit) as exc_info:
+        get_airflow_process_command("INVALID_COMPONENT")
+    assert exc_info.value.code == ExitStatus.INVALID_AIRFLOW_COMPONENT.value
+
+@pytest.mark.parametrize("ps_output,cmd_substring,expected_result", [
+    (MOCK_PS_OUTPUT_WITH_SCHEDULER, "/usr/local/airflow/.local/bin/airflow scheduler", True),
+    (MOCK_PS_OUTPUT_WITH_WORKER, "MainProcess] -active- (celery worker)", True),
+    (MOCK_PS_OUTPUT_EMPTY, "/usr/local/airflow/.local/bin/airflow scheduler", False),
+    (MOCK_PS_OUTPUT_EMPTY, "MainProcess] -active- (celery worker)", False),
+])
+def test_is_process_running(ps_output, cmd_substring, expected_result):
+    with patch('subprocess.check_output') as mock_check_output:
+        mock_check_output.return_value = ps_output.encode()
+        assert is_process_running(cmd_substring) == expected_result
+
+def test_is_process_running_subprocess_error():
+    with patch('subprocess.check_output') as mock_check_output:
+        mock_check_output.side_effect = subprocess.SubprocessError()
+        assert not is_process_running("any_command")
+
+@pytest.mark.parametrize("exit_status", [
+    ExitStatus.SUCCESS,
+    ExitStatus.INSUFFICIENT_ARGUMENTS,
+    ExitStatus.INVALID_AIRFLOW_COMPONENT,
+    ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY,
+])
+def test_exit_with_status(exit_status):
+    with pytest.raises(SystemExit) as exc_info:
+        exit_with_status(exit_status)
+    assert exc_info.value.code == exit_status.value
+
+def run_healthcheck(argv, container_unhealthy=False, ps_output=MOCK_PS_OUTPUT_EMPTY):
+    """Helper function to run the main healthcheck logic"""
+    with patch('sys.argv', argv), \
+         patch('os.path.exists') as mock_exists, \
+         patch('subprocess.check_output') as mock_check_output:
+        
+        mock_exists.return_value = container_unhealthy
+        mock_check_output.return_value = ps_output.encode()
+        
+        # Import the module to get access to the main block code
+        import healthcheck
+        
+        # Create a copy of the main block code
+        if container_unhealthy:
+            return ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY
+            
+        if len(argv) != 2:
+            return ExitStatus.INSUFFICIENT_ARGUMENTS
+            
+        airflow_component = argv[1]
+        airflow_cmd_substring = get_airflow_process_command(airflow_component)
+        
+        if is_process_running(airflow_cmd_substring):
+            return ExitStatus.SUCCESS
+        else:
+            return ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY
+
+@pytest.mark.parametrize("argv,container_unhealthy,ps_output,expected_exit_code", [
+    (["script.py", "SCHEDULER"], False, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.SUCCESS),
+    (["script.py", "WORKER"], False, MOCK_PS_OUTPUT_WITH_WORKER, ExitStatus.SUCCESS),
+    (["script.py", "SCHEDULER"], False, MOCK_PS_OUTPUT_EMPTY, ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY),
+    (["script.py"], False, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.INSUFFICIENT_ARGUMENTS),
+    (["script.py", "SCHEDULER"], True, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY),
+])
+def test_main_flow(argv, container_unhealthy, ps_output, expected_exit_code):
+    result = run_healthcheck(argv, container_unhealthy, ps_output)
+    assert result == expected_exit_code

--- a/tests/images/airflow/2.9.2/test_healthcheck.py
+++ b/tests/images/airflow/2.9.2/test_healthcheck.py
@@ -1,8 +1,7 @@
 import os
 import sys
 import pytest
-from unittest.mock import patch, mock_open
-import subprocess
+from unittest.mock import patch
 
 # Add the directory containing healthcheck.py to the Python path
 AIRFLOW_VERSION = "2.9.2"
@@ -20,103 +19,49 @@ HEALTHCHECK_DIR = os.path.abspath(
 )
 sys.path.insert(0, HEALTHCHECK_DIR)
 
-from healthcheck import ExitStatus, is_process_running, get_airflow_process_command, exit_with_status
+from healthcheck import main, ExitStatus
 
-# Mock process output for different scenarios
-MOCK_PS_OUTPUT_WITH_SCHEDULER = """
-USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-airflow    123   0.0  0.2 /usr/local/airflow/.local/bin/airflow scheduler
-root       456   0.0  0.1 /usr/sbin/sshd
-"""
+# Simple mock process outputs
+MOCK_PS_OUTPUT_WITH_PROCESS = "airflow    123   0.0  0.2 /usr/local/airflow/.local/bin/airflow scheduler"
+MOCK_PS_OUTPUT_EMPTY = "root       456   0.0  0.1 /usr/sbin/sshd"
 
-MOCK_PS_OUTPUT_WITH_WORKER = """
-USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-airflow    789   0.0  0.2 MainProcess] -active- (celery worker)
-root       456   0.0  0.1 /usr/sbin/sshd
-"""
+def test_main_success():
+    """Test main function success path"""
+    with patch('sys.argv', ['healthcheck.py', 'SCHEDULER']), \
+         patch('os.path.exists', return_value=False), \
+         patch('subprocess.check_output', return_value=MOCK_PS_OUTPUT_WITH_PROCESS.encode()), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.SUCCESS.value
 
-MOCK_PS_OUTPUT_EMPTY = """
-USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-root       456   0.0  0.1 /usr/sbin/sshd
-"""
+def test_main_unhealthy_container():
+    """Test when container is marked unhealthy"""
+    with patch('sys.argv', ['healthcheck.py', 'SCHEDULER']), \
+         patch('os.path.exists', return_value=True), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY.value
 
-@pytest.mark.parametrize("airflow_component,expected_cmd", [
-    ("SCHEDULER", "/usr/local/airflow/.local/bin/airflow scheduler"),
-    ("WORKER", "MainProcess] -active- (celery worker)"),
-    ("STATIC_ADDITIONAL_WORKER", "MainProcess] -active- (celery worker)"),
-    ("DYNAMIC_ADDITIONAL_WORKER", "MainProcess] -active- (celery worker)"),
-    ("ADDITIONAL_WEBSERVER", "/usr/local/airflow/.local/bin/airflow webserver"),
-    ("WEB_SERVER", "/usr/local/airflow/.local/bin/airflow webserver"),
-])
-def test_get_airflow_process_command_valid(airflow_component, expected_cmd):
-    assert get_airflow_process_command(airflow_component) == expected_cmd
+def test_main_process_not_found():
+    """Test when process is not found"""
+    with patch('sys.argv', ['healthcheck.py', 'SCHEDULER']), \
+         patch('os.path.exists', return_value=False), \
+         patch('subprocess.check_output', return_value=MOCK_PS_OUTPUT_EMPTY.encode()), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY.value
 
-def test_get_airflow_process_command_invalid():
-    with pytest.raises(SystemExit) as exc_info:
-        get_airflow_process_command("INVALID_COMPONENT")
+def test_main_invalid_args():
+    """Test with invalid number of arguments"""
+    with patch('sys.argv', ['healthcheck.py']), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.INSUFFICIENT_ARGUMENTS.value
+
+def test_main_invalid_component():
+    """Test with invalid component name"""
+    with patch('sys.argv', ['healthcheck.py', 'INVALID']), \
+         patch('os.path.exists', return_value=False), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
     assert exc_info.value.code == ExitStatus.INVALID_AIRFLOW_COMPONENT.value
-
-@pytest.mark.parametrize("ps_output,cmd_substring,expected_result", [
-    (MOCK_PS_OUTPUT_WITH_SCHEDULER, "/usr/local/airflow/.local/bin/airflow scheduler", True),
-    (MOCK_PS_OUTPUT_WITH_WORKER, "MainProcess] -active- (celery worker)", True),
-    (MOCK_PS_OUTPUT_EMPTY, "/usr/local/airflow/.local/bin/airflow scheduler", False),
-    (MOCK_PS_OUTPUT_EMPTY, "MainProcess] -active- (celery worker)", False),
-])
-def test_is_process_running(ps_output, cmd_substring, expected_result):
-    with patch('subprocess.check_output') as mock_check_output:
-        mock_check_output.return_value = ps_output.encode()
-        assert is_process_running(cmd_substring) == expected_result
-
-def test_is_process_running_subprocess_error():
-    with patch('subprocess.check_output') as mock_check_output:
-        mock_check_output.side_effect = subprocess.SubprocessError()
-        assert not is_process_running("any_command")
-
-@pytest.mark.parametrize("exit_status", [
-    ExitStatus.SUCCESS,
-    ExitStatus.INSUFFICIENT_ARGUMENTS,
-    ExitStatus.INVALID_AIRFLOW_COMPONENT,
-    ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY,
-])
-def test_exit_with_status(exit_status):
-    with pytest.raises(SystemExit) as exc_info:
-        exit_with_status(exit_status)
-    assert exc_info.value.code == exit_status.value
-
-def run_healthcheck(argv, container_unhealthy=False, ps_output=MOCK_PS_OUTPUT_EMPTY):
-    """Helper function to run the main healthcheck logic"""
-    with patch('sys.argv', argv), \
-         patch('os.path.exists') as mock_exists, \
-         patch('subprocess.check_output') as mock_check_output:
-        
-        mock_exists.return_value = container_unhealthy
-        mock_check_output.return_value = ps_output.encode()
-        
-        # Import the module to get access to the main block code
-        import healthcheck
-        
-        # Create a copy of the main block code
-        if container_unhealthy:
-            return ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY
-            
-        if len(argv) != 2:
-            return ExitStatus.INSUFFICIENT_ARGUMENTS
-            
-        airflow_component = argv[1]
-        airflow_cmd_substring = get_airflow_process_command(airflow_component)
-        
-        if is_process_running(airflow_cmd_substring):
-            return ExitStatus.SUCCESS
-        else:
-            return ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY
-
-@pytest.mark.parametrize("argv,container_unhealthy,ps_output,expected_exit_code", [
-    (["script.py", "SCHEDULER"], False, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.SUCCESS),
-    (["script.py", "WORKER"], False, MOCK_PS_OUTPUT_WITH_WORKER, ExitStatus.SUCCESS),
-    (["script.py", "SCHEDULER"], False, MOCK_PS_OUTPUT_EMPTY, ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY),
-    (["script.py"], False, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.INSUFFICIENT_ARGUMENTS),
-    (["script.py", "SCHEDULER"], True, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY),
-])
-def test_main_flow(argv, container_unhealthy, ps_output, expected_exit_code):
-    result = run_healthcheck(argv, container_unhealthy, ps_output)
-    assert result == expected_exit_code

--- a/tests/images/airflow/2.9.2/test_healthcheck.py
+++ b/tests/images/airflow/2.9.2/test_healthcheck.py
@@ -1,0 +1,122 @@
+import os
+import sys
+import pytest
+from unittest.mock import patch, mock_open
+import subprocess
+
+# Add the directory containing healthcheck.py to the Python path
+AIRFLOW_VERSION = "2.9.2"
+HEALTHCHECK_DIR = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "..",
+        "images",
+        "airflow",
+        AIRFLOW_VERSION
+    )
+)
+sys.path.insert(0, HEALTHCHECK_DIR)
+
+from healthcheck import ExitStatus, is_process_running, get_airflow_process_command, exit_with_status
+
+# Mock process output for different scenarios
+MOCK_PS_OUTPUT_WITH_SCHEDULER = """
+USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+airflow    123   0.0  0.2 /usr/local/airflow/.local/bin/airflow scheduler
+root       456   0.0  0.1 /usr/sbin/sshd
+"""
+
+MOCK_PS_OUTPUT_WITH_WORKER = """
+USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+airflow    789   0.0  0.2 MainProcess] -active- (celery worker)
+root       456   0.0  0.1 /usr/sbin/sshd
+"""
+
+MOCK_PS_OUTPUT_EMPTY = """
+USER       PID  %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root       456   0.0  0.1 /usr/sbin/sshd
+"""
+
+@pytest.mark.parametrize("airflow_component,expected_cmd", [
+    ("SCHEDULER", "/usr/local/airflow/.local/bin/airflow scheduler"),
+    ("WORKER", "MainProcess] -active- (celery worker)"),
+    ("STATIC_ADDITIONAL_WORKER", "MainProcess] -active- (celery worker)"),
+    ("DYNAMIC_ADDITIONAL_WORKER", "MainProcess] -active- (celery worker)"),
+    ("ADDITIONAL_WEBSERVER", "/usr/local/airflow/.local/bin/airflow webserver"),
+    ("WEB_SERVER", "/usr/local/airflow/.local/bin/airflow webserver"),
+])
+def test_get_airflow_process_command_valid(airflow_component, expected_cmd):
+    assert get_airflow_process_command(airflow_component) == expected_cmd
+
+def test_get_airflow_process_command_invalid():
+    with pytest.raises(SystemExit) as exc_info:
+        get_airflow_process_command("INVALID_COMPONENT")
+    assert exc_info.value.code == ExitStatus.INVALID_AIRFLOW_COMPONENT.value
+
+@pytest.mark.parametrize("ps_output,cmd_substring,expected_result", [
+    (MOCK_PS_OUTPUT_WITH_SCHEDULER, "/usr/local/airflow/.local/bin/airflow scheduler", True),
+    (MOCK_PS_OUTPUT_WITH_WORKER, "MainProcess] -active- (celery worker)", True),
+    (MOCK_PS_OUTPUT_EMPTY, "/usr/local/airflow/.local/bin/airflow scheduler", False),
+    (MOCK_PS_OUTPUT_EMPTY, "MainProcess] -active- (celery worker)", False),
+])
+def test_is_process_running(ps_output, cmd_substring, expected_result):
+    with patch('subprocess.check_output') as mock_check_output:
+        mock_check_output.return_value = ps_output.encode()
+        assert is_process_running(cmd_substring) == expected_result
+
+def test_is_process_running_subprocess_error():
+    with patch('subprocess.check_output') as mock_check_output:
+        mock_check_output.side_effect = subprocess.SubprocessError()
+        assert not is_process_running("any_command")
+
+@pytest.mark.parametrize("exit_status", [
+    ExitStatus.SUCCESS,
+    ExitStatus.INSUFFICIENT_ARGUMENTS,
+    ExitStatus.INVALID_AIRFLOW_COMPONENT,
+    ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY,
+])
+def test_exit_with_status(exit_status):
+    with pytest.raises(SystemExit) as exc_info:
+        exit_with_status(exit_status)
+    assert exc_info.value.code == exit_status.value
+
+def run_healthcheck(argv, container_unhealthy=False, ps_output=MOCK_PS_OUTPUT_EMPTY):
+    """Helper function to run the main healthcheck logic"""
+    with patch('sys.argv', argv), \
+         patch('os.path.exists') as mock_exists, \
+         patch('subprocess.check_output') as mock_check_output:
+        
+        mock_exists.return_value = container_unhealthy
+        mock_check_output.return_value = ps_output.encode()
+        
+        # Import the module to get access to the main block code
+        import healthcheck
+        
+        # Create a copy of the main block code
+        if container_unhealthy:
+            return ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY
+            
+        if len(argv) != 2:
+            return ExitStatus.INSUFFICIENT_ARGUMENTS
+            
+        airflow_component = argv[1]
+        airflow_cmd_substring = get_airflow_process_command(airflow_component)
+        
+        if is_process_running(airflow_cmd_substring):
+            return ExitStatus.SUCCESS
+        else:
+            return ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY
+
+@pytest.mark.parametrize("argv,container_unhealthy,ps_output,expected_exit_code", [
+    (["script.py", "SCHEDULER"], False, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.SUCCESS),
+    (["script.py", "WORKER"], False, MOCK_PS_OUTPUT_WITH_WORKER, ExitStatus.SUCCESS),
+    (["script.py", "SCHEDULER"], False, MOCK_PS_OUTPUT_EMPTY, ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY),
+    (["script.py"], False, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.INSUFFICIENT_ARGUMENTS),
+    (["script.py", "SCHEDULER"], True, MOCK_PS_OUTPUT_WITH_SCHEDULER, ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY),
+])
+def test_main_flow(argv, container_unhealthy, ps_output, expected_exit_code):
+    result = run_healthcheck(argv, container_unhealthy, ps_output)
+    assert result == expected_exit_code


### PR DESCRIPTION
#### Description of changes :
- Added `try-catch` in `entrypoint.py` which will handle all the `Exception`s thrown, gracefully and create a `container_unhealthy` marker file (flag)
- Updated `healthcheck.py` to check for the above marker file
- Added UTs for `healthcheck.py`
- Added new test for `entrypoint.py`

#### Testing
- Hardcoded an Exception line in the startup script execution block
- Deployed pinwheel environment : The ECS failed to stabilize which in turn trigger Circuit breaker and that resulted in CFN ROLLBACK
    -  CREATE : Iselink for test stack - https://tiny.amazon.com/2l4r798c/IsenLink
    - UPDATE : Isenlink for test stack - https://tiny.amazon.com/jq4npiah/IsenLink
