### PR TITLE
Fix for lint bash failure in the quality check workflow.

### DIFF
--- a/quality-checks/diff-coverage_test.sh
+++ b/quality-checks/diff-coverage_test.sh
@@ -97,6 +97,7 @@ get_base_branch() {
 }
 
 # shellcheck disable=SC2317
+# shellcheck disable=SC2329
 cleanup() {
     # Remove temporary directory
     rm -rf "$TEMP_DIR"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently quality checks are failing in the github workflow with the following error,

```
In ./quality-checks/diff-coverage_test.sh line 100: cleanup() { ^-- SC2329 (info): This function is never invoked. Check usage (or ignored if invoked indirectly).
```

Disable ShellCheck rules SC2317 and SC2329 for the cleanup function since it’s invoked indirectly via trap.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
