### PR TITLE
Skip startup-script when running migrate-db

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.10.1/python/mwaa/config/setup_environment.py
@@ -42,6 +42,10 @@ def _execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]
     purposes so the logs of the execution of the startup script get sent to the correct place.
     :param environ: A dictionary containing the environment variables.
     """
+    # Skip startup script execution for migrate-db command
+    if cmd == "migrate-db":
+        logger.info("Skipping startup script execution for migrate-db command.")
+        return {}
     startup_script_path = os.environ.get("MWAA__CORE__STARTUP_SCRIPT_PATH", "")
     if not startup_script_path:
         logger.info("MWAA__CORE__STARTUP_SCRIPT_PATH is not provided.")

--- a/images/airflow/2.10.3/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.10.3/python/mwaa/config/setup_environment.py
@@ -42,6 +42,10 @@ def _execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]
     purposes so the logs of the execution of the startup script get sent to the correct place.
     :param environ: A dictionary containing the environment variables.
     """
+    # Skip startup script execution for migrate-db command
+    if cmd == "migrate-db":
+        logger.info("Skipping startup script execution for migrate-db command.")
+        return {}
     startup_script_path = os.environ.get("MWAA__CORE__STARTUP_SCRIPT_PATH", "")
     if not startup_script_path:
         logger.info("MWAA__CORE__STARTUP_SCRIPT_PATH is not provided.")

--- a/images/airflow/2.11.0/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.11.0/python/mwaa/config/setup_environment.py
@@ -42,6 +42,10 @@ def _execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]
     purposes so the logs of the execution of the startup script get sent to the correct place.
     :param environ: A dictionary containing the environment variables.
     """
+    # Skip startup script execution for migrate-db command
+    if cmd == "migrate-db":
+        logger.info("Skipping startup script execution for migrate-db command.")
+        return {}
     startup_script_path = os.environ.get("MWAA__CORE__STARTUP_SCRIPT_PATH", "")
     if not startup_script_path:
         logger.info("MWAA__CORE__STARTUP_SCRIPT_PATH is not provided.")

--- a/images/airflow/2.9.2/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.9.2/python/mwaa/config/setup_environment.py
@@ -42,6 +42,10 @@ def _execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]
     purposes so the logs of the execution of the startup script get sent to the correct place.
     :param environ: A dictionary containing the environment variables.
     """
+    # Skip startup script execution for migrate-db command
+    if cmd == "migrate-db":
+        logger.info("Skipping startup script execution for migrate-db command.")
+        return {}
     startup_script_path = os.environ.get("MWAA__CORE__STARTUP_SCRIPT_PATH", "")
     if not startup_script_path:
         logger.info("MWAA__CORE__STARTUP_SCRIPT_PATH is not provided.")

--- a/images/airflow/3.0.3/python/mwaa/config/setup_environment.py
+++ b/images/airflow/3.0.3/python/mwaa/config/setup_environment.py
@@ -42,6 +42,10 @@ def _execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]
     purposes so the logs of the execution of the startup script get sent to the correct place.
     :param environ: A dictionary containing the environment variables.
     """
+    # Skip startup script execution for migrate-db command
+    if cmd == "migrate-db":
+        logger.info("Skipping startup script execution for migrate-db command.")
+        return {}
     startup_script_path = os.environ.get("MWAA__CORE__STARTUP_SCRIPT_PATH", "")
     if not startup_script_path:
         logger.info("MWAA__CORE__STARTUP_SCRIPT_PATH is not provided.")


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Disable the startup script when running the migrate-db command.

Tested by creating MWAA environments using the updated image.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
