### PR TITLE
Removing FAB auth-disabling irrelevant in AF3 and adding configs to protected env var list

### DIFF
--- a/images/airflow/3.0.3/python/mwaa/config/airflow.py
+++ b/images/airflow/3.0.3/python/mwaa/config/airflow.py
@@ -311,20 +311,6 @@ def _get_essential_airflow_webserver_config() -> Dict[str, str]:
         **flask_secret_key,
     }
 
-
-def _get_essential_airflow_api_config() -> Dict[str, str]:
-    """
-    Retrieve the environment variables for Airflow's "api" configuration section.
-
-    :returns A dictionary containing the environment variables.
-    """
-    api_config: Dict[str, str] = {}
-    if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "none":
-        api_config["AIRFLOW__API__AUTH_BACKENDS"] = "airflow.api.auth.backend.default"
-
-    return api_config
-
-
 def get_essential_airflow_config(executor_type: str) -> Dict[str, str]:
     """
     Retrieve the environment variables required to set Airflow configurations.
@@ -343,7 +329,6 @@ def get_essential_airflow_config(executor_type: str) -> Dict[str, str]:
         **_get_mwaa_cloudwatch_integration_config(),
         **_get_essential_airflow_scheduler_config(),
         **_get_essential_airflow_webserver_config(),
-        **_get_essential_airflow_api_config(),
         **_get_essential_airflow_auth_config(),
         **_get_essential_airflow_api_auth_config()
     }

--- a/images/airflow/3.0.3/python/mwaa/config/setup_environment.py
+++ b/images/airflow/3.0.3/python/mwaa/config/setup_environment.py
@@ -174,6 +174,9 @@ def _is_protected_os_environ(key: str) -> bool:
         # This is set to match the endpoint created
         # by MWAA and shouldn't be overridden.
         "AIRFLOW__WEBSERVER__BASE_URL",
+        # Airflow 3 replaces WEBSERVER with APISERVER, so this is Airflow 3's
+        # equivalent of AIRFLOW__WEBSERVER__BASE_URL
+        "AIRFLOW__API__BASE_URL",
         # Default AWS region set by MWAA and used for AWS services.
         "AWS_DEFAULT_REGION",
         # AWS_REGION has a broader scope that is used by not just MWAA but
@@ -202,6 +205,9 @@ def _is_protected_os_environ(key: str) -> bool:
         # This is used to control whether we use NON-CRITICAL LOGGING flow with Fluentbit
         # which we don't allow the customer to override.
         "USE_NON_CRITICAL_LOGGING",
+        # This decides whether components should use Airflow Internal API for DB connectivity,
+        # which is an experimental feature we do not support for now.
+        "AIRFLOW__CORE__DATABASE_ACCESS_ISOLATION",
     ]
 
     # Check whether this is an MWAA configuration or a protected variable

--- a/images/airflow/3.0.3/python/mwaa/webserver/webserver_config.py
+++ b/images/airflow/3.0.3/python/mwaa/webserver/webserver_config.py
@@ -21,8 +21,5 @@ if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "mwaa-iam":
 
     AUTH_TYPE = AUTH_REMOTE_USER
     SECURITY_MANAGER_CLASS = IamSecurityManager
-elif os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "none":
-    # Disable auth
-    AUTH_ROLE_PUBLIC = 'Admin'
 else:
     AUTH_TYPE = None


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
- In Airflow 3, for production we set `MWAA__CORE__AUTH_TYPE` to "mwaa-iam" with `FAB` as the Auth Manager , and during local testing via `run.sh`, we set it to "testing", and use the `Simple Auth Manager`, not FAB. The code in `_get_essential_airflow_api_config()` is thus not needed in Airflow 3, and also setting `AUTH_ROLE_PUBLIC` is not useful since that is a FAB config, hence removed them, since they are used to disable auth if we were using FAB.

- Adding `AIRFLOW__API__BASE_URL` and `AIRFLOW__CORE__DATABASE_ACCESS_ISOLATION` to the the protected os environment variable list.
- Refer [link1](https://airflow.apache.org/docs/apache-airflow/2.9.1/configurations-ref.html#auth-backends) and [link2](https://airflow.apache.org/docs/apache-airflow-providers-fab/1.1.1/auth-manager/api-authentication.html) for documentation on how the old code was used to disable auth.

Tested this change by deploying locally and verifying Auth works as expected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
