### PR TITLE
Pin fluent-logger version to latest compatible version across all images

### DIFF
--- a/images/airflow/2.10.1/etc/mwaa_essential_constraints.txt
+++ b/images/airflow/2.10.1/etc/mwaa_essential_constraints.txt
@@ -36,3 +36,5 @@ SQLAlchemy==1.4.53
 statsd==4.0.1
 # Watchtower
 watchtower==3.3.1
+# Fluent Logger
+fluent-logger==0.11.1

--- a/images/airflow/2.10.1/requirements.txt
+++ b/images/airflow/2.10.1/requirements.txt
@@ -15,6 +15,7 @@ celery[sqs]
 psycopg2
 pycurl
 watchtower
+fluent-logger
 # Additional packages for development
 # NOTE: Like above, we don't specify the version here.
 boto3-stubs[logs]

--- a/images/airflow/2.10.3/etc/mwaa_essential_constraints.txt
+++ b/images/airflow/2.10.3/etc/mwaa_essential_constraints.txt
@@ -36,3 +36,5 @@ SQLAlchemy==1.4.54
 statsd==4.0.1
 # Watchtower
 watchtower==3.3.1
+# Fluent Logger
+fluent-logger==0.11.1

--- a/images/airflow/2.11.0/etc/mwaa_essential_constraints.txt
+++ b/images/airflow/2.11.0/etc/mwaa_essential_constraints.txt
@@ -36,3 +36,5 @@ SQLAlchemy==1.4.54
 statsd==4.0.1
 # Watchtower
 watchtower==3.4.0
+# Fluent Logger
+fluent-logger==0.11.1

--- a/images/airflow/2.9.2/etc/mwaa_essential_constraints.txt
+++ b/images/airflow/2.9.2/etc/mwaa_essential_constraints.txt
@@ -36,3 +36,5 @@ SQLAlchemy==1.4.52
 statsd==4.0.1
 # Watchtower
 watchtower==3.2.0
+# Fluent Logger
+fluent-logger==0.11.1

--- a/images/airflow/2.9.2/requirements.txt
+++ b/images/airflow/2.9.2/requirements.txt
@@ -15,6 +15,7 @@ celery[sqs]
 psycopg2
 pycurl
 watchtower
+fluent-logger
 # Additional packages for development
 # NOTE: Like above, we don't specify the version here.
 boto3-stubs[logs]

--- a/images/airflow/3.0.3/etc/mwaa_essential_constraints.txt
+++ b/images/airflow/3.0.3/etc/mwaa_essential_constraints.txt
@@ -36,3 +36,5 @@ SQLAlchemy==1.4.54
 statsd==4.0.1
 # Watchtower
 watchtower==3.4.0
+# Fluent Logger
+fluent-logger==0.11.1

--- a/images/airflow/3.0.3/requirements.txt
+++ b/images/airflow/3.0.3/requirements.txt
@@ -15,6 +15,7 @@ celery[sqs]
 psycopg2
 pycurl
 watchtower
+fluent-logger
 # Additional packages for development
 # NOTE: Like above, we don't specify the version here.
 boto3-stubs[logs]


### PR DESCRIPTION
*Issue # (if available):* N/A

*Description of changes:*

Pin fluent-logger version to latest compatible version across all images

- Add fluent-logger==0.11.1 to mwaa_essential_constraints.txt for all versions
- Add fluent-logger to requirements.txt for versions 2.9.2, 2.10.1, and 3.0.3
- Versions 2.10.3 and 2.11.0 already had fluent-logger in requirements.txt

This ensures consistent fluent-logger behavior across all MWAA environments and follows best practices for dependency management by pinning to a specific version (0.11.1) in the constraints files.

*Testing performed:*
- Tested all versions using `./run.sh test-requirements` - all packages installed correctly with fluent-logger==0.11.1
- Ran all versions using `./run.sh` - environments started successfully with the changes

*List any breaking changes for*
* *The Environment runtime*: None - fluent-logger 0.11.1 is compatible with Python 3.11.x (used by 2.9.2, 2.10.1, 2.10.3) and Python 3.12.x (used by 2.11.0, 3.0.3), and has minimal dependencies (only msgpack>=1.0)
* *The local development experience*: None - this change only ensures version consistency


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
