### PR TITLE
Add new task logging handler for Airflow 3, plus minor task API related setup changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ images/airflow/3.*/requirements-dev.txt
 .coverage
 coverage.xml
 .coverage.*
+
+# MacOS
+*.DS_Store
+
+# Intellij
+*.idea*

--- a/images/airflow/3.0.2/python/mwaa/config/airflow.py
+++ b/images/airflow/3.0.2/python/mwaa/config/airflow.py
@@ -149,11 +149,8 @@ def _get_essential_airflow_api_auth_config() -> Dict[str, str]:
     :returns A dictionary containing the environment variables.
     """
     api_config: Dict[str, str] = {}
-    # TODO remove the condition after testing is complete.
-    if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "testing":
-        api_config["AIRFLOW__API_AUTH__JWT_SECRET"] = os.environ.get("MWAA__CORE__FERNET_KEY")
-        api_config["AIRFLOW__API_AUTH__JWT_ALGORITHM"] = "HS256"
-
+    api_config["AIRFLOW__API_AUTH__JWT_SECRET"] = os.environ.get("MWAA__CORE__FERNET_KEY")
+    api_config["AIRFLOW__API_AUTH__JWT_ALGORITHM"] = "HS256"
 
     return api_config
 

--- a/images/airflow/3.0.2/python/mwaa/config/airflow.py
+++ b/images/airflow/3.0.2/python/mwaa/config/airflow.py
@@ -61,6 +61,7 @@ def _get_essential_airflow_core_config() -> Dict[str, str]:
 
     fernet_secret_json = os.environ.get("MWAA__CORE__FERNET_KEY")
     api_server_url = os.environ.get("MWAA__CORE__API_SERVER_URL")
+    prefix = "" if "://" in api_server_url else "https://"
     if fernet_secret_json:
         try:
             fernet_key = {
@@ -73,7 +74,7 @@ def _get_essential_airflow_core_config() -> Dict[str, str]:
 
     return {
         "AIRFLOW__CORE__LOAD_EXAMPLES": "False",
-        "AIRFLOW__CORE__EXECUTION_API_SERVER_URL": api_server_url + "/execution",
+        "AIRFLOW__CORE__EXECUTION_API_SERVER_URL": prefix + api_server_url + "/execution",
         **fernet_key,
     }
 
@@ -148,8 +149,9 @@ def _get_essential_airflow_api_auth_config() -> Dict[str, str]:
     :returns A dictionary containing the environment variables.
     """
     api_config: Dict[str, str] = {}
+    # TODO remove the condition after testing is complete.
     if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "testing":
-        api_config["AIRFLOW__API_AUTH__JWT_SECRET"] = "dev-jwt-secret"
+        api_config["AIRFLOW__API_AUTH__JWT_SECRET"] = os.environ.get("MWAA__CORE__FERNET_KEY")
         api_config["AIRFLOW__API_AUTH__JWT_ALGORITHM"] = "HS256"
 
 

--- a/images/airflow/3.0.2/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.0.2/python/mwaa/logging/cloudwatch_handlers.py
@@ -8,25 +8,32 @@ handling scheduler/worker/etc logs, and so on.
 """
 
 # Python imports
+import contextlib
+import copy
+from datetime import datetime, timedelta, timezone
+from functools import cached_property
 import logging
+import json
 import os
 import re
+import structlog
 import sys
 import traceback
 
 # 3rd party imports
 from airflow.models.taskinstance import TaskInstance
-from airflow.providers.amazon.aws.log.cloudwatch_task_handler import (
-    CloudwatchTaskHandler,
-)
+from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
+from airflow.providers.amazon.aws.utils import datetime_to_epoch_utc_ms
+from airflow.sdk.types import RuntimeTaskInstanceProtocol as RuntimeTI
 from airflow.utils.helpers import parse_template_string
+from airflow.utils.log.file_task_handler import LogMessages, LogSourceInfo
+from airflow.utils.log.log_reader import LogMetadata
+from airflow.utils.log.logging_mixin import LoggingMixin
 from mypy_boto3_logs.client import CloudWatchLogsClient
-from typing import Dict
 import boto3
 import socket
 import time
 import watchtower
-
 # Our imports
 from mwaa.logging.utils import parse_arn, throttle
 from mwaa.utils.statsd import get_statsd
@@ -217,87 +224,189 @@ class BaseLogHandler(logging.Handler):
             self.stats.incr(f"mwaa.logging.{self.logs_source}.flush_error", 1)
             self._report_logging_error("Failed to flush log records.")
 
-
-class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
-    """A log handler used for Airflow task logs."""
-
-    # this option is required to be able to serve triggerer logs
-    trigger_should_wrap = True
+class CloudWatchRemoteLogger(BaseLogHandler, LoggingMixin):
+    """
+        In Airflow 3, we need to enable remote logging in order to load our custom logging logic into the task logger
+        which uses Structlog. The main logic resides in 'processors' property which is loaded by Structlog logger in
+        task-sdk/src/airflow/sdk/log.py#L143
+    """
+    LOG_SOURCE = "task"
+    TASK_LOG_STREAM_PATTERN = re.compile(r"dag_id=(.*?)\/run_id=(.*?)\/task_id=(.*?)\/attempt=(.*)")
 
     def __init__(
         self,
-        base_log_folder: str,
         log_group_arn: str,
         kms_key_arn: str | None,
         enabled: bool,
+        log_level: str
     ):
-        """
-        Initialize the instance.
-
-        :param log_group_arn - The ARN of the log group where logs will be published.
-        :param kms_key_arn - The ARN of the KMS key to use when creating the log group
-            if necessary.
-        :param enabled - Whether this handler is actually enabled, or just does nothing.
-            This makes it easier to control enabling and disabling logging without
-            much changes to the logging configuration.
-        """
-        self.processors = []
         BaseLogHandler.__init__(self, log_group_arn, kms_key_arn, enabled)
-        CloudwatchTaskHandler.__init__(
-            self,
-            log_group_arn=log_group_arn,
-            base_log_folder="",  # We only push to CloudWatch Logs.
-        )
+        self.log_level = logging.getLevelName(log_level)
 
-    def set_context(self, ti: TaskInstance, *, identifier: str | None = None) -> None:
-        """
-        Provide context to the logger.
+    @cached_property
+    def handler(self) -> watchtower.CloudWatchLogHandler:
+        return self._init_handler()
 
-        This method is called by Airflow to provide the necessary context to configure
-        the handler. In this case, Airflow is passing us the task instance the logs
-        are for.
-
-        :param ti: The task instance generating the logs.
-        :param identifier: Airflow uses this when relaying exceptional messages to task
-        logs from a context other than task itself. We ignore this parameter in this
-        handler, i.e. those exceptional messages will go to the same log stream.
-        """
-        # TODO Consider making use of the 'identifier' argument:
-        # https://github.com/aws/amazon-mwaa-docker-images/issues/57
+    def _init_handler(self):
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
-        if self.enabled:
-            # identical to open-source implementation, except create_log_group set to False
-            self.handler = watchtower.CloudWatchLogHandler(
-                log_group_name=self.log_group_name,
-                log_stream_name=self._render_filename(ti, ti.try_number),  # type: ignore
-                boto3_client=logs_client,
-                use_queues=True,
-                create_log_group=False,
-            )
-
-            if self.formatter:
-                self.handler.setFormatter(self.formatter)
-        else:
-            self.handler = None
+        return watchtower.CloudWatchLogHandler(
+            log_group_name=self.log_group_name,
+            boto3_client=logs_client,
+            use_queues=True,
+            create_log_group=False,
+        )
 
     def _render_filename(self, ti: TaskInstance, try_number: int) -> str:
         return f"dag_id={ti.dag_id}/run_id={ti.run_id}/task_id={ti.task_id}/attempt={try_number}.log"
 
-    def _event_to_str(self, event: Dict[str, str]) -> str:
-        # When rendering logs in the UI, the open-source implementation prefixes the
-        # logs by their timestamp metadata from the Cloudwatch response. Since the
-        # default log format already includes a timestamp within the message, this
-        # causes duplicate timestamps to appear and result in "invalid date" rendering
-        # in the UI
-        #
-        # Open-source code: https://github.com/apache/airflow/blob/v2-7-stable/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py#L120
-        #
-        # TODO: explore option to condition this function by the log_format. i.e. if it
-        # does not include a timestamp, add it here. Since customers can freely change
-        # the log_format, we should work towards accommodating both cases, but the
-        # default behavior is more important
-        return event["message"]
+    @cached_property
+    def processors(self) -> tuple[structlog.typing.Processor, ...]:
+        """
+            This is a (almost) direct port from CloudWatchRemoteLogIO class in Amazon provider. We need to carry out
+            the log writing logic in a processor that belongs to the remote logging class in Airflow 3 specifically
+            for task logging. In Airflow 3 task logging is done through Structlog instead of the old customer task log
+            handlers. And only the processor attribute from the remote logging class is loaded into the Structlog
+            logger used for task logging.
+        """
+        from logging import getLogRecordFactory
+
+        import structlog.stdlib
+
+        logRecordFactory = getLogRecordFactory()
+        # The handler MUST be initted here, before the processor is actually used to log anything.
+        # Otherwise, logging that occurs during the creation of the handler can create infinite loops.
+        _handler = self.handler if self.handler else self._init_handler()
+        from airflow.sdk.log import relative_path_from_logger
+
+        def proc(logger: structlog.typing.WrappedLogger, method_name: str, event: structlog.typing.EventDict):
+            if not logger or not (stream_name := relative_path_from_logger(logger)):
+                return event
+            _handler.log_stream_name = stream_name.as_posix().replace(":", "_")
+
+            # Dag processor log (from loading DagBag) shows up in task log during execution with a different
+            # stream name. Here we strictly limit that only task logs are printed in task log group.
+            if self.log_group_name.endswith("-Task") \
+                    and not re.match(CloudWatchRemoteLogger.TASK_LOG_STREAM_PATTERN, _handler.log_stream_name):
+                return event
+
+            name = event.get("logger_name") or event.get("logger", "")
+            level = structlog.stdlib.NAME_TO_LEVEL.get(method_name.lower(), logging.INFO)
+            if level < self.log_level:
+                return event
+
+            msg = copy.copy(event)
+            created = None
+            if ts := msg.pop("timestamp", None):
+                with contextlib.suppress(Exception):
+                    created = datetime.fromisoformat(ts)
+            record = logRecordFactory(
+                name, level, pathname="", lineno=0, msg=msg, args=(), exc_info=None, func=None, sinfo=None
+            )
+            if created is not None:
+                ct = created.timestamp()
+                record.created = ct
+                record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
+            try:
+                _handler.handle(record)
+            except Exception as e:
+                self.stats.incr(f"mwaa.logging.{CloudWatchRemoteLogger.LOG_SOURCE}.emit_error", 1)
+                # TODO maybe consider removing this if we plan to make logging non-critical
+                raise e
+            return event
+
+        return (proc,)
+
+    def emit(self, record: logging.LogRecord):
+        # No-op as the processor will take care of the uploading part. Also since set_context will no longer be called
+        # in Airflow 3, we will have no information on the current log stream name here.
+        return
+
+    def close(self):
+        if self.handler:
+            self.handler.close()
+
+    def upload(self, path: os.PathLike | str, ti: RuntimeTI):
+        # No-op, as we upload via the processor as we go
+        # But we need to give the handler time to finish off its business
+        self.flush()
+        return
+
+    def read(
+        self, task_instance, try_number, metadata=None
+    ) -> tuple[LogMessages, LogMetadata]:
+        """
+            Invoked by airflow-core/src/airflow/utils/log/log_reader.py when console tries to load task log. This is
+            the reason why we set Task logging handler to this class even though the actual log writing is done through
+            remote logging processor.
+        """
+        stream_name = self._render_filename(task_instance, try_number)
+        messages, logs = self._read_remote_logs(stream_name, task_instance)
+        return messages + logs, metadata
+
+    def _read_remote_logs(self, relative_path, ti: RuntimeTI) -> tuple[LogSourceInfo, LogMessages | None]:
+        messages = [
+            f"Reading remote log from Cloudwatch log_group: {self.log_group_arn} log_stream: {relative_path}"
+        ]
+        try:
+            from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+            logs = [
+                StructuredLogMessage.model_validate(log)
+                for log in self.get_cloudwatch_logs(relative_path, ti)
+            ]
+        except Exception as e:
+            logs = None
+            messages.append(str(e))
+
+        return messages, logs or []
+
+    @cached_property
+    def hook(self):
+        """Returns AwsLogsHook."""
+        return AwsLogsHook(
+            region_name=self.region_name
+        )
+
+    def get_cloudwatch_logs(self, stream_name: str, task_instance: RuntimeTI):
+        """
+        Return all logs from the given log stream.
+
+        :param stream_name: name of the Cloudwatch log stream to get all logs from
+        :param task_instance: the task instance to get logs about
+        :return: string of all logs from the given log stream
+        """
+        stream_name = stream_name.replace(":", "_")
+        # If there is an end_date to the task instance, fetch logs until that date + 30 seconds
+        # 30 seconds is an arbitrary buffer so that we don't miss any logs that were emitted
+        end_time = (
+            None
+            if (end_date := getattr(task_instance, "end_date", None)) is None
+            else datetime_to_epoch_utc_ms(end_date + timedelta(seconds=30))
+        )
+        log_group = self.log_group_arn.rsplit(":", 1)[1]
+        events = self.hook.get_log_events(
+            log_group=log_group,
+            log_stream_name=stream_name,
+            end_time=end_time,
+        )
+        return list(self._event_to_dict(e) for e in events)
+
+    def _event_to_dict(self, event: dict) -> dict:
+        event_dt = datetime.fromtimestamp(event["timestamp"] / 1000.0, tz=timezone.utc).isoformat()
+        message = event["message"]
+        try:
+            message = json.loads(message)
+            message["timestamp"] = event_dt
+            return message
+        except Exception:
+            return {"timestamp": event_dt, "event": message}
+
+    def _event_to_str(self, event: dict) -> str:
+        event_dt = datetime.fromtimestamp(event["timestamp"] / 1000.0, tz=timezone.utc)
+        formatted_event_dt = event_dt.strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
+        message = event["message"]
+        return f"[{formatted_event_dt}] {message}"
 
 
 class DagProcessorManagerLogHandler(BaseLogHandler):

--- a/images/airflow/3.0.2/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.0.2/python/mwaa/logging/cloudwatch_handlers.py
@@ -8,25 +8,32 @@ handling scheduler/worker/etc logs, and so on.
 """
 
 # Python imports
+import contextlib
+import copy
+from datetime import datetime, timedelta, timezone
+from functools import cached_property
 import logging
+import json
 import os
 import re
+import structlog
 import sys
 import traceback
 
 # 3rd party imports
 from airflow.models.taskinstance import TaskInstance
-from airflow.providers.amazon.aws.log.cloudwatch_task_handler import (
-    CloudwatchTaskHandler,
-)
+from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
+from airflow.providers.amazon.aws.utils import datetime_to_epoch_utc_ms
+from airflow.sdk.types import RuntimeTaskInstanceProtocol as RuntimeTI
 from airflow.utils.helpers import parse_template_string
+from airflow.utils.log.file_task_handler import LogMessages, LogSourceInfo
+from airflow.utils.log.log_reader import LogMetadata
+from airflow.utils.log.logging_mixin import LoggingMixin
 from mypy_boto3_logs.client import CloudWatchLogsClient
-from typing import Dict
 import boto3
 import socket
 import time
 import watchtower
-
 # Our imports
 from mwaa.logging.utils import parse_arn, throttle
 from mwaa.utils.statsd import get_statsd
@@ -217,87 +224,186 @@ class BaseLogHandler(logging.Handler):
             self.stats.incr(f"mwaa.logging.{self.logs_source}.flush_error", 1)
             self._report_logging_error("Failed to flush log records.")
 
-
-class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
-    """A log handler used for Airflow task logs."""
-
-    # this option is required to be able to serve triggerer logs
-    trigger_should_wrap = True
+class CloudWatchRemoteLogger(BaseLogHandler, LoggingMixin):
+    """
+        In Airflow 3, we need to enable remote logging in order to load our custom logging logic into the task logger
+        which uses Structlog. The main logic resides in 'processors' property which is loaded by Structlog logger in
+        task-sdk/src/airflow/sdk/log.py#L143
+    """
+    LOG_SOURCE = "task"
+    TASK_LOG_STREAM_PATTERN = re.compile(r"dag_id=(.*?)\/run_id=(.*?)\/task_id=(.*?)\/attempt=(.*)")
 
     def __init__(
         self,
-        base_log_folder: str,
         log_group_arn: str,
         kms_key_arn: str | None,
         enabled: bool,
+        log_level: str
     ):
-        """
-        Initialize the instance.
-
-        :param log_group_arn - The ARN of the log group where logs will be published.
-        :param kms_key_arn - The ARN of the KMS key to use when creating the log group
-            if necessary.
-        :param enabled - Whether this handler is actually enabled, or just does nothing.
-            This makes it easier to control enabling and disabling logging without
-            much changes to the logging configuration.
-        """
-        self.processors = []
         BaseLogHandler.__init__(self, log_group_arn, kms_key_arn, enabled)
-        CloudwatchTaskHandler.__init__(
-            self,
-            log_group_arn=log_group_arn,
-            base_log_folder="",  # We only push to CloudWatch Logs.
-        )
+        self.log_level = logging.getLevelName(log_level)
 
-    def set_context(self, ti: TaskInstance, *, identifier: str | None = None) -> None:
-        """
-        Provide context to the logger.
+    @cached_property
+    def handler(self) -> watchtower.CloudWatchLogHandler:
+        return self._init_handler()
 
-        This method is called by Airflow to provide the necessary context to configure
-        the handler. In this case, Airflow is passing us the task instance the logs
-        are for.
-
-        :param ti: The task instance generating the logs.
-        :param identifier: Airflow uses this when relaying exceptional messages to task
-        logs from a context other than task itself. We ignore this parameter in this
-        handler, i.e. those exceptional messages will go to the same log stream.
-        """
-        # TODO Consider making use of the 'identifier' argument:
-        # https://github.com/aws/amazon-mwaa-docker-images/issues/57
+    def _init_handler(self):
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
-        if self.enabled:
-            # identical to open-source implementation, except create_log_group set to False
-            self.handler = watchtower.CloudWatchLogHandler(
-                log_group_name=self.log_group_name,
-                log_stream_name=self._render_filename(ti, ti.try_number),  # type: ignore
-                boto3_client=logs_client,
-                use_queues=True,
-                create_log_group=False,
-            )
-
-            if self.formatter:
-                self.handler.setFormatter(self.formatter)
-        else:
-            self.handler = None
+        return watchtower.CloudWatchLogHandler(
+            log_group_name=self.log_group_name,
+            boto3_client=logs_client,
+            use_queues=True,
+            create_log_group=False,
+        )
 
     def _render_filename(self, ti: TaskInstance, try_number: int) -> str:
         return f"dag_id={ti.dag_id}/run_id={ti.run_id}/task_id={ti.task_id}/attempt={try_number}.log"
 
-    def _event_to_str(self, event: Dict[str, str]) -> str:
-        # When rendering logs in the UI, the open-source implementation prefixes the
-        # logs by their timestamp metadata from the Cloudwatch response. Since the
-        # default log format already includes a timestamp within the message, this
-        # causes duplicate timestamps to appear and result in "invalid date" rendering
-        # in the UI
-        #
-        # Open-source code: https://github.com/apache/airflow/blob/v2-7-stable/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py#L120
-        #
-        # TODO: explore option to condition this function by the log_format. i.e. if it
-        # does not include a timestamp, add it here. Since customers can freely change
-        # the log_format, we should work towards accommodating both cases, but the
-        # default behavior is more important
-        return event["message"]
+    @cached_property
+    def processors(self) -> tuple[structlog.typing.Processor, ...]:
+        """
+            This is a (almost) direct port from CloudWatchRemoteLogIO class in Amazon provider. We need to carry out
+            the log writing logic in a processor that belongs to the remote logging class in Airflow 3 specifically
+            for task logging. In Airflow 3 task logging is done through Structlog instead of the old customer task log
+            handlers. And only the processor attribute from the remote logging class is loaded into the Structlog
+            logger used for task logging.
+        """
+        from logging import getLogRecordFactory
+
+        import structlog.stdlib
+
+        logRecordFactory = getLogRecordFactory()
+        # The handler MUST be initted here, before the processor is actually used to log anything.
+        # Otherwise, logging that occurs during the creation of the handler can create infinite loops.
+        _handler = self.handler if self.handler else self._init_handler()
+        from airflow.sdk.log import relative_path_from_logger
+
+        def proc(logger: structlog.typing.WrappedLogger, method_name: str, event: structlog.typing.EventDict):
+            if not logger or not (stream_name := relative_path_from_logger(logger)):
+                return event
+            _handler.log_stream_name = stream_name.as_posix().replace(":", "_")
+
+            # Dag processor log (from loading DagBag) shows up in task log during execution with a different
+            # stream name. Here we strictly limit that only task logs are printed in task log group.
+            if self.log_group_name.endswith("-Task") \
+                    and not re.match(CloudWatchRemoteLogger.TASK_LOG_STREAM_PATTERN, _handler.log_stream_name):
+                return event
+
+            name = event.get("logger_name") or event.get("logger", "")
+            level = structlog.stdlib.NAME_TO_LEVEL.get(method_name.lower(), logging.INFO)
+            if level < self.log_level:
+                return event
+
+            msg = copy.copy(event)
+            created = None
+            if ts := msg.pop("timestamp", None):
+                with contextlib.suppress(Exception):
+                    created = datetime.fromisoformat(ts)
+            record = logRecordFactory(
+                name, level, pathname="", lineno=0, msg=msg, args=(), exc_info=None, func=None, sinfo=None
+            )
+            if created is not None:
+                ct = created.timestamp()
+                record.created = ct
+                record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
+            try:
+                _handler.handle(record)
+            except Exception as e:
+                self.stats.incr(f"mwaa.logging.{CloudWatchRemoteLogger.LOG_SOURCE}.emit_error", 1)
+                raise e
+            return event
+
+        return (proc,)
+
+    def emit(self, record: logging.LogRecord):
+        return
+
+    def close(self):
+        if self.handler:
+            self.handler.close()
+
+    def upload(self, path: os.PathLike | str, ti: RuntimeTI):
+        # No-op, as we upload via the processor as we go
+        # But we need to give the handler time to finish off its business
+        self.flush()
+        return
+
+    def read(
+        self, task_instance, try_number, metadata=None
+    ) -> tuple[LogMessages, LogMetadata]:
+        """
+            Invoked by airflow-core/src/airflow/utils/log/log_reader.py when console tries to load task log. This is
+            the reason why we set Task logging handler to this class even though the actual log writing is done through
+            remote logging processor.
+        """
+        stream_name = self._render_filename(task_instance, try_number)
+        messages, logs = self._read_remote_logs(stream_name, task_instance)
+        return messages + logs, metadata
+
+    def _read_remote_logs(self, relative_path, ti: RuntimeTI) -> tuple[LogSourceInfo, LogMessages | None]:
+        messages = [
+            f"Reading remote log from Cloudwatch log_group: {self.log_group_arn} log_stream: {relative_path}"
+        ]
+        try:
+            from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+            logs = [
+                StructuredLogMessage.model_validate(log)
+                for log in self.get_cloudwatch_logs(relative_path, ti)
+            ]
+        except Exception as e:
+            logs = None
+            messages.append(str(e))
+
+        return messages, logs or []
+
+    @cached_property
+    def hook(self):
+        """Returns AwsLogsHook."""
+        return AwsLogsHook(
+            region_name=self.region_name
+        )
+
+    def get_cloudwatch_logs(self, stream_name: str, task_instance: RuntimeTI):
+        """
+        Return all logs from the given log stream.
+
+        :param stream_name: name of the Cloudwatch log stream to get all logs from
+        :param task_instance: the task instance to get logs about
+        :return: string of all logs from the given log stream
+        """
+        stream_name = stream_name.replace(":", "_")
+        # If there is an end_date to the task instance, fetch logs until that date + 30 seconds
+        # 30 seconds is an arbitrary buffer so that we don't miss any logs that were emitted
+        end_time = (
+            None
+            if (end_date := getattr(task_instance, "end_date", None)) is None
+            else datetime_to_epoch_utc_ms(end_date + timedelta(seconds=30))
+        )
+        log_group = self.log_group_arn.rsplit(":", 1)[1]
+        events = self.hook.get_log_events(
+            log_group=log_group,
+            log_stream_name=stream_name,
+            end_time=end_time,
+        )
+        return list(self._event_to_dict(e) for e in events)
+
+    def _event_to_dict(self, event: dict) -> dict:
+        event_dt = datetime.fromtimestamp(event["timestamp"] / 1000.0, tz=timezone.utc).isoformat()
+        message = event["message"]
+        try:
+            message = json.loads(message)
+            message["timestamp"] = event_dt
+            return message
+        except Exception:
+            return {"timestamp": event_dt, "event": message}
+
+    def _event_to_str(self, event: dict) -> str:
+        event_dt = datetime.fromtimestamp(event["timestamp"] / 1000.0, tz=timezone.utc)
+        formatted_event_dt = event_dt.strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
+        message = event["message"]
+        return f"[{formatted_event_dt}] {message}"
 
 
 class DagProcessorManagerLogHandler(BaseLogHandler):

--- a/images/airflow/3.0.2/python/mwaa/logging/config.py
+++ b/images/airflow/3.0.2/python/mwaa/logging/config.py
@@ -29,7 +29,7 @@ from airflow.config_templates.airflow_local_settings import (
 
 # Our imports
 from mwaa.logging import cloudwatch_handlers
-from mwaa.logging.cloudwatch_handlers import CloudWatchRemoteLogger
+from mwaa.logging.cloudwatch_handlers import CloudWatchRemoteTaskLogger
 from mwaa.utils import qualified_name
 
 # We adopt the default logging configuration from Airflow and do the necessary changes
@@ -91,7 +91,7 @@ def _configure_remote_task_logging():
     global REMOTE_TASK_LOG
     # This is a weird thing from Airflow. Instead of providing the module path, Airflow expects the REMOTE_TASK_LOG
     # attribute from the custom logging module to be an instantiated class.
-    REMOTE_TASK_LOG = CloudWatchRemoteLogger(
+    REMOTE_TASK_LOG = CloudWatchRemoteTaskLogger(
         log_group_arn=log_group_arn,
         kms_key_arn=_get_kms_key_arn(),
         enabled=logging_enabled,
@@ -103,7 +103,7 @@ def _configure_task_logging():
     if log_group_arn:
         # Setup CloudWatch logging.
         LOGGING_CONFIG["handlers"]["task"] = {
-            "class": qualified_name(cloudwatch_handlers.CloudWatchRemoteLogger),
+            "class": qualified_name(cloudwatch_handlers.CloudWatchRemoteTaskLogger),
             "formatter": "airflow",
             "filters": ["mask_secrets"],
             "log_group_arn": log_group_arn,


### PR DESCRIPTION
Revamped the MWAA custom task logger for the Airflow 3 Structlog era. 

Since task logging will be carried out with Structlog in Airflow 3, our custom logger needs to have the core upload logic implemented in the processor property which is only loaded if remote logging is enabled before task execution starts. (in supervisor.py)

In the logging config setup, we also need to initialize the remote logging class and pass it to the REMOTE_TASK_LOG variable which will be loaded by Airflow.

Minor changes to the environment variable setup to enable task api.

Unit test will be added in a future PR.
