### PR TITLE
Adding logs to debug unexpected response in celery sqs broker for remaining versions and syncing unit tests for all versions

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/celery/sqs_broker.py
+++ b/images/airflow/2.10.1/python/mwaa/celery/sqs_broker.py
@@ -1158,7 +1158,11 @@ class Channel(virtual.Channel):
         resp = c.get_queue_attributes(
             QueueUrl=url, AttributeNames=["ApproximateNumberOfMessages"]
         )
-        return int(resp["Attributes"]["ApproximateNumberOfMessages"])
+        try:
+            return int(resp["Attributes"]["ApproximateNumberOfMessages"])
+        except Exception:
+            logger.error("Unexpected response from SQS get_queue_attributes: %s", resp)
+            raise
 
     def _purge(self, queue):
         """Delete all current messages in a queue."""

--- a/images/airflow/2.9.2/python/mwaa/celery/sqs_broker.py
+++ b/images/airflow/2.9.2/python/mwaa/celery/sqs_broker.py
@@ -1158,7 +1158,11 @@ class Channel(virtual.Channel):
         resp = c.get_queue_attributes(
             QueueUrl=url, AttributeNames=["ApproximateNumberOfMessages"]
         )
-        return int(resp["Attributes"]["ApproximateNumberOfMessages"])
+        try:
+            return int(resp["Attributes"]["ApproximateNumberOfMessages"])
+        except Exception:
+            logger.error("Unexpected response from SQS get_queue_attributes: %s", resp)
+            raise
 
     def _purge(self, queue):
         """Delete all current messages in a queue."""

--- a/tests/images/airflow/2.10.3/python/mwaa/celery/test_sqs_broker_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/celery/test_sqs_broker_2_10_3.py
@@ -119,9 +119,8 @@ class TestChannelBasicPublish:
         }
 
         with patch.object(mock_channel, '_new_queue', return_value='queue-url'), \
-             patch.object(mock_channel, 'canonical_queue_name', return_value=queue), \
-             patch.object(mock_channel, 'sqs', return_value=mock_sqs):
-
+                patch.object(mock_channel, 'canonical_queue_name', return_value=queue), \
+                patch.object(mock_channel, 'sqs', return_value=mock_sqs):
             result = mock_channel._size(queue)
 
             assert result == 5
@@ -136,10 +135,9 @@ class TestChannelBasicPublish:
         mock_sqs.get_queue_attributes.return_value = {}
 
         with patch.object(mock_channel, '_new_queue', return_value='queue-url'), \
-             patch.object(mock_channel, 'canonical_queue_name', return_value=queue), \
-             patch.object(mock_channel, 'sqs', return_value=mock_sqs), \
-             patch('mwaa.celery.sqs_broker.logger') as mock_logger:
-
+                patch.object(mock_channel, 'canonical_queue_name', return_value=queue), \
+                patch.object(mock_channel, 'sqs', return_value=mock_sqs), \
+                patch('mwaa.celery.sqs_broker.logger') as mock_logger:
             with pytest.raises(KeyError):
                 mock_channel._size(queue)
 


### PR DESCRIPTION
Adding logs to debug unexpected response in celery sqs broker for remaining versions and syncing unit tests for all versions

*Issue #, if available:* https://github.com/aws/amazon-mwaa-docker-images/issues/315

*Description of changes:*
Adding a check to make sure Attributes field is present and log the response if no to helping debugging the issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
