### PR TITLE
Set reserialize_dags to False on DB upgrades and downgrades

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.10.1/python/mwaa/database/migrate_with_downgrade.py
@@ -47,7 +47,7 @@ def _migrate_db():
         args = Namespace(
             from_revision=None,
             from_version=None,
-            reserialize_dags=True,
+            reserialize_dags=False,
             show_sql_only=None,
             to_revision=None,
             to_version=None,
@@ -64,7 +64,7 @@ def _check_downgrade_db():
         args = Namespace(
                 from_revision=None,
                 from_version=None,
-                reserialize_dags=True,
+                reserialize_dags=False,
                 show_sql_only=None,
                 to_revision=None,
                 to_version=target_version,

--- a/images/airflow/2.10.1/python/mwaa/database/reseralize.py
+++ b/images/airflow/2.10.1/python/mwaa/database/reseralize.py
@@ -1,0 +1,40 @@
+"""
+This script is responsible for reserializing Airflow meta database objects.
+"""
+
+from argparse import Namespace
+import logging.config
+import os
+import sys
+
+from mwaa.utils.dblock import with_db_lock
+
+
+# Hard-code the module path for logging since __name__ will be '__main__' when run as script
+logger = logging.getLogger("mwaa.database.reserialize")
+
+
+def _reserialize():
+    """
+    Reserializes Airflow database objects by calling the Airflow CLI reserialize command.
+    Requires all Airflow environment variables to be properly configured.
+    """
+    from argparse import Namespace
+    from airflow.cli.commands import dag_command as airflow_dag_command
+
+    args = Namespace(bundle_name=None, clear_only=False, subdir=None)
+    logging.info("Reserializing Airflow dags")
+    airflow_dag_command.dag_reserialize(args)
+
+def _main():
+    """Main entry point for the reserialize script."""
+    _reserialize()
+
+
+if __name__ == "__main__":
+    _main()
+else:
+    logger.error(
+        "This module cannot be imported. It should be run directly using: python -m mwaa.database.reseralize"
+    )
+    sys.exit(1)

--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -143,6 +143,16 @@ async def airflow_db_migrate(environ: dict[str, str]):
     await run_command("python3 -m mwaa.database.migrate_with_downgrade", env=environ)
 
 
+async def airflow_dag_reserialize():
+    """
+    Reserialize the dags.
+
+    Have the process run the dag_reserialize command to make sure the dags are compatible
+    with the current airflow database version.
+    """
+    await run_command("python3 -m mwaa.database.reserialize")
+
+
 @with_db_lock(5678)
 async def create_airflow_user(environ: dict[str, str]):
     """
@@ -239,6 +249,9 @@ async def main() -> None:
 
     # Remove this when we only want the migrate container to update db
     await airflow_db_init(environ)
+
+    if command == "scheduler":
+        await airflow_dag_reserialize()
 
     if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "testing":
         # In "simple" auth mode, we create an admin user "airflow" with password

--- a/images/airflow/2.10.3/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.10.3/python/mwaa/database/migrate_with_downgrade.py
@@ -47,7 +47,7 @@ def _migrate_db():
         args = Namespace(
             from_revision=None,
             from_version=None,
-            reserialize_dags=True,
+            reserialize_dags=False,
             show_sql_only=None,
             to_revision=None,
             to_version=None,
@@ -64,7 +64,7 @@ def _check_downgrade_db():
         args = Namespace(
                 from_revision=None,
                 from_version=None,
-                reserialize_dags=True,
+                reserialize_dags=False,
                 show_sql_only=None,
                 to_revision=None,
                 to_version=target_version,

--- a/images/airflow/2.10.3/python/mwaa/database/reseralize.py
+++ b/images/airflow/2.10.3/python/mwaa/database/reseralize.py
@@ -1,0 +1,40 @@
+"""
+This script is responsible for reserializing Airflow meta database objects.
+"""
+
+from argparse import Namespace
+import logging.config
+import os
+import sys
+
+from mwaa.utils.dblock import with_db_lock
+
+
+# Hard-code the module path for logging since __name__ will be '__main__' when run as script
+logger = logging.getLogger("mwaa.database.reserialize")
+
+
+def _reserialize():
+    """
+    Reserializes Airflow database objects by calling the Airflow CLI reserialize command.
+    Requires all Airflow environment variables to be properly configured.
+    """
+    from argparse import Namespace
+    from airflow.cli.commands import dag_command as airflow_dag_command
+
+    args = Namespace(bundle_name=None, clear_only=False, subdir=None)
+    logging.info("Reserializing Airflow dags")
+    airflow_dag_command.dag_reserialize(args)
+
+def _main():
+    """Main entry point for the reserialize script."""
+    _reserialize()
+
+
+if __name__ == "__main__":
+    _main()
+else:
+    logger.error(
+        "This module cannot be imported. It should be run directly using: python -m mwaa.database.reseralize"
+    )
+    sys.exit(1)

--- a/images/airflow/2.10.3/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.3/python/mwaa/entrypoint.py
@@ -142,6 +142,16 @@ async def airflow_db_migrate(environ: dict[str, str]):
     await run_command("python3 -m mwaa.database.migrate_with_downgrade", env=environ)
 
 
+async def airflow_dag_reserialize():
+    """
+    Reserialize the dags.
+
+    Have the process run the dag_reserialize command to make sure the dags are compatible
+    with the current airflow database version.
+    """
+    await run_command("python3 -m mwaa.database.reserialize")
+
+
 @with_db_lock(5678)
 async def create_airflow_user(environ: dict[str, str]):
     """
@@ -238,6 +248,9 @@ async def main() -> None:
 
     # Remove this when we only want the migrate container to update db
     await airflow_db_init(environ)
+
+    if command == "scheduler":
+        await airflow_dag_reserialize()
 
     if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "testing":
         # In "simple" auth mode, we create an admin user "airflow" with password

--- a/images/airflow/2.11.0/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.11.0/python/mwaa/database/migrate_with_downgrade.py
@@ -47,7 +47,7 @@ def _migrate_db():
         args = Namespace(
             from_revision=None,
             from_version=None,
-            reserialize_dags=True,
+            reserialize_dags=False,
             show_sql_only=None,
             to_revision=None,
             to_version=None,
@@ -64,7 +64,7 @@ def _check_downgrade_db():
         args = Namespace(
                 from_revision=None,
                 from_version=None,
-                reserialize_dags=True,
+                reserialize_dags=False,
                 show_sql_only=None,
                 to_revision=None,
                 to_version=target_version,

--- a/images/airflow/2.11.0/python/mwaa/database/reseralize.py
+++ b/images/airflow/2.11.0/python/mwaa/database/reseralize.py
@@ -1,0 +1,40 @@
+"""
+This script is responsible for reserializing Airflow meta database objects.
+"""
+
+from argparse import Namespace
+import logging.config
+import os
+import sys
+
+from mwaa.utils.dblock import with_db_lock
+
+
+# Hard-code the module path for logging since __name__ will be '__main__' when run as script
+logger = logging.getLogger("mwaa.database.reserialize")
+
+
+def _reserialize():
+    """
+    Reserializes Airflow database objects by calling the Airflow CLI reserialize command.
+    Requires all Airflow environment variables to be properly configured.
+    """
+    from argparse import Namespace
+    from airflow.cli.commands import dag_command as airflow_dag_command
+
+    args = Namespace(bundle_name=None, clear_only=False, subdir=None)
+    logging.info("Reserializing Airflow dags")
+    airflow_dag_command.dag_reserialize(args)
+
+def _main():
+    """Main entry point for the reserialize script."""
+    _reserialize()
+
+
+if __name__ == "__main__":
+    _main()
+else:
+    logger.error(
+        "This module cannot be imported. It should be run directly using: python -m mwaa.database.reseralize"
+    )
+    sys.exit(1)

--- a/images/airflow/2.11.0/python/mwaa/entrypoint.py
+++ b/images/airflow/2.11.0/python/mwaa/entrypoint.py
@@ -142,6 +142,16 @@ async def airflow_db_migrate(environ: dict[str, str]):
     await run_command("python3 -m mwaa.database.migrate_with_downgrade", env=environ)
 
 
+async def airflow_dag_reserialize():
+    """
+    Reserialize the dags.
+
+    Have the process run the dag_reserialize command to make sure the dags are compatible
+    with the current airflow database version.
+    """
+    await run_command("python3 -m mwaa.database.reserialize")
+
+
 @with_db_lock(5678)
 async def create_airflow_user(environ: dict[str, str]):
     """
@@ -238,6 +248,9 @@ async def main() -> None:
 
     # Remove this when we only want the migrate container to update db
     await airflow_db_init(environ)
+
+    if command == "scheduler":
+        await airflow_dag_reserialize()
 
     if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "testing":
         # In "simple" auth mode, we create an admin user "airflow" with password

--- a/images/airflow/2.9.2/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.9.2/python/mwaa/database/migrate_with_downgrade.py
@@ -47,7 +47,7 @@ def _migrate_db():
         args = Namespace(
             from_revision=None,
             from_version=None,
-            reserialize_dags=True,
+            reserialize_dags=False,
             show_sql_only=None,
             to_revision=None,
             to_version=None,
@@ -64,7 +64,7 @@ def _check_downgrade_db():
         args = Namespace(
                 from_revision=None,
                 from_version=None,
-                reserialize_dags=True,
+                reserialize_dags=False,
                 show_sql_only=None,
                 to_revision=None,
                 to_version=target_version,

--- a/images/airflow/2.9.2/python/mwaa/database/reseralize.py
+++ b/images/airflow/2.9.2/python/mwaa/database/reseralize.py
@@ -1,0 +1,40 @@
+"""
+This script is responsible for reserializing Airflow meta database objects.
+"""
+
+from argparse import Namespace
+import logging.config
+import os
+import sys
+
+from mwaa.utils.dblock import with_db_lock
+
+
+# Hard-code the module path for logging since __name__ will be '__main__' when run as script
+logger = logging.getLogger("mwaa.database.reserialize")
+
+
+def _reserialize():
+    """
+    Reserializes Airflow database objects by calling the Airflow CLI reserialize command.
+    Requires all Airflow environment variables to be properly configured.
+    """
+    from argparse import Namespace
+    from airflow.cli.commands import dag_command as airflow_dag_command
+
+    args = Namespace(bundle_name=None, clear_only=False, subdir=None)
+    logging.info("Reserializing Airflow dags")
+    airflow_dag_command.dag_reserialize(args)
+
+def _main():
+    """Main entry point for the reserialize script."""
+    _reserialize()
+
+
+if __name__ == "__main__":
+    _main()
+else:
+    logger.error(
+        "This module cannot be imported. It should be run directly using: python -m mwaa.database.reseralize"
+    )
+    sys.exit(1)

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -144,6 +144,16 @@ async def airflow_db_migrate(environ: dict[str, str]):
     await run_command("python3 -m mwaa.database.migrate_with_downgrade", env=environ)
 
 
+async def airflow_dag_reserialize():
+    """
+    Reserialize the dags.
+
+    Have the process run the dag_reserialize command to make sure the dags are compatible
+    with the current airflow database version.
+    """
+    await run_command("python3 -m mwaa.database.reserialize")
+
+
 async def increase_pool_size_if_default_size(environ: dict[str, str]):
     """
     Update the default pool size
@@ -278,6 +288,8 @@ async def main() -> None:
 
     # Remove this when we only want the migrate container to update db
     await airflow_db_init(environ)
+    if command == "scheduler":
+        await airflow_dag_reserialize()
 
     await increase_pool_size_if_default_size(environ)
     if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "testing":

--- a/images/airflow/3.0.3/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.0.3/python/mwaa/database/migrate_with_downgrade.py
@@ -47,7 +47,7 @@ def _migrate_db():
         args = Namespace(
             from_revision=None,
             from_version=None,
-            reserialize_dags=True,
+            reserialize_dags=False,
             show_sql_only=None,
             to_revision=None,
             to_version=None,
@@ -64,7 +64,7 @@ def _check_downgrade_db():
         args = Namespace(
                 from_revision=None,
                 from_version=None,
-                reserialize_dags=True,
+                reserialize_dags=False,
                 show_sql_only=None,
                 to_revision=None,
                 to_version=target_version,

--- a/images/airflow/3.0.3/python/mwaa/database/reseralize.py
+++ b/images/airflow/3.0.3/python/mwaa/database/reseralize.py
@@ -1,0 +1,40 @@
+"""
+This script is responsible for reserializing Airflow meta database objects.
+"""
+
+from argparse import Namespace
+import logging.config
+import os
+import sys
+
+from mwaa.utils.dblock import with_db_lock
+
+
+# Hard-code the module path for logging since __name__ will be '__main__' when run as script
+logger = logging.getLogger("mwaa.database.reserialize")
+
+
+def _reserialize():
+    """
+    Reserializes Airflow database objects by calling the Airflow CLI reserialize command.
+    Requires all Airflow environment variables to be properly configured.
+    """
+    from argparse import Namespace
+    from airflow.cli.commands import dag_command as airflow_dag_command
+
+    args = Namespace(bundle_name=None)
+    logging.info("Reserializing Airflow DAGs")
+    airflow_dag_command.dag_reserialize(args)
+
+def _main():
+    """Main entry point for the reserialize script."""
+    _reserialize()
+
+
+if __name__ == "__main__":
+    _main()
+else:
+    logger.error(
+        "This module cannot be imported. It should be run directly using: python -m mwaa.database.reseralize"
+    )
+    sys.exit(1)

--- a/images/airflow/3.0.3/python/mwaa/entrypoint.py
+++ b/images/airflow/3.0.3/python/mwaa/entrypoint.py
@@ -142,6 +142,15 @@ async def airflow_db_migrate(environ: dict[str, str]):
     await run_command("python3 -m mwaa.database.migrate_with_downgrade", env=environ)
 
 
+async def airflow_dag_reserialize():
+    """
+    Reserialize the dags.
+
+    Have the process run the dag_reserialize command to make sure the dags are compatible
+    with the current airflow database version.
+    """
+    await run_command("python3 -m mwaa.database.reserialize")
+
 @with_db_lock(5678)
 async def create_airflow_user(environ: dict[str, str]):
     """
@@ -238,6 +247,10 @@ async def main() -> None:
 
     # Remove this when we only want the migrate container to update db
     await airflow_db_init(environ)
+
+    if command == "scheduler":
+        await airflow_dag_reserialize()
+
     if executor_type.lower() == "celeryexecutor":
         create_queue()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set reserialize_dags to False on DB upgrades and downgrades as it is loading dags for the upgrades/downgrades. We do not install requirements for this process now so we cannot load their dags.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
