### PR TITLE
Improve healthcheck: fallback to un-modified title

### DIFF
--- a/images/airflow/2.10.1/healthcheck.py
+++ b/images/airflow/2.10.1/healthcheck.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import os
 from enum import Enum
+from typing import List
 
 class ExitStatus(Enum):
     """
@@ -23,49 +24,52 @@ def exit_with_status(exit_status: ExitStatus):
     print(f"Exiting with status: {exit_status.name}")
     sys.exit(exit_status.value)
 
-def is_process_running(cmd_substring: str) -> bool:
+def is_process_running(cmd_substrings: List[str]) -> bool:
     """
-    Check if a process containing the given command substring is running.
+    Check if a process containing any of the given command substrings is running.
 
-    :param cmd_substring: Substring of the command used to launch the process.
+    :param cmd_substrings: A list of strings to search for in process commands.
     :return: True if a matching process is found, False otherwise.
     """
     try:
         procs = subprocess.check_output(['ps', 'uaxw']).decode().splitlines()
         for proc in procs:
-            if cmd_substring in proc:
-                print(f"Process found: {proc}")
-                return True
+            for substring in cmd_substrings:
+                if substring in proc:
+                    print(f"Process found: {proc}")
+                    return True
     except subprocess.SubprocessError as e:
         print(f"Error checking processes: {e}")
     return False
 
-def get_airflow_process_command(airflow_component: str):
+def get_airflow_process_command(airflow_component: str) -> List[str]:
     """
-    Get airflow command substring for a given airflow component.
+    Get airflow command substring(s) for a given airflow component.
 
-    :param airflow_component: Airflow component running on host. 
-    :return: Airflow command substring.
+    :param airflow_component: Airflow component running on host.
+    :return: List of airflow command substrings.
     """
     if airflow_component == "SCHEDULER":
-        return "/usr/local/airflow/.local/bin/airflow scheduler"
+        return ["/usr/local/airflow/.local/bin/airflow scheduler"]
 
     if airflow_component == "WORKER":
-        return "MainProcess] -active- (celery worker)"
+        return ["MainProcess] -active- (celery worker)", "/bin/airflow celery worker"]
 
     if airflow_component == "STATIC_ADDITIONAL_WORKER":
-        return "MainProcess] -active- (celery worker)"
+        return ["MainProcess] -active- (celery worker)", "/bin/airflow celery worker"]
 
     if airflow_component == "DYNAMIC_ADDITIONAL_WORKER":
-        return "MainProcess] -active- (celery worker)"
+        return ["MainProcess] -active- (celery worker)", "/bin/airflow celery worker"]
 
     if airflow_component == "ADDITIONAL_WEBSERVER":
-        return "/usr/local/airflow/.local/bin/airflow webserver"
+        return ["/usr/local/airflow/.local/bin/airflow webserver"]
 
     if airflow_component == "WEB_SERVER":
-        return "/usr/local/airflow/.local/bin/airflow webserver"
+        return ["/usr/local/airflow/.local/bin/airflow webserver"]
 
     exit_with_status(ExitStatus.INVALID_AIRFLOW_COMPONENT)
+    # This return will never be reached due to sys.exit() in exit_with_status
+    return []  # Return empty list to satisfy type checker
 
 def main():
     """

--- a/images/airflow/2.10.3/healthcheck.py
+++ b/images/airflow/2.10.3/healthcheck.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import os
 from enum import Enum
+from typing import List
 
 class ExitStatus(Enum):
     """
@@ -23,49 +24,52 @@ def exit_with_status(exit_status: ExitStatus):
     print(f"Exiting with status: {exit_status.name}")
     sys.exit(exit_status.value)
 
-def is_process_running(cmd_substring: str) -> bool:
+def is_process_running(cmd_substrings: List[str]) -> bool:
     """
-    Check if a process containing the given command substring is running.
+    Check if a process containing any of the given command substrings is running.
 
-    :param cmd_substring: Substring of the command used to launch the process.
+    :param cmd_substrings: A list of strings to search for in process commands.
     :return: True if a matching process is found, False otherwise.
     """
     try:
         procs = subprocess.check_output(['ps', 'uaxw']).decode().splitlines()
         for proc in procs:
-            if cmd_substring in proc:
-                print(f"Process found: {proc}")
-                return True
+            for substring in cmd_substrings:
+                if substring in proc:
+                    print(f"Process found: {proc}")
+                    return True
     except subprocess.SubprocessError as e:
         print(f"Error checking processes: {e}")
     return False
 
-def get_airflow_process_command(airflow_component: str):
+def get_airflow_process_command(airflow_component: str) -> List[str]:
     """
-    Get airflow command substring for a given airflow component.
+    Get airflow command substring(s) for a given airflow component.
 
-    :param airflow_component: Airflow component running on host. 
-    :return: Airflow command substring.
+    :param airflow_component: Airflow component running on host.
+    :return: List of airflow command substrings.
     """
     if airflow_component == "SCHEDULER":
-        return "/usr/local/airflow/.local/bin/airflow scheduler"
+        return ["/usr/local/airflow/.local/bin/airflow scheduler"]
 
     if airflow_component == "WORKER":
-        return "MainProcess] -active- (celery worker)"
+        return ["MainProcess] -active- (celery worker)", "/bin/airflow celery worker"]
 
     if airflow_component == "STATIC_ADDITIONAL_WORKER":
-        return "MainProcess] -active- (celery worker)"
+        return ["MainProcess] -active- (celery worker)", "/bin/airflow celery worker"]
 
     if airflow_component == "DYNAMIC_ADDITIONAL_WORKER":
-        return "MainProcess] -active- (celery worker)"
+        return ["MainProcess] -active- (celery worker)", "/bin/airflow celery worker"]
 
     if airflow_component == "ADDITIONAL_WEBSERVER":
-        return "/usr/local/airflow/.local/bin/airflow webserver"
+        return ["/usr/local/airflow/.local/bin/airflow webserver"]
 
     if airflow_component == "WEB_SERVER":
-        return "/usr/local/airflow/.local/bin/airflow webserver"
+        return ["/usr/local/airflow/.local/bin/airflow webserver"]
 
     exit_with_status(ExitStatus.INVALID_AIRFLOW_COMPONENT)
+    # This return will never be reached due to sys.exit() in exit_with_status
+    return []  # Return empty list to satisfy type checker
 
 def main():
     """

--- a/images/airflow/2.9.2/healthcheck.py
+++ b/images/airflow/2.9.2/healthcheck.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import os
 from enum import Enum
+from typing import List
 
 class ExitStatus(Enum):
     """
@@ -23,49 +24,52 @@ def exit_with_status(exit_status: ExitStatus):
     print(f"Exiting with status: {exit_status.name}")
     sys.exit(exit_status.value)
 
-def is_process_running(cmd_substring: str) -> bool:
+def is_process_running(cmd_substrings: List[str]) -> bool:
     """
-    Check if a process containing the given command substring is running.
+    Check if a process containing any of the given command substrings is running.
 
-    :param cmd_substring: Substring of the command used to launch the process.
+    :param cmd_substrings: A list of strings to search for in process commands.
     :return: True if a matching process is found, False otherwise.
     """
     try:
         procs = subprocess.check_output(['ps', 'uaxw']).decode().splitlines()
         for proc in procs:
-            if cmd_substring in proc:
-                print(f"Process found: {proc}")
-                return True
+            for substring in cmd_substrings:
+                if substring in proc:
+                    print(f"Process found: {proc}")
+                    return True
     except subprocess.SubprocessError as e:
         print(f"Error checking processes: {e}")
     return False
 
-def get_airflow_process_command(airflow_component: str):
+def get_airflow_process_command(airflow_component: str) -> List[str]:
     """
-    Get airflow command substring for a given airflow component.
+    Get airflow command substring(s) for a given airflow component.
 
-    :param airflow_component: Airflow component running on host. 
-    :return: Airflow command substring.
+    :param airflow_component: Airflow component running on host.
+    :return: List of airflow command substrings.
     """
     if airflow_component == "SCHEDULER":
-        return "/usr/local/airflow/.local/bin/airflow scheduler"
+        return ["/usr/local/airflow/.local/bin/airflow scheduler"]
 
     if airflow_component == "WORKER":
-        return "MainProcess] -active- (celery worker)"
+        return ["MainProcess] -active- (celery worker)", "/bin/airflow celery worker"]
 
     if airflow_component == "STATIC_ADDITIONAL_WORKER":
-        return "MainProcess] -active- (celery worker)"
+        return ["MainProcess] -active- (celery worker)", "/bin/airflow celery worker"]
 
     if airflow_component == "DYNAMIC_ADDITIONAL_WORKER":
-        return "MainProcess] -active- (celery worker)"
+        return ["MainProcess] -active- (celery worker)", "/bin/airflow celery worker"]
 
     if airflow_component == "ADDITIONAL_WEBSERVER":
-        return "/usr/local/airflow/.local/bin/airflow webserver"
+        return ["/usr/local/airflow/.local/bin/airflow webserver"]
 
     if airflow_component == "WEB_SERVER":
-        return "/usr/local/airflow/.local/bin/airflow webserver"
+        return ["/usr/local/airflow/.local/bin/airflow webserver"]
 
     exit_with_status(ExitStatus.INVALID_AIRFLOW_COMPONENT)
+    # This return will never be reached due to sys.exit() in exit_with_status
+    return []  # Return empty list to satisfy type checker
 
 def main():
     """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fallback to un-modified process title if celery process renaming fails due to any reason

*Testing*
Quality check is failing since test is not setup for version 3.0.2.

Tested all versions with following cases
1. Regular case 
```
[airflow@9011bf25155e /]$ python3 healthcheck.py WORKER
Process found: airflow     36  4.1  2.2 506068 176924 ?       Ss   09:51   0:09 [celeryd: celery@9011bf25155e:MainProcess] -active- (celery worker)
Airflow process WORKER is running.
Exiting with status: SUCCESS
```
2. Fallback case 
```
[airflow@823c6868afac /]$ python3 /healthcheck.py WORKER
Process found: airflow     53 68.6  2.1 506084 176492 ?       Ss   09:58   0:05 /usr/local/bin/python3.11 /usr/local/airflow/.local/bin/airflow celery worker
Airflow process WORKER is running.
Exiting with status: SUCCESS
```
4. Failure case
```
[airflow@2f07d0a3e07a ~]$ python3 /healthcheck.py WORKER
/tmp/mwaa/container_unhealthy file found - marking as unhealthy.
Exiting with status: AIRFLOW_COMPONENT_UNHEALTHY
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
