### PR TITLE
Updating 3.0.2 constraints based on airflow updates

### DIFF
--- a/images/airflow/3.0.2/etc/airflow_constraints.txt
+++ b/images/airflow/3.0.2/etc/airflow_constraints.txt
@@ -132,7 +132,7 @@ apache-airflow-providers-cncf-kubernetes==10.5.0
 apache-airflow-providers-cohere==1.5.0
 apache-airflow-providers-common-compat==1.7.0
 apache-airflow-providers-common-io==1.6.0
-apache-airflow-providers-common-messaging==1.0.2
+apache-airflow-providers-common-messaging==1.0.3
 apache-airflow-providers-common-sql==1.27.1
 apache-airflow-providers-databricks==7.4.0
 apache-airflow-providers-datadog==3.9.0
@@ -143,6 +143,7 @@ apache-airflow-providers-docker==4.4.0
 apache-airflow-providers-edge3==1.1.0
 apache-airflow-providers-elasticsearch==6.3.0
 apache-airflow-providers-exasol==4.8.0
+apache-airflow-providers-fab==2.2.1
 apache-airflow-providers-facebook==3.8.0
 apache-airflow-providers-ftp==3.13.0
 apache-airflow-providers-git==0.0.2


### PR DESCRIPTION
*Issue #, if available:*
Airflow community updated constraints and rebuilt reference images for Airflow 3.0.2 following release of common-messaging provider 1.0.3 and fab provider 2.2.1.

Updating MWAA constraints file to reflect those changes.

Refer:

- https://github.com/apache/airflow/issues/51854
- https://github.com/apache/airflow/issues/51770

*Description of changes:*
Updated the constraints file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
