### PR TITLE
Correct the python and watchtower version in the post startup script

### DIFF
--- a/images/airflow/3.0.2/bin/airflow-user/post-startup-script-verification
+++ b/images/airflow/3.0.2/bin/airflow-user/post-startup-script-verification
@@ -2,7 +2,7 @@
 echo "Executing post startup script verification"
 
 EXPECTED_AIRFLOW_VERSION="3.0.2"
-EXPECTED_WATCHTOWER_VERSION="3.3.1"
+EXPECTED_WATCHTOWER_VERSION="3.4.0"
 
 validate_version_with_pip() {
   if [[ $(pip3 show "$1" | grep 'Version' | grep -o '[0-9].*') != "$2" ]]
@@ -11,9 +11,9 @@ validate_version_with_pip() {
   fi
 }
 
-if ! python3 -c 'import sys; assert sys.version_info[:2] == (3,11)' > /dev/null;
+if ! python3 -c 'import sys; assert sys.version_info[:2] == (3,12)' > /dev/null;
 then
-  echo "Validation Error: Python version 3.11 expected"
+  echo "Validation Error: Python version 3.12 expected"
 fi
 
 validate_version_with_pip "apache-airflow" "$EXPECTED_AIRFLOW_VERSION"


### PR DESCRIPTION
…verification

*Issue #, if available:*

*Description of changes:*
Bugfix: Correct the python and watchtower version in the post startup script
https://github.com/isshishi/amazon-mwaa-docker-images/blob/7293f597877c84c226d63331528ee26e1c495a64/images/airflow/3.0.2/etc/mwaa_essential_constraints.txt#L4


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
