### PR TITLE
Refactoring code to fix TaskHandler errors

### DIFF
--- a/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
@@ -170,7 +170,6 @@ class BaseLogHandler(logging.Handler):
                 self.handler.setFormatter(DefaultRoutingFormatter())
 
         elif self.enabled:
-            print(f"Inside with stream name {stream_name}")
             self.handler = watchtower.CloudWatchLogHandler(
                 log_group_name=self.log_group_name,
                 log_stream_name=stream_name,


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*
- Refactored the code to use if-elif instead of multiple if statements, since this was causing the task handler to malfunction and not create task log streams in the case where NON_CRITICAL_LOGGING was disabled.
- This was happening since in the case NON_CRITICAL_LOGGING was not enabled, the second if statement would turn out to be false, and hence the else statement was getting executed, which was setting the handler to none again.

*Description of testing:*
- Tested via run.sh and deploying full fledged environments with NON_CRITICAL_LOGGING enabled and disabled, with different formatters for each, running dags for each case ensuring that all loggers work as expected in all cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
