### PR TITLE
Use killpg to kill subprocesses

### DIFF
--- a/images/airflow/2.9.2/python/mwaa/subprocess/subprocess.py
+++ b/images/airflow/2.9.2/python/mwaa/subprocess/subprocess.py
@@ -307,15 +307,18 @@ class Subprocess:
         # Do nothing if process has already terminated
         if self.process is None or self.process.poll() is not None:
             return
+
         module_logger.info(f"Shutting down {self}")
+
         try:
-            module_logger.info(f"Sending SIGTERM to {self}")
-            self.process.terminate()
+            module_logger.info(f"Sending SIGTERM to process group {self}")
+            os.killpg(os.getpgid(process.pid), signal.SIGTERM)
             action_taken = "terminated"
         except OSError:
-            module_logger.error(f"Failed to send SIGTERM to {self}. Sending SIGKILL...")
-            self.process.kill()
+            module_logger.error(f"Failed to send SIGTERM to process group {self}. Sending SIGKILL...")
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
             action_taken = "killed"
+
         sigterm_patience_interval_secs = self.sigterm_patience_interval.total_seconds()
         try:
             outs, _ = self.process.communicate(timeout=sigterm_patience_interval_secs)
@@ -323,14 +326,15 @@ class Subprocess:
                 self.process_logger.info(outs.decode("utf-8"))
         except subprocess.TimeoutExpired:
             module_logger.error(
-                f"Failed to kill {self} with a SIGTERM signal. Process didn't "
+                f"Failed to kill {self} with a SIGTERM signal. Process group didn't "
                 f"respond to SIGTERM after {sigterm_patience_interval_secs} "
                 "seconds. Sending SIGKILL..."
             )
-            self.process.kill()
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
             action_taken = "killed"
+
         module_logger.info(
-            f"Process {action_taken}. Return code is {self.process.returncode}."
+            f"Process group {action_taken}. Return code is {self.process.returncode}."
         )
 
     def start_log_capture(self):


### PR DESCRIPTION
*Issue #, if available:* #272 

*Description of changes:*

According to [Python documentation `process.terminate()`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process.terminate) does not properly clean up shell-spawned processes. 
This will impact the worker message queue consistency during worker shutdown: Without proper process group handling, worker subprocesses end up orphaned that continue running in the background, but will eventually get lost as the worker container is killed by ECS.

To address this: 
- Replaced `process.terminate()` with `os.killpg(os.getpgid(process.pid), signal.SIGTERM)`
- Replaced `process.kill()` with `os.killpg(os.getpgid(process.pid), signal.SIGKILL)`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
