### PR TITLE
Update error message for failed RDS credentials

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.10.1/python/mwaa/database/migrate_with_downgrade.py
@@ -65,7 +65,7 @@ def _ensure_rds_iam_user():
                 conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"))
                 conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"))
     except Exception as e:
-        logger.error(f"Error while ensuring rds iam user: {e}")
+        logger.warning(f"Error while ensuring rds iam db credentials, skipping. {e}")
 
 
 @with_db_lock(1234)

--- a/images/airflow/2.10.3/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.10.3/python/mwaa/database/migrate_with_downgrade.py
@@ -65,7 +65,7 @@ def _ensure_rds_iam_user():
                 conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"))
                 conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"))
     except Exception as e:
-        logger.error(f"Error while ensuring rds iam user: {e}")
+        logger.warning(f"Error while ensuring rds iam db credentials, skipping. {e}")
 
 
 @with_db_lock(1234)

--- a/images/airflow/2.11.0/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.11.0/python/mwaa/database/migrate_with_downgrade.py
@@ -65,7 +65,7 @@ def _ensure_rds_iam_user():
                 conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"))
                 conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"))
     except Exception as e:
-        logger.error(f"Error while ensuring rds iam user: {e}")
+        logger.warning(f"Error while ensuring rds iam db credentials, skipping. {e}")
 
 
 @with_db_lock(1234)

--- a/images/airflow/2.9.2/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.9.2/python/mwaa/database/migrate_with_downgrade.py
@@ -65,7 +65,7 @@ def _ensure_rds_iam_user():
                 conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"))
                 conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"))
     except Exception as e:
-        logger.error(f"Error while ensuring rds iam user: {e}")
+        logger.warning(f"Error while ensuring rds iam db credentials, skipping. {e}")
 
 
 @with_db_lock(1234)

--- a/images/airflow/3.0.6/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.0.6/python/mwaa/database/migrate_with_downgrade.py
@@ -65,7 +65,7 @@ def _ensure_rds_iam_user():
                 conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"))
                 conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"))
     except Exception as e:
-        logger.error(f"Error while ensuring rds iam user: {e}")
+        logger.warning(f"Error while ensuring rds iam db credentials, skipping. {e}")
 
 
 @with_db_lock(1234)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-mwaa-docker-images/issues/363
*Description of changes:*
Updating the error log to a warning log. This RDS credential code doesn't work locally so we skip if we encounter an error as it is not necessary for a local run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
