### PR TITLE
Bug fixes for Airflow 3 support

### DIFF
--- a/images/airflow/3.0.3/python/mwaa/celery/task_monitor.py
+++ b/images/airflow/3.0.3/python/mwaa/celery/task_monitor.py
@@ -532,7 +532,7 @@ class WorkerTaskMonitor:
 
         :return: Number of current tasks marked for cleanup.
         """
-        return _get_celery_tasks(self.cleanup_celery_state)
+        return len(_get_celery_tasks(self.cleanup_celery_state))
 
 
     def _get_next_unprocessed_signal(self) -> tuple[str | None, SignalData | None]:

--- a/images/airflow/3.0.3/python/mwaa/config/airflow.py
+++ b/images/airflow/3.0.3/python/mwaa/config/airflow.py
@@ -154,6 +154,17 @@ def _get_essential_airflow_api_auth_config() -> Dict[str, str]:
 
     return api_config
 
+def _get_essential_aiflow_execution_api_config() -> Dict[str, str]:
+
+    """
+    Retrieve the environment variables for Airflow's "execution_api" configuration section.
+
+    :returns A dictionary containing the environment variables.
+    """
+    return {
+        "AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME": "86400"
+    }
+
 def _get_essential_airflow_logging_config() -> Dict[str, str]:
     """
     Retrieve the environment variables for Airflow's "logging" configuration section.
@@ -269,6 +280,7 @@ def _get_opinionated_airflow_secrets_config() -> Dict[str, str]:
     connection_lookup_pattern = {"connections_lookup_pattern": "^(?!aws_default$).*$"}
     return {
         "AIRFLOW__SECRETS__BACKEND_KWARGS": json.dumps(connection_lookup_pattern),
+        "AIRFLOW__WORKERS__SECRETS_BACKEND_KWARGS": json.dumps(connection_lookup_pattern),
     }
 
 def _get_opinionated_airflow_usage_data_config() -> Dict[str, str]:
@@ -331,7 +343,8 @@ def get_essential_airflow_config(executor_type: str) -> Dict[str, str]:
         **_get_essential_airflow_scheduler_config(),
         **_get_essential_airflow_webserver_config(),
         **_get_essential_airflow_auth_config(),
-        **_get_essential_airflow_api_auth_config()
+        **_get_essential_airflow_api_auth_config(),
+        **_get_essential_aiflow_execution_api_config(),
     }
 
 

--- a/images/airflow/3.0.3/python/mwaa/subprocess/subprocess.py
+++ b/images/airflow/3.0.3/python/mwaa/subprocess/subprocess.py
@@ -215,13 +215,14 @@ class Subprocess:
                     time.sleep(_SUBPROCESS_LOG_POLL_IDLE_SLEEP_INTERVAL.total_seconds())
             else:
                 log_level = os.environ['AIRFLOW_CONSOLE_LOG_LEVEL']
+                decoded_line = line.decode("utf-8", errors="replace").rstrip()
                 match log_level:
                     case "ERROR":
-                        self.process_logger.error(line.decode("utf-8"))
+                        self.process_logger.error(decoded_line)
                     case "WARNING":
-                        self.process_logger.warning(line.decode("utf-8"))
+                        self.process_logger.warning(decoded_line)
                     case _:
-                        self.process_logger.info(line.decode("utf-8"))
+                        self.process_logger.info(decoded_line)
     
     def _get_subprocess_status(self, process: Popen[Any]):
         return ProcessStatus.RUNNING if process.poll() is None else ProcessStatus.FINISHED


### PR DESCRIPTION
*Description of changes:*
This PR addressed multiple bug fixes:

1. Handling of `ServerResponseError Invalid auth token: Signature has expired`

Also related to Airflow issue: https://github.com/apache/airflow/issues/53713

In case the task is queued for long duration, jwt token associated to it could expire. Increasing execution API jwt expiration time.

2. Handling of `UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 155-156: invalid continuation byte`

The root cause is that something occasionally writes non-UTF-8 bytes into the stream. The logger assumes everything is valid UTF-8, so it crashes when it encounters a bad sequence.

line.decode("utf-8", errors="replace") ensures the logger never crashes — we might see � in logs where non-UTF-8 data appeared.

3. Handling of `[inputs.statsd] Parsing value to int64, unable to parse metric: airflow.mwaa.task_monitor.cleanup_task_count:[]|c`

This error appears from Telegraf’s statsd input processing. Telegraf is trying to parse [] as an integer (int64), fails, and logs the warning. Fixing `get_cleanup_task_count` to return len(...) fixes this error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
