### PR TITLE
Adding Non-Critical Logging support

### DIFF
--- a/images/airflow/2.10.3/bootstrap/02-airflow/001-install-required-pip-packages.sh
+++ b/images/airflow/2.10.3/bootstrap/02-airflow/001-install-required-pip-packages.sh
@@ -15,6 +15,7 @@ REQUIRED_PACKAGES=(
     psycopg2
     pycurl
     watchtower
+    fluent-logger
     virtualenv
 )
 

--- a/images/airflow/2.10.3/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.10.3/python/mwaa/config/setup_environment.py
@@ -195,6 +195,9 @@ def _is_protected_os_environ(key: str) -> bool:
         # This is used to validate the version of Watchtower installed
         # which we don't allow the customer to override.
         "WATCHTOWER_VERSION",
+        # This is used to control whether we use NON-CRITICAL LOGGING flow with Fluentbit
+        # which we don't allow the customer to override.
+        "USE_NON_CRITICAL_LOGGING",
     ]
 
     # Check whether this is an MWAA configuration or a protected variable

--- a/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
@@ -26,11 +26,13 @@ import boto3
 import socket
 import time
 import watchtower
+from fluent import asynchandler as fluent_handler
 
 # Our imports
 from mwaa.logging.utils import parse_arn, throttle
 from mwaa.utils.statsd import get_statsd
 
+USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
@@ -98,13 +100,15 @@ class BaseLogHandler(logging.Handler):
         self.log_group_name, self.region_name = parse_arn(log_group_arn)
         self.handler = None
         self.logs_source = "Unknown"
+        self.NON_CRITICAL_LOGGING_ENABLED = USE_NON_CRITICAL_LOGGING.lower() == 'true'
+        self.log_stream = None
 
         # TODO Find a nice and unambiguous solution to the craziness of super() and MRO.
         logging.Handler.__init__(self)
 
         self.stats = get_statsd()
 
-    def create_watchtower_handler(
+    def create_cloudwatch_handler(
         self,
         stream_name: str,
         logs_source: str,
@@ -125,7 +129,7 @@ class BaseLogHandler(logging.Handler):
         """
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
-        if self.enabled:
+        if self.enabled and not self.NON_CRITICAL_LOGGING_ENABLED:
             self.handler = watchtower.CloudWatchLogHandler(
                 log_group_name=self.log_group_name,
                 log_stream_name=stream_name,
@@ -137,6 +141,44 @@ class BaseLogHandler(logging.Handler):
             if self.formatter:
                 self.handler.setFormatter(self.formatter)
         self.logs_source = logs_source
+        self.log_stream = stream_name
+
+        if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            self.handler = fluent_handler.FluentHandler(
+                'customer.logs',
+                host='localhost',
+                port=24224
+            )
+            if self.formatter:
+                # Wrap the existing formatter to add routing fields
+                original_formatter = self.formatter
+
+                log_group = self.log_group_name
+                log_stream = self.log_stream
+
+                class RoutingFormatter(logging.Formatter):
+                    def format(self, record):
+                        # Get the original formatted message
+                        formatted_msg = original_formatter.format(record)
+                        # Return dict with both the original format and routing fields
+                        return {
+                            'log_group': log_group,
+                            'log_stream': log_stream,
+                            'message': formatted_msg
+                        }
+                self.handler.setFormatter(RoutingFormatter())
+            else:
+                log_group = self.log_group_name
+                log_stream = self.log_stream
+                # If no formatter exists, use a basic one with routing fields
+                class DefaultRoutingFormatter(logging.Formatter):
+                    def format(self, record):
+                        return {
+                            'log_group': log_group,
+                            'log_stream': log_stream,
+                            'message': record.getMessage()
+                        }
+                self.handler.setFormatter(DefaultRoutingFormatter())
 
     def close(self):
         """Close the log handler (by closing the underlying log handler)."""
@@ -265,7 +307,7 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
         # https://github.com/aws/amazon-mwaa-docker-images/issues/57
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
-        if self.enabled:
+        if self.enabled and not self.NON_CRITICAL_LOGGING_ENABLED:
             # identical to open-source implementation, except create_log_group set to False
             self.handler = watchtower.CloudWatchLogHandler(
                 log_group_name=self.log_group_name,
@@ -277,6 +319,31 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
 
             if self.formatter:
                 self.handler.setFormatter(self.formatter)
+        if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            self.handler = fluent_handler.FluentHandler(
+                'customer.task.logs',
+                host='localhost',
+                port=24224,
+                queue_maxsize=50000,
+            )
+
+            original_formatter = self.formatter
+            log_group = self.log_group_name
+            stream_name = self._render_filename(ti, ti.try_number)
+
+            class TaskFormatter(logging.Formatter):
+                def format(self, record):
+                    if original_formatter:
+                        formatted_msg = original_formatter.format(record)
+                    else:
+                        formatted_msg = record.getMessage()
+                    return {
+                        'message': formatted_msg,
+                        'log_group': log_group,
+                        'log_stream': stream_name
+                    }
+
+            self.handler.setFormatter(TaskFormatter())
         else:
             self.handler = None
 
@@ -326,7 +393,7 @@ class DagProcessorManagerLogHandler(BaseLogHandler):
         [1] https://airflow.apache.org/docs/apache-airflow/2.9.2/configurations-ref.html#config-logging-log-processor-filename-template
         """
         super().__init__(log_group_arn, kms_key_arn, enabled)
-        self.create_watchtower_handler(stream_name, "DAGProcessorManager")
+        self.create_cloudwatch_handler(stream_name, "DAGProcessorManager")
 
     def _print(self, msg: str):
         # The DAG processing loggers are not started in the same way that the Web
@@ -385,7 +452,7 @@ class DagProcessingLogHandler(BaseLogHandler):
         :param filename: The name of the DAG file being processed.
         """
         stream_name = self._render_filename(filename)
-        self.create_watchtower_handler(
+        self.create_cloudwatch_handler(
             stream_name,
             logs_source="DAGProcessing",
             # cannot use queues/batching with DAG processing, since the DAG processor
@@ -469,4 +536,4 @@ class SubprocessLogHandler(BaseLogHandler):
         # not guaranteed unique and may be reused so include an epoch for uniqueness and
         # easy sorting chronologically.
         _stream_name = "%s_%s_%s.log" % (stream_name_prefix, hostname, epoch)
-        self.create_watchtower_handler(_stream_name, logs_source)
+        self.create_cloudwatch_handler(_stream_name, logs_source)

--- a/images/airflow/2.10.3/requirements.txt
+++ b/images/airflow/2.10.3/requirements.txt
@@ -15,6 +15,7 @@ celery[sqs]
 psycopg2
 pycurl
 watchtower
+fluent-logger
 # Additional packages for development
 # NOTE: Like above, we don't specify the version here.
 boto3-stubs[logs]

--- a/tests/images/airflow/2.10.3/requirements.txt
+++ b/tests/images/airflow/2.10.3/requirements.txt
@@ -14,6 +14,7 @@ apache-airflow-providers-amazon[aiobotocore]
 celery[sqs]
 pycurl
 watchtower
+fluent-logger
 # Additional packages for development
 # NOTE: Like above, we don't specify the version here.
 boto3-stubs[logs]


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Adding airflow image side Support to use FluentHandler for remote logging, disabled for now.
- Eventually when the feature flag is enabled, then we will switch to using a Fluenthandler instead of a watchtower handler, and also format record to include destination log group and stream for routing, and send the the logs to a fluentbit process, before routing to cloudwatch.
- Also added unit test cases for the changes
- Added USE_NON_CRITICAL_LOGGING to the protected env vars list.
- Only making the change to 2.10.3 for now, after testing and ensuring stability, we will extend to all versions.
- Not refactoring for the testing, since the formatter code is finnickey, and the current changes have been tested for all scenarios. Will try refactoring the code as suggested parallely along with the testing.

*Testing*
- Deployed environment with a Fluentbit container and feature flag enabled, ensured logging is working fine.
- Deployed as is, to ensure we still use the Watchtower handler by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
