### PR TITLE
Remove Deprecated Config & SimpleAuthManager Username Fix

### DIFF
--- a/images/airflow/3.0.3/python/mwaa/config/airflow.py
+++ b/images/airflow/3.0.3/python/mwaa/config/airflow.py
@@ -291,24 +291,8 @@ def _get_essential_airflow_webserver_config() -> Dict[str, str]:
     :returns A dictionary containing the environment variables.
     """
 
-    flask_secret_key = {}
-    flask_secret_secret = os.environ.get("MWAA__WEBSERVER__SECRET")
-    if flask_secret_secret:
-        try:
-            flask_secret_key = {
-                "AIRFLOW__WEBSERVER__SECRET_KEY": json.loads(flask_secret_secret)[
-                    "secret_key"
-                ]
-            }
-        except:
-            logger.warning(
-                "Invalid value for the webserver secret key. Value not printed "
-                "for security reasons.",
-            )
-
     return {
         "AIRFLOW__FAB__CONFIG_FILE": "/python/mwaa/webserver/webserver_config.py",
-        **flask_secret_key,
     }
 
 

--- a/images/airflow/3.0.3/python/mwaa/config/airflow.py
+++ b/images/airflow/3.0.3/python/mwaa/config/airflow.py
@@ -137,7 +137,7 @@ def _get_essential_airflow_auth_config() -> Dict[str, str]:
     # SIMPLE_AUTH_MANAGER_USERS is in username:role format. Set SIMPLE_AUTH_MANAGER_ALL_ADMINS=false to have dedicated
     # roles. In that case, the password for each username will be printed in webserver logs.
     return {
-        "AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS": "admin:admin,admin:viewer",
+        "AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS": "admin:admin,viewer:viewer",
         "AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS": "True",
     }
 


### PR DESCRIPTION
*Description of changes:*

- **Fix default username for SimpleAuthManager:** There was a bug where both admin and viewer roles had the same username. This is of the format `username:role`. Ref: https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#simple-auth-manager-users
- 
- **Remove deprecated AIRFLOW__WEBSERVER__SECRET_KEY config from Airflow 3.0.3:** `AIRFLOW__WEBSERVER__SECRET_KEY` no longer exists in Airflow 3. `AIRFLOW__API_AUTH__JWT_SECRET` is the equivalent which is already set. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
