### PR TITLE
Disable dag serialization when performing database migration

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.10.1/python/mwaa/database/migrate_with_downgrade.py
@@ -47,7 +47,7 @@ def _migrate_db():
         args = Namespace(
             from_revision=None,
             from_version=None,
-            reserialize_dags=True,
+            reserialize_dags=False,
             show_sql_only=None,
             to_revision=None,
             to_version=None,
@@ -64,7 +64,7 @@ def _check_downgrade_db():
         args = Namespace(
                 from_revision=None,
                 from_version=None,
-                reserialize_dags=True,
+                reserialize_dags=False,
                 show_sql_only=None,
                 to_revision=None,
                 to_version=target_version,

--- a/images/airflow/2.10.3/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.10.3/python/mwaa/database/migrate_with_downgrade.py
@@ -47,7 +47,7 @@ def _migrate_db():
         args = Namespace(
             from_revision=None,
             from_version=None,
-            reserialize_dags=True,
+            reserialize_dags=False,
             show_sql_only=None,
             to_revision=None,
             to_version=None,
@@ -64,7 +64,7 @@ def _check_downgrade_db():
         args = Namespace(
                 from_revision=None,
                 from_version=None,
-                reserialize_dags=True,
+                reserialize_dags=False,
                 show_sql_only=None,
                 to_revision=None,
                 to_version=target_version,

--- a/images/airflow/2.11.0/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.11.0/python/mwaa/database/migrate_with_downgrade.py
@@ -47,7 +47,7 @@ def _migrate_db():
         args = Namespace(
             from_revision=None,
             from_version=None,
-            reserialize_dags=True,
+            reserialize_dags=False,
             show_sql_only=None,
             to_revision=None,
             to_version=None,
@@ -64,7 +64,7 @@ def _check_downgrade_db():
         args = Namespace(
                 from_revision=None,
                 from_version=None,
-                reserialize_dags=True,
+                reserialize_dags=False,
                 show_sql_only=None,
                 to_revision=None,
                 to_version=target_version,

--- a/images/airflow/2.9.2/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.9.2/python/mwaa/database/migrate_with_downgrade.py
@@ -47,7 +47,7 @@ def _migrate_db():
         args = Namespace(
             from_revision=None,
             from_version=None,
-            reserialize_dags=True,
+            reserialize_dags=False,
             show_sql_only=None,
             to_revision=None,
             to_version=None,
@@ -64,7 +64,7 @@ def _check_downgrade_db():
         args = Namespace(
                 from_revision=None,
                 from_version=None,
-                reserialize_dags=True,
+                reserialize_dags=False,
                 show_sql_only=None,
                 to_revision=None,
                 to_version=target_version,

--- a/images/airflow/3.0.3/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.0.3/python/mwaa/database/migrate_with_downgrade.py
@@ -47,7 +47,7 @@ def _migrate_db():
         args = Namespace(
             from_revision=None,
             from_version=None,
-            reserialize_dags=True,
+            reserialize_dags=False,
             show_sql_only=None,
             to_revision=None,
             to_version=None,
@@ -64,7 +64,7 @@ def _check_downgrade_db():
         args = Namespace(
                 from_revision=None,
                 from_version=None,
-                reserialize_dags=True,
+                reserialize_dags=False,
                 show_sql_only=None,
                 to_revision=None,
                 to_version=target_version,


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Disables dag serialization during Airflow db migrations for the migrate-db command. The command is intended to be used without custom plugins/requirements/startup script that could interfere with db operations. This means that it is unable to serialize dags which require dependencies which have not been installed. So we need to disable dag serialization during the migration. This is ok because the dag processor is responsible for dag serialization and will handle it after the db migration/initialization. The flag was removed from Airflow as of Airflow 2.11.0 because the dag processor makes it redundant: https://github.com/apache/airflow/pull/45362.

For testing I deployed a control environment and test environment to verify the dag serialization errors are resolved by the fix. The dags functioned as expected with the flag disabled.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
