### PR TITLE
Use Empty Config for MigrateDb container

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.10.1/python/mwaa/config/setup_environment.py
@@ -223,7 +223,7 @@ def setup_environment_variables(command: str, executor_type: str) -> Dict:
     mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
     mwaa_essential_airflow_environ = get_essential_environ(command)
     mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = get_user_airflow_config()
+    user_airflow_config = {} if command == "migrate-db" else get_user_airflow_config()
 
 
     startup_script_environ = _execute_startup_script(

--- a/images/airflow/2.10.3/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.10.3/python/mwaa/config/setup_environment.py
@@ -226,7 +226,7 @@ def setup_environment_variables(command: str, executor_type: str) -> Dict:
     mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
     mwaa_essential_airflow_environ = get_essential_environ(command)
     mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = get_user_airflow_config()
+    user_airflow_config = {} if command == "migrate-db" else get_user_airflow_config()
 
 
     startup_script_environ = _execute_startup_script(

--- a/images/airflow/2.11.0/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.11.0/python/mwaa/config/setup_environment.py
@@ -226,7 +226,7 @@ def setup_environment_variables(command: str, executor_type: str) -> Dict:
     mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
     mwaa_essential_airflow_environ = get_essential_environ(command)
     mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = get_user_airflow_config()
+    user_airflow_config = {} if command == "migrate-db" else get_user_airflow_config()
 
 
     startup_script_environ = _execute_startup_script(

--- a/images/airflow/2.9.2/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.9.2/python/mwaa/config/setup_environment.py
@@ -223,7 +223,7 @@ def setup_environment_variables(command: str, executor_type: str) -> Dict:
     mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
     mwaa_essential_airflow_environ = get_essential_environ(command)
     mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = get_user_airflow_config()
+    user_airflow_config = {} if command == "migrate-db" else get_user_airflow_config()
 
 
     startup_script_environ = _execute_startup_script(

--- a/images/airflow/3.0.6/python/mwaa/config/setup_environment.py
+++ b/images/airflow/3.0.6/python/mwaa/config/setup_environment.py
@@ -232,7 +232,7 @@ def setup_environment_variables(command: str, executor_type: str) -> Dict:
     mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
     mwaa_essential_airflow_environ = get_essential_environ(command)
     mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = get_user_airflow_config()
+    user_airflow_config = {} if command == "migrate-db" else get_user_airflow_config()
 
 
     startup_script_environ = _execute_startup_script(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If a customer passed in a config that required a plugin installation, it can cause errors in the migratedb container because we do not sync plugins for this container. Using an empty config to allow this process to be more isolated so the customer cannot break it. This does not affect other containers. Tested by using this image for a MWAA environment and verified that the config no longer breaks it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
