### PR TITLE
Set Webserver Secure Cookies to True

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/config/airflow.py
+++ b/images/airflow/2.10.1/python/mwaa/config/airflow.py
@@ -280,6 +280,7 @@ def _get_essential_airflow_webserver_config() -> Dict[str, str]:
 
     return {
         "AIRFLOW__WEBSERVER__CONFIG_FILE": "/python/mwaa/webserver/webserver_config.py",
+        "AIRFLOW__WEBSERVER__COOKIE_SECURE": "true",
         **flask_secret_key,
     }
 

--- a/images/airflow/2.10.3/python/mwaa/config/airflow.py
+++ b/images/airflow/2.10.3/python/mwaa/config/airflow.py
@@ -280,6 +280,7 @@ def _get_essential_airflow_webserver_config() -> Dict[str, str]:
 
     return {
         "AIRFLOW__WEBSERVER__CONFIG_FILE": "/python/mwaa/webserver/webserver_config.py",
+        "AIRFLOW__WEBSERVER__COOKIE_SECURE": "true",
         **flask_secret_key,
     }
 

--- a/images/airflow/2.9.2/python/mwaa/config/airflow.py
+++ b/images/airflow/2.9.2/python/mwaa/config/airflow.py
@@ -267,6 +267,7 @@ def _get_essential_airflow_webserver_config() -> Dict[str, str]:
 
     return {
         "AIRFLOW__WEBSERVER__CONFIG_FILE": "/python/mwaa/webserver/webserver_config.py",
+        "AIRFLOW__WEBSERVER__COOKIE_SECURE": "true",
         **flask_secret_key,
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We set Secure Cookies to true for MWAA environments before 2.9, we should keep this for 2.9 - 2.10.x versions as well. But this config is removed starting from 3.0.0. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
