### PR TITLE
Add Worker at max concurrency and sqs consumption paused metrics

### DIFF
--- a/images/airflow/2.10.3/python/mwaa/celery/sqs_broker.py
+++ b/images/airflow/2.10.3/python/mwaa/celery/sqs_broker.py
@@ -183,6 +183,8 @@ from threading import Lock
 import os
 
 from mwaa.logging.utils import throttle
+
+CELERY_WORKER_TASK_LIMIT = int(os.environ.get("AIRFLOW__CELERY__WORKER_AUTOSCALE", "1,1").split(",")[0])
 # End of Amazon addition
 
 logger = get_logger(__name__)
@@ -603,7 +605,12 @@ class Channel(virtual.Channel):
         if os.environ.get('MWAA__HEALTH_MONITORING_ENABLE_REVAMPED_HEALTHCHECK', 'false') == 'true' and exchange == 'celeryev':
             # This branch catches all celery task events and generates process heartbeat metrics
             if routing_key == 'worker.heartbeat':
-                Stats.incr("mwaa.celery.process.heartbeat", 1)
+                Stats.gauge("mwaa.celery.process.heartbeat", 1)
+                num_active_tasks = len(self._get_tasks_from_state(self.celery_state)) if self.idle_worker_monitoring_enabled else CELERY_WORKER_TASK_LIMIT
+                if num_active_tasks >= CELERY_WORKER_TASK_LIMIT:
+                    Stats.gauge("mwaa.celery.at_max_concurrency", num_active_tasks)
+                if self._is_task_consumption_paused():
+                    Stats.gauge("mwaa.celery.sqs.consumption_paused", 1)
             return
         return super().basic_publish(message, exchange, routing_key, **kwargs)
     # End of Amazon addition.

--- a/tests/images/airflow/2.10.1/celery/test_sqs_broker_2_10_1.py
+++ b/tests/images/airflow/2.10.1/celery/test_sqs_broker_2_10_1.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch, MagicMock
-from mwaa.celery.sqs_broker import Channel
+from mwaa.celery.sqs_broker import Channel, CELERY_WORKER_TASK_LIMIT
 
 
 class TestChannelBasicPublish:
@@ -45,7 +45,8 @@ class TestChannelBasicPublish:
                 yield channel
 
     @pytest.mark.parametrize("env_value", ['false', None])
-    def test_health_monitoring_disabled_calls_super(self, mock_channel, env_value):
+    @patch('mwaa.celery.sqs_broker.Stats')
+    def test_health_monitoring_disabled_calls_super(self, mock_stats, mock_channel, env_value):
         """When health monitoring is disabled or not set, should always call super."""
         message = {'test': 'message'}
         kwargs = {'extra': 'args'}
@@ -61,12 +62,19 @@ class TestChannelBasicPublish:
                 message, exchange, routing_key, **kwargs
             )
 
+            mock_stats.gauge.assert_not_called()
+
     @pytest.mark.parametrize("routing_key", ['worker.heartbeat', 'other.routing.key'])
-    def test_celeryev_exchange_blocks_super(self, mock_channel, routing_key):
+    @patch('mwaa.celery.sqs_broker.Stats')
+    def test_celeryev_exchange_blocks_super(self, mock_stats, mock_channel, routing_key):
         """When health monitoring is enabled and exchange is celeryev, should not call super."""
         message = {'test': 'message'}
         kwargs = {'extra': 'args'}
         exchange = 'celeryev'
+
+        mock_channel._get_tasks_from_state = MagicMock(return_value=[{'task': 'test'}] * 15)
+        mock_channel._is_task_consumption_paused = MagicMock(return_value=False)
+        mock_channel.idle_worker_monitoring_enabled = True
 
         with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
             mock_env_get.return_value = 'true'
@@ -74,6 +82,15 @@ class TestChannelBasicPublish:
             mock_channel.basic_publish(message, exchange, routing_key, **kwargs)
 
             mock_channel._super_basic_publish.assert_not_called()
+
+            if routing_key == 'worker.heartbeat':
+                mock_stats.gauge.assert_any_call("mwaa.celery.process.heartbeat", 1)
+                mock_stats.gauge.assert_any_call("mwaa.celery.at_max_concurrency", 15)
+                assert not any(call[0][0] == "mwaa.celery.sqs.consumption_paused"
+                              for call in mock_stats.gauge.call_args_list)
+            else:
+                # For other routing keys, no metrics should be called
+                mock_stats.gauge.assert_not_called()
 
     @pytest.mark.parametrize("exchange,routing_key", [
         ('other_exchange', 'worker.heartbeat'),
@@ -92,3 +109,78 @@ class TestChannelBasicPublish:
             mock_channel._super_basic_publish.assert_called_once_with(
                 message, exchange, routing_key, **kwargs
             )
+
+    def test_celery_worker_task_limit_constant_parsing(self):
+        """Test CELERY_WORKER_TASK_LIMIT correctly parses environment variable."""
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = '20,10'
+
+            # Re-import to trigger constant re-evaluation
+            import importlib
+            import mwaa.celery.sqs_broker
+            importlib.reload(mwaa.celery.sqs_broker)
+
+            from mwaa.celery.sqs_broker import CELERY_WORKER_TASK_LIMIT
+            assert CELERY_WORKER_TASK_LIMIT == 20
+
+    @pytest.mark.parametrize("monitoring_enabled,expected_tasks", [
+        (True, 15),   # When monitoring enabled, use actual task count
+        (False, 20),  # When monitoring disabled, use CELERY_WORKER_TASK_LIMIT
+    ])
+    @patch('mwaa.celery.sqs_broker.Stats')
+    def test_worker_heartbeat_active_tasks_calculation(self, mock_stats, mock_channel, monitoring_enabled, expected_tasks):
+        """Test num_active_tasks calculation logic."""
+        message = {'test': 'message'}
+        exchange = 'celeryev'
+        routing_key = 'worker.heartbeat'
+
+        mock_channel._get_tasks_from_state = MagicMock(return_value=[{'task': 'test'}] * 15)
+        mock_channel._is_task_consumption_paused = MagicMock(return_value=False)
+        mock_channel.idle_worker_monitoring_enabled = monitoring_enabled
+
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = 'true'
+
+            mock_channel.basic_publish(message, exchange, routing_key)
+
+            if expected_tasks >= 20:  # CELERY_WORKER_TASK_LIMIT
+                mock_stats.gauge.assert_any_call("mwaa.celery.at_max_concurrency", expected_tasks)
+            else:
+                assert not any(call[0][0] == "mwaa.celery.at_max_concurrency"
+                              for call in mock_stats.gauge.call_args_list)
+
+    @pytest.mark.parametrize("num_tasks,is_paused,expect_max_concurrency,expect_consumption_paused", [
+        (25, False, True, False),   # Above limit, not paused
+        (15, True, False, True),    # Below limit, paused
+        (20, False, True, False),   # At limit, not paused
+        (10, False, False, False),  # Below limit, not paused
+    ])
+    @patch('mwaa.celery.sqs_broker.Stats')
+    def test_worker_heartbeat_conditional_metrics(self, mock_stats, mock_channel, num_tasks, is_paused, expect_max_concurrency, expect_consumption_paused):
+        """Test conditional metric emission logic."""
+        message = {'test': 'message'}
+        exchange = 'celeryev'
+        routing_key = 'worker.heartbeat'
+
+        mock_channel._get_tasks_from_state = MagicMock(return_value=[{'task': 'test'}] * num_tasks)
+        mock_channel._is_task_consumption_paused = MagicMock(return_value=is_paused)
+        mock_channel.idle_worker_monitoring_enabled = True
+
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = 'true'
+
+            mock_channel.basic_publish(message, exchange, routing_key)
+
+            mock_stats.gauge.assert_any_call("mwaa.celery.process.heartbeat", 1)
+
+            if expect_max_concurrency:
+                mock_stats.gauge.assert_any_call("mwaa.celery.at_max_concurrency", num_tasks)
+            else:
+                assert not any(call[0][0] == "mwaa.celery.at_max_concurrency"
+                              for call in mock_stats.gauge.call_args_list)
+
+            if expect_consumption_paused:
+                mock_stats.gauge.assert_any_call("mwaa.celery.sqs.consumption_paused", 1)
+            else:
+                assert not any(call[0][0] == "mwaa.celery.sqs.consumption_paused"
+                              for call in mock_stats.gauge.call_args_list)

--- a/tests/images/airflow/2.10.3/python/mwaa/celery/test_sqs_broker_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/celery/test_sqs_broker_2_10_3.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch, MagicMock
-from mwaa.celery.sqs_broker import Channel
+from mwaa.celery.sqs_broker import Channel, CELERY_WORKER_TASK_LIMIT
 
 
 class TestChannelBasicPublish:
@@ -45,7 +45,8 @@ class TestChannelBasicPublish:
                 yield channel
 
     @pytest.mark.parametrize("env_value", ['false', None])
-    def test_health_monitoring_disabled_calls_super(self, mock_channel, env_value):
+    @patch('mwaa.celery.sqs_broker.Stats')
+    def test_health_monitoring_disabled_calls_super(self, mock_stats, mock_channel, env_value):
         """When health monitoring is disabled or not set, should always call super."""
         message = {'test': 'message'}
         kwargs = {'extra': 'args'}
@@ -61,12 +62,19 @@ class TestChannelBasicPublish:
                 message, exchange, routing_key, **kwargs
             )
 
+            mock_stats.gauge.assert_not_called()
+
     @pytest.mark.parametrize("routing_key", ['worker.heartbeat', 'other.routing.key'])
-    def test_celeryev_exchange_blocks_super(self, mock_channel, routing_key):
+    @patch('mwaa.celery.sqs_broker.Stats')
+    def test_celeryev_exchange_blocks_super(self, mock_stats, mock_channel, routing_key):
         """When health monitoring is enabled and exchange is celeryev, should not call super."""
         message = {'test': 'message'}
         kwargs = {'extra': 'args'}
         exchange = 'celeryev'
+
+        mock_channel._get_tasks_from_state = MagicMock(return_value=[{'task': 'test'}] * 15)
+        mock_channel._is_task_consumption_paused = MagicMock(return_value=False)
+        mock_channel.idle_worker_monitoring_enabled = True
 
         with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
             mock_env_get.return_value = 'true'
@@ -74,6 +82,15 @@ class TestChannelBasicPublish:
             mock_channel.basic_publish(message, exchange, routing_key, **kwargs)
 
             mock_channel._super_basic_publish.assert_not_called()
+
+            if routing_key == 'worker.heartbeat':
+                mock_stats.gauge.assert_any_call("mwaa.celery.process.heartbeat", 1)
+                mock_stats.gauge.assert_any_call("mwaa.celery.at_max_concurrency", 15)
+                assert not any(call[0][0] == "mwaa.celery.sqs.consumption_paused"
+                              for call in mock_stats.gauge.call_args_list)
+            else:
+                # For other routing keys, no metrics should be called
+                mock_stats.gauge.assert_not_called()
 
     @pytest.mark.parametrize("exchange,routing_key", [
         ('other_exchange', 'worker.heartbeat'),
@@ -100,13 +117,13 @@ class TestChannelBasicPublish:
         mock_sqs.get_queue_attributes.return_value = {
             'Attributes': {'ApproximateNumberOfMessages': '5'}
         }
-        
+
         with patch.object(mock_channel, '_new_queue', return_value='queue-url'), \
              patch.object(mock_channel, 'canonical_queue_name', return_value=queue), \
              patch.object(mock_channel, 'sqs', return_value=mock_sqs):
-            
+
             result = mock_channel._size(queue)
-            
+
             assert result == 5
             mock_sqs.get_queue_attributes.assert_called_once_with(
                 QueueUrl='queue-url', AttributeNames=['ApproximateNumberOfMessages']
@@ -117,13 +134,88 @@ class TestChannelBasicPublish:
         queue = 'test-queue'
         mock_sqs = MagicMock()
         mock_sqs.get_queue_attributes.return_value = {}
-        
+
         with patch.object(mock_channel, '_new_queue', return_value='queue-url'), \
              patch.object(mock_channel, 'canonical_queue_name', return_value=queue), \
              patch.object(mock_channel, 'sqs', return_value=mock_sqs), \
              patch('mwaa.celery.sqs_broker.logger') as mock_logger:
-            
+
             with pytest.raises(KeyError):
                 mock_channel._size(queue)
-            
+
             mock_logger.error.assert_called_once()
+
+    def test_celery_worker_task_limit_constant_parsing(self):
+        """Test CELERY_WORKER_TASK_LIMIT correctly parses environment variable."""
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = '20,10'
+
+            # Re-import to trigger constant re-evaluation
+            import importlib
+            import mwaa.celery.sqs_broker
+            importlib.reload(mwaa.celery.sqs_broker)
+
+            from mwaa.celery.sqs_broker import CELERY_WORKER_TASK_LIMIT
+            assert CELERY_WORKER_TASK_LIMIT == 20
+
+    @pytest.mark.parametrize("monitoring_enabled,expected_tasks", [
+        (True, 15),   # When monitoring enabled, use actual task count
+        (False, 20),  # When monitoring disabled, use CELERY_WORKER_TASK_LIMIT
+    ])
+    @patch('mwaa.celery.sqs_broker.Stats')
+    def test_worker_heartbeat_active_tasks_calculation(self, mock_stats, mock_channel, monitoring_enabled, expected_tasks):
+        """Test num_active_tasks calculation logic."""
+        message = {'test': 'message'}
+        exchange = 'celeryev'
+        routing_key = 'worker.heartbeat'
+
+        mock_channel._get_tasks_from_state = MagicMock(return_value=[{'task': 'test'}] * 15)
+        mock_channel._is_task_consumption_paused = MagicMock(return_value=False)
+        mock_channel.idle_worker_monitoring_enabled = monitoring_enabled
+
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = 'true'
+
+            mock_channel.basic_publish(message, exchange, routing_key)
+
+            if expected_tasks >= 20:  # CELERY_WORKER_TASK_LIMIT
+                mock_stats.gauge.assert_any_call("mwaa.celery.at_max_concurrency", expected_tasks)
+            else:
+                assert not any(call[0][0] == "mwaa.celery.at_max_concurrency"
+                              for call in mock_stats.gauge.call_args_list)
+
+    @pytest.mark.parametrize("num_tasks,is_paused,expect_max_concurrency,expect_consumption_paused", [
+        (25, False, True, False),   # Above limit, not paused
+        (15, True, False, True),    # Below limit, paused
+        (20, False, True, False),   # At limit, not paused
+        (10, False, False, False),  # Below limit, not paused
+    ])
+    @patch('mwaa.celery.sqs_broker.Stats')
+    def test_worker_heartbeat_conditional_metrics(self, mock_stats, mock_channel, num_tasks, is_paused, expect_max_concurrency, expect_consumption_paused):
+        """Test conditional metric emission logic."""
+        message = {'test': 'message'}
+        exchange = 'celeryev'
+        routing_key = 'worker.heartbeat'
+
+        mock_channel._get_tasks_from_state = MagicMock(return_value=[{'task': 'test'}] * num_tasks)
+        mock_channel._is_task_consumption_paused = MagicMock(return_value=is_paused)
+        mock_channel.idle_worker_monitoring_enabled = True
+
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = 'true'
+
+            mock_channel.basic_publish(message, exchange, routing_key)
+
+            mock_stats.gauge.assert_any_call("mwaa.celery.process.heartbeat", 1)
+
+            if expect_max_concurrency:
+                mock_stats.gauge.assert_any_call("mwaa.celery.at_max_concurrency", num_tasks)
+            else:
+                assert not any(call[0][0] == "mwaa.celery.at_max_concurrency"
+                              for call in mock_stats.gauge.call_args_list)
+
+            if expect_consumption_paused:
+                mock_stats.gauge.assert_any_call("mwaa.celery.sqs.consumption_paused", 1)
+            else:
+                assert not any(call[0][0] == "mwaa.celery.sqs.consumption_paused"
+                              for call in mock_stats.gauge.call_args_list)

--- a/tests/images/airflow/2.9.2/python/mwaa/celery/test_sqs_broker_2_9_2.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/celery/test_sqs_broker_2_9_2.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch, MagicMock
-from mwaa.celery.sqs_broker import Channel
+from mwaa.celery.sqs_broker import Channel, CELERY_WORKER_TASK_LIMIT
 
 
 class TestChannelBasicPublish:
@@ -45,7 +45,8 @@ class TestChannelBasicPublish:
                 yield channel
 
     @pytest.mark.parametrize("env_value", ['false', None])
-    def test_health_monitoring_disabled_calls_super(self, mock_channel, env_value):
+    @patch('mwaa.celery.sqs_broker.Stats')
+    def test_health_monitoring_disabled_calls_super(self, mock_stats, mock_channel, env_value):
         """When health monitoring is disabled or not set, should always call super."""
         message = {'test': 'message'}
         kwargs = {'extra': 'args'}
@@ -61,12 +62,19 @@ class TestChannelBasicPublish:
                 message, exchange, routing_key, **kwargs
             )
 
+            mock_stats.gauge.assert_not_called()
+
     @pytest.mark.parametrize("routing_key", ['worker.heartbeat', 'other.routing.key'])
-    def test_celeryev_exchange_blocks_super(self, mock_channel, routing_key):
+    @patch('mwaa.celery.sqs_broker.Stats')
+    def test_celeryev_exchange_blocks_super(self, mock_stats, mock_channel, routing_key):
         """When health monitoring is enabled and exchange is celeryev, should not call super."""
         message = {'test': 'message'}
         kwargs = {'extra': 'args'}
         exchange = 'celeryev'
+
+        mock_channel._get_tasks_from_state = MagicMock(return_value=[{'task': 'test'}] * 15)
+        mock_channel._is_task_consumption_paused = MagicMock(return_value=False)
+        mock_channel.idle_worker_monitoring_enabled = True
 
         with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
             mock_env_get.return_value = 'true'
@@ -74,6 +82,15 @@ class TestChannelBasicPublish:
             mock_channel.basic_publish(message, exchange, routing_key, **kwargs)
 
             mock_channel._super_basic_publish.assert_not_called()
+
+            if routing_key == 'worker.heartbeat':
+                mock_stats.gauge.assert_any_call("mwaa.celery.process.heartbeat", 1)
+                mock_stats.gauge.assert_any_call("mwaa.celery.at_max_concurrency", 15)
+                assert not any(call[0][0] == "mwaa.celery.sqs.consumption_paused"
+                              for call in mock_stats.gauge.call_args_list)
+            else:
+                # For other routing keys, no metrics should be called
+                mock_stats.gauge.assert_not_called()
 
     @pytest.mark.parametrize("exchange,routing_key", [
         ('other_exchange', 'worker.heartbeat'),
@@ -92,3 +109,78 @@ class TestChannelBasicPublish:
             mock_channel._super_basic_publish.assert_called_once_with(
                 message, exchange, routing_key, **kwargs
             )
+
+    def test_celery_worker_task_limit_constant_parsing(self):
+        """Test CELERY_WORKER_TASK_LIMIT correctly parses environment variable."""
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = '20,10'
+
+            # Re-import to trigger constant re-evaluation
+            import importlib
+            import mwaa.celery.sqs_broker
+            importlib.reload(mwaa.celery.sqs_broker)
+
+            from mwaa.celery.sqs_broker import CELERY_WORKER_TASK_LIMIT
+            assert CELERY_WORKER_TASK_LIMIT == 20
+
+    @pytest.mark.parametrize("monitoring_enabled,expected_tasks", [
+        (True, 15),   # When monitoring enabled, use actual task count
+        (False, 20),  # When monitoring disabled, use CELERY_WORKER_TASK_LIMIT
+    ])
+    @patch('mwaa.celery.sqs_broker.Stats')
+    def test_worker_heartbeat_active_tasks_calculation(self, mock_stats, mock_channel, monitoring_enabled, expected_tasks):
+        """Test num_active_tasks calculation logic."""
+        message = {'test': 'message'}
+        exchange = 'celeryev'
+        routing_key = 'worker.heartbeat'
+
+        mock_channel._get_tasks_from_state = MagicMock(return_value=[{'task': 'test'}] * 15)
+        mock_channel._is_task_consumption_paused = MagicMock(return_value=False)
+        mock_channel.idle_worker_monitoring_enabled = monitoring_enabled
+
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = 'true'
+
+            mock_channel.basic_publish(message, exchange, routing_key)
+
+            if expected_tasks >= 20:  # CELERY_WORKER_TASK_LIMIT
+                mock_stats.gauge.assert_any_call("mwaa.celery.at_max_concurrency", expected_tasks)
+            else:
+                assert not any(call[0][0] == "mwaa.celery.at_max_concurrency"
+                              for call in mock_stats.gauge.call_args_list)
+
+    @pytest.mark.parametrize("num_tasks,is_paused,expect_max_concurrency,expect_consumption_paused", [
+        (25, False, True, False),   # Above limit, not paused
+        (15, True, False, True),    # Below limit, paused
+        (20, False, True, False),   # At limit, not paused
+        (10, False, False, False),  # Below limit, not paused
+    ])
+    @patch('mwaa.celery.sqs_broker.Stats')
+    def test_worker_heartbeat_conditional_metrics(self, mock_stats, mock_channel, num_tasks, is_paused, expect_max_concurrency, expect_consumption_paused):
+        """Test conditional metric emission logic."""
+        message = {'test': 'message'}
+        exchange = 'celeryev'
+        routing_key = 'worker.heartbeat'
+
+        mock_channel._get_tasks_from_state = MagicMock(return_value=[{'task': 'test'}] * num_tasks)
+        mock_channel._is_task_consumption_paused = MagicMock(return_value=is_paused)
+        mock_channel.idle_worker_monitoring_enabled = True
+
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = 'true'
+
+            mock_channel.basic_publish(message, exchange, routing_key)
+
+            mock_stats.gauge.assert_any_call("mwaa.celery.process.heartbeat", 1)
+
+            if expect_max_concurrency:
+                mock_stats.gauge.assert_any_call("mwaa.celery.at_max_concurrency", num_tasks)
+            else:
+                assert not any(call[0][0] == "mwaa.celery.at_max_concurrency"
+                              for call in mock_stats.gauge.call_args_list)
+
+            if expect_consumption_paused:
+                mock_stats.gauge.assert_any_call("mwaa.celery.sqs.consumption_paused", 1)
+            else:
+                assert not any(call[0][0] == "mwaa.celery.sqs.consumption_paused"
+                              for call in mock_stats.gauge.call_args_list)


### PR DESCRIPTION
*Issue #, if available:*
Add worker concurrency and consumption metrics to observe worker health better

*Description of changes:*
Add Worker at max concurrency and sqs consumption paused metrics behind feature flag

*Testing*
Deployed on dev aws account and validated that metrics are emitted as expected

Some coverage tests on PR is failing since test setup does not exists for some new versions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
