### PR TITLE
Disabling colored console logs for AF3

### DIFF
--- a/images/airflow/3.0.3/python/mwaa/config/airflow.py
+++ b/images/airflow/3.0.3/python/mwaa/config/airflow.py
@@ -162,6 +162,7 @@ def _get_essential_airflow_logging_config() -> Dict[str, str]:
     """
     return {
         "AIRFLOW__LOGGING__LOGGING_CONFIG_CLASS": "mwaa.logging.config.LOGGING_CONFIG",
+        "AIRFLOW__LOGGING__COLORED_CONSOLE_LOG": "False",
     }
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Disabling Colored Console logs for AF3, since the move to structlog was causing airflow to send colored logs ( containing ANSI codes for color formatting), which is not useful for MWAA's usecase, since we read the logstream as bytes and forward them to customer, leading to these characters appearing as noise in the worker logs.
- Best solution is disabling colored logs, so airflow doesn't send formatted logs to us in the first place, since for MWAA's logging scheme, they are not useful.
- Here are worker logs after disabling colored logs :
<img width="1728" height="674" alt="image" src="https://github.com/user-attachments/assets/3efefa30-48a8-4328-a6bd-801af5f052ae" />
- Below ss shows worker logs with colored logs enabled :
<img width="3456" height="1348" alt="image" src="https://github.com/user-attachments/assets/a5f73a59-4057-49eb-83b5-aea99754d73d" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
