### PR TITLE
Add metadata db RDS IAM user

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -252,6 +252,7 @@ if __name__ == "__main__":
     except Exception as ex:
         logger.error("Fatal error in entrypoint: %s", str(ex), exc_info=True)
         _mark_as_unhealthy()
+        sys.exit(1)
 elif os.environ.get("MWAA__CORE__TESTING_MODE", "false") != "true":
     logger.error("This module cannot be imported.")
     sys.exit(1)

--- a/images/airflow/2.10.3/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.3/python/mwaa/entrypoint.py
@@ -251,6 +251,7 @@ if __name__ == "__main__":
     except Exception as ex:
         logger.error("Fatal error in entrypoint: %s", str(ex), exc_info=True)
         _mark_as_unhealthy()
+        sys.exit(1)
 elif os.environ.get("MWAA__CORE__TESTING_MODE", "false") != "true":
     logger.error("This module cannot be imported.")
     sys.exit(1)

--- a/images/airflow/2.11.0/python/mwaa/entrypoint.py
+++ b/images/airflow/2.11.0/python/mwaa/entrypoint.py
@@ -251,6 +251,7 @@ if __name__ == "__main__":
     except Exception as ex:
         logger.error("Fatal error in entrypoint: %s", str(ex), exc_info=True)
         _mark_as_unhealthy()
+        sys.exit(1)
 elif os.environ.get("MWAA__CORE__TESTING_MODE", "false") != "true":
     logger.error("This module cannot be imported.")
     sys.exit(1)

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -292,6 +292,7 @@ if __name__ == "__main__":
     except Exception as ex:
         logger.error("Fatal error in entrypoint: %s", str(ex), exc_info=True)
         _mark_as_unhealthy()
+        sys.exit(1)
 
 elif os.environ.get("MWAA__CORE__TESTING_MODE", "false") != "true":
     logger.error("This module cannot be imported.")

--- a/images/airflow/3.0.6/python/mwaa/entrypoint.py
+++ b/images/airflow/3.0.6/python/mwaa/entrypoint.py
@@ -244,6 +244,7 @@ if __name__ == "__main__":
     except Exception as ex:
         logger.error("Fatal error in entrypoint: %s", str(ex), exc_info=True)
         _mark_as_unhealthy()
+        sys.exit(1)
 elif os.environ.get("MWAA__CORE__TESTING_MODE", "false") != "true":
     logger.error("This module cannot be imported.")
     sys.exit(1)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Add new db user for Amazon RDS IAM auth on-boarding. We plan to replace the default airflow db user with a user which has rds iam auth enabled. This will allow us to introduce db credential rotation. I also added a missing sys.exit within the entrypoint so the containers exit correctly with a non-zero code when they are unhealthy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
