### PR TITLE
Increase pool size for problematic sizes

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -37,6 +37,7 @@ from mwaa.config.sqs import (
 )
 from mwaa.utils.cmd import run_command
 from mwaa.utils.dblock import with_db_lock
+from mwaa.utils.statsd import get_statsd
 from mwaa.utils.user_requirements import install_user_requirements
 
 # Usually, we pass the `__name__` variable instead as that defaults to the
@@ -140,6 +141,34 @@ async def airflow_dag_reserialize():
     await run_command("python3 -m mwaa.database.reserialize")
 
 
+async def increase_pool_size_if_insufficient(environ: dict[str, str]):
+    """
+    Increase the default pool size if it is too small.
+
+    Increases the default_pool size to 10000 if it is less than or equal 5000
+    as it improves performance in environments.
+
+    :param environ: A dictionary containing the environment variables.
+    """
+    problematic_pool_size = 5000
+
+    try:
+        command_output = []
+
+        # Get the current default_pool size
+        await run_command("airflow pools get default_pool | grep default_pool | awk '{print $3}'",
+                        env=environ, stdout_logging_method=lambda output : command_output.append(output))
+
+        # Increasing the pool size if it is the default size
+        if len(command_output) == 1 and int(command_output[0]) <= problematic_pool_size:
+            logger.info("Setting default_pool size to 10000.")
+            await run_command("airflow pools set default_pool 10000 default", env=environ)
+            stats = get_statsd()
+            stats.incr("mwaa.pool.increased_default_pool_size", 1)
+    except Exception as error:
+        logger.error(f"Error checking if pool issue is present: {error}")
+
+
 @with_db_lock(5678)
 async def create_airflow_user(environ: dict[str, str]):
     """
@@ -234,6 +263,7 @@ async def main() -> None:
         print("Finished testing requirements")
         return
 
+    await increase_pool_size_if_insufficient(environ)
     if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "testing":
         # In "simple" auth mode, we create an admin user "airflow" with password
         # "airflow". We use this to make the Docker Compose setup easy to use without

--- a/images/airflow/2.10.3/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.3/python/mwaa/entrypoint.py
@@ -37,6 +37,7 @@ from mwaa.config.sqs import (
 )
 from mwaa.utils.cmd import run_command
 from mwaa.utils.dblock import with_db_lock
+from mwaa.utils.statsd import get_statsd
 from mwaa.utils.user_requirements import install_user_requirements
 
 # Usually, we pass the `__name__` variable instead as that defaults to the
@@ -139,6 +140,34 @@ async def airflow_dag_reserialize():
     await run_command("python3 -m mwaa.database.reserialize")
 
 
+async def increase_pool_size_if_insufficient(environ: dict[str, str]):
+    """
+    Increase the default pool size if it is too small.
+
+    Increases the default_pool size to 10000 if it is less than or equal 5000
+    as it improves performance in environments.
+
+    :param environ: A dictionary containing the environment variables.
+    """
+    problematic_pool_size = 5000
+
+    try:
+        command_output = []
+
+        # Get the current default_pool size
+        await run_command("airflow pools get default_pool | grep default_pool | awk '{print $3}'",
+                        env=environ, stdout_logging_method=lambda output : command_output.append(output))
+
+        # Increasing the pool size if it is the default size
+        if len(command_output) == 1 and int(command_output[0]) <= problematic_pool_size:
+            logger.info("Setting default_pool size to 10000.")
+            await run_command("airflow pools set default_pool 10000 default", env=environ)
+            stats = get_statsd()
+            stats.incr("mwaa.pool.increased_default_pool_size", 1)
+    except Exception as error:
+        logger.error(f"Error checking if pool issue is present: {error}")
+
+
 @with_db_lock(5678)
 async def create_airflow_user(environ: dict[str, str]):
     """
@@ -233,6 +262,7 @@ async def main() -> None:
         print("Finished testing requirements")
         return
 
+    await increase_pool_size_if_insufficient(environ)
     if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "testing":
         # In "simple" auth mode, we create an admin user "airflow" with password
         # "airflow". We use this to make the Docker Compose setup easy to use without

--- a/images/airflow/2.11.0/python/mwaa/entrypoint.py
+++ b/images/airflow/2.11.0/python/mwaa/entrypoint.py
@@ -37,6 +37,7 @@ from mwaa.config.sqs import (
 )
 from mwaa.utils.cmd import run_command
 from mwaa.utils.dblock import with_db_lock
+from mwaa.utils.statsd import get_statsd
 from mwaa.utils.user_requirements import install_user_requirements
 
 # Usually, we pass the `__name__` variable instead as that defaults to the
@@ -139,6 +140,34 @@ async def airflow_dag_reserialize():
     await run_command("python3 -m mwaa.database.reserialize")
 
 
+async def increase_pool_size_if_insufficient(environ: dict[str, str]):
+    """
+    Increase the default pool size if it is too small.
+
+    Increases the default_pool size to 10000 if it is less than or equal 5000
+    as it improves performance in environments.
+
+    :param environ: A dictionary containing the environment variables.
+    """
+    problematic_pool_size = 5000
+
+    try:
+        command_output = []
+
+        # Get the current default_pool size
+        await run_command("airflow pools get default_pool | grep default_pool | awk '{print $3}'",
+                        env=environ, stdout_logging_method=lambda output : command_output.append(output))
+
+        # Increasing the pool size if it is the default size
+        if len(command_output) == 1 and int(command_output[0]) <= problematic_pool_size:
+            logger.info("Setting default_pool size to 10000.")
+            await run_command("airflow pools set default_pool 10000 default", env=environ)
+            stats = get_statsd()
+            stats.incr("mwaa.pool.increased_default_pool_size", 1)
+    except Exception as error:
+        logger.error(f"Error checking if pool issue is present: {error}")
+
+
 @with_db_lock(5678)
 async def create_airflow_user(environ: dict[str, str]):
     """
@@ -233,6 +262,7 @@ async def main() -> None:
         print("Finished testing requirements")
         return
 
+    await increase_pool_size_if_insufficient(environ)
     if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "testing":
         # In "simple" auth mode, we create an admin user "airflow" with password
         # "airflow". We use this to make the Docker Compose setup easy to use without

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -141,42 +141,32 @@ async def airflow_dag_reserialize():
     await run_command("python3 -m mwaa.database.reserialize")
 
 
-async def increase_pool_size_if_default_size(environ: dict[str, str]):
+async def increase_pool_size_if_insufficient(environ: dict[str, str]):
     """
-    Update the default pool size
+    Increase the default pool size if it is too small.
 
-    Fix a regression where some 2.9.2 environments were created with the default 128 default
-    pool size. This function checks if the environment was created during the problematic
-    timeframe and update the size if it has not been updated by the customer.
+    Increases the default_pool size to 10000 if it is less than or equal 5000
+    as it improves performance in environments.
 
     :param environ: A dictionary containing the environment variables.
     """
-    created_at = os.environ.get("MWAA__CORE__CREATED_AT")
-    problematic_pool_size = 128
+    problematic_pool_size = 5000
 
-    if created_at:
-        try:
-            date_format = "%a %b %d %H:%M:%S %Z %Y"
-            created_date = datetime.strptime(created_at, date_format)
-            # Has a little buffer from when 2.9.2 was released and when the fix was fully deployed
-            issue_beginning = datetime(2024, 7, 8)
-            issue_resolution = datetime(2024, 9, 6)
+    try:
+        command_output = []
 
-            if created_date > issue_beginning and created_date < issue_resolution:
-                command_output = []
+        # Get the current default_pool size
+        await run_command("airflow pools get default_pool | grep default_pool | awk '{print $3}'",
+                        env=environ, stdout_logging_method=lambda output : command_output.append(output))
 
-                # Get the current default_pool size
-                await run_command("airflow pools get default_pool | grep default_pool | awk '{print $3}'",
-                                env=environ, stdout_logging_method=lambda output : command_output.append(output))
-
-                # Increasing the pool size if it is the default size
-                if len(command_output) == 1 and int(command_output[0]) == problematic_pool_size:
-                    logger.info("Setting default_pool size to 10000.")
-                    await run_command("airflow pools set default_pool 10000 default", env=environ)
-                    stats = get_statsd()
-                    stats.incr("mwaa.pool.increased_default_pool_size", 1)
-        except Exception as error:
-            logger.error(f"Error checking if pool issue is present: {error}")
+        # Increasing the pool size if it is the default size
+        if len(command_output) == 1 and int(command_output[0]) <= problematic_pool_size:
+            logger.info("Setting default_pool size to 10000.")
+            await run_command("airflow pools set default_pool 10000 default", env=environ)
+            stats = get_statsd()
+            stats.incr("mwaa.pool.increased_default_pool_size", 1)
+    except Exception as error:
+        logger.error(f"Error checking if pool issue is present: {error}")
 
 
 @with_db_lock(5678)
@@ -273,7 +263,7 @@ async def main() -> None:
         print("Finished testing requirements")
         return
 
-    await increase_pool_size_if_default_size(environ)
+    await increase_pool_size_if_insufficient(environ)
     if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "testing":
         # In "simple" auth mode, we create an admin user "airflow" with password
         # "airflow". We use this to make the Docker Compose setup easy to use without

--- a/images/airflow/3.0.6/python/mwaa/entrypoint.py
+++ b/images/airflow/3.0.6/python/mwaa/entrypoint.py
@@ -37,6 +37,7 @@ from mwaa.config.sqs import (
 )
 from mwaa.utils.cmd import run_command
 from mwaa.utils.dblock import with_db_lock
+from mwaa.utils.statsd import get_statsd
 from mwaa.utils.user_requirements import install_user_requirements
 
 # Usually, we pass the `__name__` variable instead as that defaults to the
@@ -138,6 +139,34 @@ async def airflow_dag_reserialize():
     """
     await run_command("python3 -m mwaa.database.reserialize")
 
+
+async def increase_pool_size_if_insufficient(environ: dict[str, str]):
+    """
+    Increase the default pool size if it is too small.
+
+    Increases the default_pool size to 10000 if it is less than or equal 5000
+    as it improves performance in environments.
+
+    :param environ: A dictionary containing the environment variables.
+    """
+    problematic_pool_size = 5000
+
+    try:
+        command_output = []
+
+        # Get the current default_pool size
+        await run_command("airflow pools get default_pool | grep default_pool | awk '{print $3}'",
+                        env=environ, stdout_logging_method=lambda output : command_output.append(output))
+
+        # Increasing the pool size if it is the default size
+        if len(command_output) == 1 and int(command_output[0]) <= problematic_pool_size:
+            logger.info("Setting default_pool size to 10000.")
+            await run_command("airflow pools set default_pool 10000 default", env=environ)
+            stats = get_statsd()
+            stats.incr("mwaa.pool.increased_default_pool_size", 1)
+    except Exception as error:
+        logger.error(f"Error checking if pool issue is present: {error}")
+
 @with_db_lock(5678)
 async def create_airflow_user(environ: dict[str, str]):
     """
@@ -232,6 +261,7 @@ async def main() -> None:
         print("Finished testing requirements")
         return
 
+    await increase_pool_size_if_insufficient(environ)
     if executor_type.lower() == "celeryexecutor":
         create_queue()
 

--- a/tests/images/airflow/2.10.1/python/mwaa/test_entrypoint_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/test_entrypoint_2_10_1.py
@@ -11,6 +11,7 @@ from mwaa.entrypoint import (
     _setup_console_log_level,
     _configure_root_logger,
     airflow_db_migrate,
+    increase_pool_size_if_insufficient,
     create_airflow_user,
     create_queue,
     main
@@ -104,15 +105,53 @@ async def test_airflow_db_migrate(mock_db_utils):
 
 @pytest.fixture
 def mock_run_command():
+    """Mock run_command with AsyncMock"""
 
     async def mock_run(*args, **kwargs):
-        if 'stdout_logging_method' in kwargs in args[0]:
-            kwargs['stdout_logging_method']("128")
+        if 'stdout_logging_method' in kwargs and 'airflow pools get default_pool' in args[0]:
+            kwargs['stdout_logging_method']("4000")
         return 0
 
     with patch('mwaa.entrypoint.run_command') as mock:
         mock.side_effect = mock_run
         yield mock
+
+
+@pytest.mark.asyncio
+async def test_increase_pool_size_if_insufficient(mock_environ):
+    """Test pool size increase functionality"""
+    from unittest.mock import AsyncMock
+
+    # Track executed commands
+    called_commands = []
+
+    async def mock_run(cmd, env=None, stdout_logging_method=None):
+        called_commands.append(cmd)
+        if stdout_logging_method and "airflow pools get default_pool" in cmd:
+            stdout_logging_method("4000")  # Simulate the default pool size
+        return 0  # Simulate success
+
+    with patch('mwaa.entrypoint.run_command', new_callable=AsyncMock, side_effect=mock_run) as mock_cmd, \
+            patch('mwaa.entrypoint.get_statsd') as mock_statsd:
+        mock_stats = MagicMock()
+        mock_statsd.return_value = mock_stats
+
+        # Run the function
+        await increase_pool_size_if_insufficient(mock_environ)
+
+        # Ensure two commands were executed
+        assert len(called_commands) == 2, f"Expected 2 commands, got {len(called_commands)}: {called_commands}"
+
+        # Verify the first command retrieves the pool size
+        assert "airflow pools get default_pool" in called_commands[0], \
+            f"First command should be get pool, got: {called_commands[0]}"
+
+        # Verify the second command updates the pool size
+        assert "airflow pools set default_pool 10000" in called_commands[1], \
+            f"Second command should be set pool, got: {called_commands[1]}"
+
+        # Ensure the statsd increment function is called
+        mock_stats.incr.assert_called_once_with("mwaa.pool.increased_default_pool_size", 1)
 
 
 @pytest.mark.asyncio

--- a/tests/images/airflow/2.10.3/python/mwaa/test_entrypoint_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/test_entrypoint_2_10_3.py
@@ -10,6 +10,7 @@ from mwaa.entrypoint import (
     _setup_console_log_level,
     _configure_root_logger,
     airflow_db_migrate,
+    increase_pool_size_if_insufficient,
     create_airflow_user,
     create_queue,
     main
@@ -103,14 +104,53 @@ async def test_airflow_db_migrate(mock_db_utils):
 
 @pytest.fixture
 def mock_run_command():
+    """Mock run_command with AsyncMock"""
+
     async def mock_run(*args, **kwargs):
-        if 'stdout_logging_method' in kwargs in args[0]:
-            kwargs['stdout_logging_method']("128")
+        if 'stdout_logging_method' in kwargs and 'airflow pools get default_pool' in args[0]:
+            kwargs['stdout_logging_method']("4000")
         return 0
 
     with patch('mwaa.entrypoint.run_command') as mock:
         mock.side_effect = mock_run
         yield mock
+
+
+@pytest.mark.asyncio
+async def test_increase_pool_size_if_insufficient(mock_environ):
+    """Test pool size increase functionality"""
+    from unittest.mock import AsyncMock
+
+    # Track executed commands
+    called_commands = []
+
+    async def mock_run(cmd, env=None, stdout_logging_method=None):
+        called_commands.append(cmd)
+        if stdout_logging_method and "airflow pools get default_pool" in cmd:
+            stdout_logging_method("4000")  # Simulate the default pool size
+        return 0  # Simulate success
+
+    with patch('mwaa.entrypoint.run_command', new_callable=AsyncMock, side_effect=mock_run) as mock_cmd, \
+            patch('mwaa.entrypoint.get_statsd') as mock_statsd:
+        mock_stats = MagicMock()
+        mock_statsd.return_value = mock_stats
+
+        # Run the function
+        await increase_pool_size_if_insufficient(mock_environ)
+
+        # Ensure two commands were executed
+        assert len(called_commands) == 2, f"Expected 2 commands, got {len(called_commands)}: {called_commands}"
+
+        # Verify the first command retrieves the pool size
+        assert "airflow pools get default_pool" in called_commands[0], \
+            f"First command should be get pool, got: {called_commands[0]}"
+
+        # Verify the second command updates the pool size
+        assert "airflow pools set default_pool 10000" in called_commands[1], \
+            f"Second command should be set pool, got: {called_commands[1]}"
+
+        # Ensure the statsd increment function is called
+        mock_stats.incr.assert_called_once_with("mwaa.pool.increased_default_pool_size", 1)
 
 
 @pytest.mark.asyncio

--- a/tests/images/airflow/2.11.0/python/mwaa/test_entrypoint_2_11_0.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/test_entrypoint_2_11_0.py
@@ -10,6 +10,7 @@ from mwaa.entrypoint import (
     _setup_console_log_level,
     _configure_root_logger,
     airflow_db_migrate,
+    increase_pool_size_if_insufficient,
     create_airflow_user,
     create_queue,
     main
@@ -103,14 +104,53 @@ async def test_airflow_db_migrate(mock_db_utils):
 
 @pytest.fixture
 def mock_run_command():
+    """Mock run_command with AsyncMock"""
+
     async def mock_run(*args, **kwargs):
-        if 'stdout_logging_method' in kwargs in args[0]:
-            kwargs['stdout_logging_method']("128")
+        if 'stdout_logging_method' in kwargs and 'airflow pools get default_pool' in args[0]:
+            kwargs['stdout_logging_method']("4000")
         return 0
 
     with patch('mwaa.entrypoint.run_command') as mock:
         mock.side_effect = mock_run
         yield mock
+
+
+@pytest.mark.asyncio
+async def test_increase_pool_size_if_insufficient(mock_environ):
+    """Test pool size increase functionality"""
+    from unittest.mock import AsyncMock
+
+    # Track executed commands
+    called_commands = []
+
+    async def mock_run(cmd, env=None, stdout_logging_method=None):
+        called_commands.append(cmd)
+        if stdout_logging_method and "airflow pools get default_pool" in cmd:
+            stdout_logging_method("4000")  # Simulate the default pool size
+        return 0  # Simulate success
+
+    with patch('mwaa.entrypoint.run_command', new_callable=AsyncMock, side_effect=mock_run) as mock_cmd, \
+            patch('mwaa.entrypoint.get_statsd') as mock_statsd:
+        mock_stats = MagicMock()
+        mock_statsd.return_value = mock_stats
+
+        # Run the function
+        await increase_pool_size_if_insufficient(mock_environ)
+
+        # Ensure two commands were executed
+        assert len(called_commands) == 2, f"Expected 2 commands, got {len(called_commands)}: {called_commands}"
+
+        # Verify the first command retrieves the pool size
+        assert "airflow pools get default_pool" in called_commands[0], \
+            f"First command should be get pool, got: {called_commands[0]}"
+
+        # Verify the second command updates the pool size
+        assert "airflow pools set default_pool 10000" in called_commands[1], \
+            f"Second command should be set pool, got: {called_commands[1]}"
+
+        # Ensure the statsd increment function is called
+        mock_stats.incr.assert_called_once_with("mwaa.pool.increased_default_pool_size", 1)
 
 
 @pytest.mark.asyncio

--- a/tests/images/airflow/2.9.2/python/mwaa/test_entrypoint_2_9_2.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/test_entrypoint_2_9_2.py
@@ -10,7 +10,7 @@ from mwaa.entrypoint import (
     _setup_console_log_level,
     _configure_root_logger,
     airflow_db_migrate,
-    increase_pool_size_if_default_size,
+    increase_pool_size_if_insufficient,
     create_airflow_user,
     create_queue,
     main
@@ -117,10 +117,8 @@ def mock_run_command():
 
 
 @pytest.mark.asyncio
-async def test_increase_pool_size_if_default_size(mock_environ):
+async def test_increase_pool_size_if_insufficient(mock_environ):
     """Test pool size increase functionality"""
-    # Set environment variable within the problematic timeframe
-    mock_environ["MWAA__CORE__CREATED_AT"] = "Mon Jul 15 12:00:00 UTC 2024"
 
     # Track executed commands
     called_commands = []
@@ -128,7 +126,7 @@ async def test_increase_pool_size_if_default_size(mock_environ):
     async def mock_run(cmd, env=None, stdout_logging_method=None):
         called_commands.append(cmd)
         if stdout_logging_method and "airflow pools get default_pool" in cmd:
-            stdout_logging_method("128")  # Simulate the default pool size
+            stdout_logging_method("4000")  # Simulate the default pool size
         return 0  # Simulate success
 
     with patch('mwaa.entrypoint.run_command', new_callable=AsyncMock, side_effect=mock_run) as mock_cmd, \
@@ -137,7 +135,7 @@ async def test_increase_pool_size_if_default_size(mock_environ):
         mock_statsd.return_value = mock_stats
 
         # Run the function
-        await increase_pool_size_if_default_size(mock_environ)
+        await increase_pool_size_if_insufficient(mock_environ)
 
         # Ensure two commands were executed
         assert len(called_commands) == 2, f"Expected 2 commands, got {len(called_commands)}: {called_commands}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Increase the default_pool size to a very large number as we have seen issues if the value is too small. There is no downside to having it very large and customers can optimize/control their environment using other configurations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
