### PR TITLE
Adding logs to debug unexpected response in celery sqs broker

### DIFF
--- a/images/airflow/2.10.3/python/mwaa/celery/sqs_broker.py
+++ b/images/airflow/2.10.3/python/mwaa/celery/sqs_broker.py
@@ -1150,10 +1150,11 @@ class Channel(virtual.Channel):
         resp = c.get_queue_attributes(
             QueueUrl=url, AttributeNames=["ApproximateNumberOfMessages"]
         )
-        if "Attributes" in resp:
+        try:
             return int(resp["Attributes"]["ApproximateNumberOfMessages"])
-        else:
+        except Exception:
             logger.error("Unexpected response from SQS get_queue_attributes: %s", resp)
+            raise
 
     def _purge(self, queue):
         """Delete all current messages in a queue."""

--- a/images/airflow/2.10.3/python/mwaa/celery/sqs_broker.py
+++ b/images/airflow/2.10.3/python/mwaa/celery/sqs_broker.py
@@ -1150,7 +1150,10 @@ class Channel(virtual.Channel):
         resp = c.get_queue_attributes(
             QueueUrl=url, AttributeNames=["ApproximateNumberOfMessages"]
         )
-        return int(resp["Attributes"]["ApproximateNumberOfMessages"])
+        if "Attributes" in resp:
+            return int(resp["Attributes"]["ApproximateNumberOfMessages"])
+        else:
+            logger.error("Unexpected response from SQS get_queue_attributes: %s", resp)
 
     def _purge(self, queue):
         """Delete all current messages in a queue."""

--- a/tests/images/airflow/2.10.3/python/mwaa/celery/test_sqs_broker_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/celery/test_sqs_broker_2_10_3.py
@@ -113,7 +113,7 @@ class TestChannelBasicPublish:
             )
 
     def test_size_without_attributes(self, mock_channel):
-        """Test _size returns None when Attributes missing."""
+        """Test _size raises exception when Attributes missing."""
         queue = 'test-queue'
         mock_sqs = MagicMock()
         mock_sqs.get_queue_attributes.return_value = {}
@@ -123,7 +123,7 @@ class TestChannelBasicPublish:
              patch.object(mock_channel, 'sqs', return_value=mock_sqs), \
              patch('mwaa.celery.sqs_broker.logger') as mock_logger:
             
-            result = mock_channel._size(queue)
+            with pytest.raises(KeyError):
+                mock_channel._size(queue)
             
-            assert result is None
             mock_logger.error.assert_called_once()


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-mwaa-docker-images/issues/315

*Description of changes:*
Adding a check to make sure `Attributes` field is present and log the response if no to helping debugging the issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
