### PR TITLE
[PINWHEEL-5408] Logging issue

### DIFF
--- a/images/airflow/2.10.3/python/mwaa/subprocess/subprocess.py
+++ b/images/airflow/2.10.3/python/mwaa/subprocess/subprocess.py
@@ -214,7 +214,14 @@ class Subprocess:
                 else:
                     time.sleep(_SUBPROCESS_LOG_POLL_IDLE_SLEEP_INTERVAL.total_seconds())
             else:
-                self.process_logger.info(line.decode("utf-8"))
+                log_level = os.environ['AIRFLOW_CONSOLE_LOG_LEVEL']
+                match log_level:
+                    case "ERROR":
+                        self.process_logger.error(line.decode("utf-8"))
+                    case "WARNING":
+                        self.process_logger.warning(line.decode("utf-8"))
+                    case _:
+                        self.process_logger.info(line.decode("utf-8"))
     
     def _get_subprocess_status(self, process: Popen[Any]):
         return ProcessStatus.RUNNING if process.poll() is None else ProcessStatus.FINISHED

--- a/tests/images/airflow/2.10.3/python/mwaa/logging/test_subprocess.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/logging/test_subprocess.py
@@ -1,0 +1,98 @@
+import pytest
+from unittest.mock import patch, Mock, call
+import os
+from io import BytesIO
+from subprocess import Popen
+from mwaa.subprocess.subprocess import Subprocess
+import time
+
+@pytest.fixture
+def subprocess_instance():
+    """Fixture to create a Subprocess instance with mock command"""
+    return Subprocess(cmd="test_command")
+
+
+def test_read_subprocess_log_stream_empty_stream(subprocess_instance):
+    """Test behavior when stream is None"""
+    # Create mock process with None stdout
+    mock_process = Mock(spec=Popen)
+    mock_process.stdout = None
+
+    subprocess_instance.process_logger = Mock()
+    subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    # Assert no logging calls were made
+    subprocess_instance.process_logger.info.assert_not_called()
+    subprocess_instance.process_logger.error.assert_not_called()
+    subprocess_instance.process_logger.warning.assert_not_called()
+
+
+def test_read_subprocess_log_stream_process_running(self, mocker, mock_process, mock_logger):
+    """
+    Test that read_subprocess_log_stream correctly handles a running process
+    """
+    # Arrange
+    mock_sleep = mocker.patch('time.sleep')
+    expected_calls = [call(1)]  # Expect sleep to be called with 1 second delay
+
+    # Act
+    read_subprocess_log_stream(
+        process=mock_process,
+        logger=mock_logger
+    )
+
+    # Assert
+    mock_sleep.assert_called_once()
+    assert mock_sleep.call_args_list == expected_calls
+    assert mock_process.poll.call_count == 3  # Called until process ends
+    mock_logger.info.assert_called_with('test output')
+
+
+def test_read_subprocess_log_stream_closed_stream(subprocess_instance):
+    """Test behavior when stream is closed"""
+    # Create and configure mock process
+    mock_process = Mock(spec=Popen)
+    mock_process.stdout = Mock()
+    mock_process.stdout.closed = True
+
+    subprocess_instance.process_logger = Mock()
+    subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    subprocess_instance.process_logger.info.assert_not_called()
+
+
+def test_read_subprocess_log_stream_process_terminated(subprocess_instance):
+    """Test behavior when process has terminated"""
+    # Create and configure mock process
+    mock_process = Mock(spec=Popen)
+    mock_process.stdout = BytesIO(b"final message\n")
+    mock_process.poll.return_value = 0
+
+    subprocess_instance.process_logger = Mock()
+
+    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'INFO'}):
+        subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    subprocess_instance.process_logger.info.assert_called_once_with("final message\n")
+
+def read_subprocess_log_stream(process, logger):
+    """
+    Read and log output from a subprocess stream
+
+    Args:
+        process: subprocess.Popen instance
+        logger: logging.Logger instance
+    """
+    try:
+        while process.poll() is None:
+            output = process.stdout.readline()
+            if output:
+                # Decode bytes to string and strip whitespace
+                log_line = output.decode('utf-8').strip()
+                if log_line:
+                    logger.info(log_line)
+            else:
+                time.sleep(1)
+    except Exception as e:
+        logger.error(f"Error reading subprocess output: {str(e)}")
+        raise

--- a/tests/images/airflow/2.10.3/python/mwaa/logging/test_subprocess.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/logging/test_subprocess.py
@@ -27,7 +27,7 @@ def test_read_subprocess_log_stream_empty_stream(subprocess_instance):
     subprocess_instance.process_logger.warning.assert_not_called()
 
 
-def test_read_subprocess_log_stream_process_running(self, mocker, mock_process, mock_logger):
+def test_read_subprocess_log_stream_process_running(mocker, mock_process, mock_logger):
     """
     Test that read_subprocess_log_stream correctly handles a running process
     """


### PR DESCRIPTION
***Issue***
When emitting logs to CloudWatch we validate the log level of logs against the value set by the customer on the console. If the level matches, the log is pushed to CloudWatch. This is done using the below if block:
`
if record.levelno >= logging._nameToLevel[os.environ.get(
                    f"MWAA__LOGGING__AIRFLOW_{self.logs_source.upper()}_LOG_LEVEL", "INFO")]:
`

This condition works fine for most of the usecases.
However, in case of Scheduler and Worker MWAA overrides the log level coming from Airflow to INFO, which means if Airflow emits ERROR logs, MWAA makes them INFO while reading the logs via a stream and so the logLevel is lost. This is done because the log level is not available for logs coming from Airflow and we read them via a stream.
`
self.process_logger.info(line.decode("utf-8"))
`

***Description of changes:***
To fix this issue, we are now validating the logging level set in the console in the subprocess as well. This is under the verified assumption that only the desired logs will arrive from Airflow (If WARNING is set in console, Airflow will send WARNING and ERROR logs only). We manually set the log level to the LOG_LEVEL set in console. 
