### PR TITLE
Revert "Increase pool size for problematic sizes (#358)"

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -37,7 +37,6 @@ from mwaa.config.sqs import (
 )
 from mwaa.utils.cmd import run_command
 from mwaa.utils.dblock import with_db_lock
-from mwaa.utils.statsd import get_statsd
 from mwaa.utils.user_requirements import install_user_requirements
 
 # Usually, we pass the `__name__` variable instead as that defaults to the
@@ -141,34 +140,6 @@ async def airflow_dag_reserialize():
     await run_command("python3 -m mwaa.database.reserialize")
 
 
-async def increase_pool_size_if_insufficient(environ: dict[str, str]):
-    """
-    Increase the default pool size if it is too small.
-
-    Increases the default_pool size to 10000 if it is less than or equal 5000
-    as it improves performance in environments.
-
-    :param environ: A dictionary containing the environment variables.
-    """
-    problematic_pool_size = 5000
-
-    try:
-        command_output = []
-
-        # Get the current default_pool size
-        await run_command("airflow pools get default_pool | grep default_pool | awk '{print $3}'",
-                        env=environ, stdout_logging_method=lambda output : command_output.append(output))
-
-        # Increasing the pool size if it is the default size
-        if len(command_output) == 1 and int(command_output[0]) <= problematic_pool_size:
-            logger.info("Setting default_pool size to 10000.")
-            await run_command("airflow pools set default_pool 10000 default", env=environ)
-            stats = get_statsd()
-            stats.incr("mwaa.pool.increased_default_pool_size", 1)
-    except Exception as error:
-        logger.error(f"Error checking if pool issue is present: {error}")
-
-
 @with_db_lock(5678)
 async def create_airflow_user(environ: dict[str, str]):
     """
@@ -263,7 +234,6 @@ async def main() -> None:
         print("Finished testing requirements")
         return
 
-    await increase_pool_size_if_insufficient(environ)
     if os.environ.get("MWAA__CORE__AUTH_TYPE", "").lower() == "testing":
         # In "simple" auth mode, we create an admin user "airflow" with password
         # "airflow". We use this to make the Docker Compose setup easy to use without

--- a/images/airflow/3.0.6/python/mwaa/entrypoint.py
+++ b/images/airflow/3.0.6/python/mwaa/entrypoint.py
@@ -37,7 +37,6 @@ from mwaa.config.sqs import (
 )
 from mwaa.utils.cmd import run_command
 from mwaa.utils.dblock import with_db_lock
-from mwaa.utils.statsd import get_statsd
 from mwaa.utils.user_requirements import install_user_requirements
 
 # Usually, we pass the `__name__` variable instead as that defaults to the
@@ -139,34 +138,6 @@ async def airflow_dag_reserialize():
     """
     await run_command("python3 -m mwaa.database.reserialize")
 
-
-async def increase_pool_size_if_insufficient(environ: dict[str, str]):
-    """
-    Increase the default pool size if it is too small.
-
-    Increases the default_pool size to 10000 if it is less than or equal 5000
-    as it improves performance in environments.
-
-    :param environ: A dictionary containing the environment variables.
-    """
-    problematic_pool_size = 5000
-
-    try:
-        command_output = []
-
-        # Get the current default_pool size
-        await run_command("airflow pools get default_pool | grep default_pool | awk '{print $3}'",
-                        env=environ, stdout_logging_method=lambda output : command_output.append(output))
-
-        # Increasing the pool size if it is the default size
-        if len(command_output) == 1 and int(command_output[0]) <= problematic_pool_size:
-            logger.info("Setting default_pool size to 10000.")
-            await run_command("airflow pools set default_pool 10000 default", env=environ)
-            stats = get_statsd()
-            stats.incr("mwaa.pool.increased_default_pool_size", 1)
-    except Exception as error:
-        logger.error(f"Error checking if pool issue is present: {error}")
-
 @with_db_lock(5678)
 async def create_airflow_user(environ: dict[str, str]):
     """
@@ -261,7 +232,6 @@ async def main() -> None:
         print("Finished testing requirements")
         return
 
-    await increase_pool_size_if_insufficient(environ)
     if executor_type.lower() == "celeryexecutor":
         create_queue()
 

--- a/tests/images/airflow/2.10.3/python/mwaa/test_entrypoint_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/test_entrypoint_2_10_3.py
@@ -10,7 +10,6 @@ from mwaa.entrypoint import (
     _setup_console_log_level,
     _configure_root_logger,
     airflow_db_migrate,
-    increase_pool_size_if_insufficient,
     create_airflow_user,
     create_queue,
     main
@@ -104,53 +103,14 @@ async def test_airflow_db_migrate(mock_db_utils):
 
 @pytest.fixture
 def mock_run_command():
-    """Mock run_command with AsyncMock"""
-
     async def mock_run(*args, **kwargs):
-        if 'stdout_logging_method' in kwargs and 'airflow pools get default_pool' in args[0]:
-            kwargs['stdout_logging_method']("4000")
+        if 'stdout_logging_method' in kwargs in args[0]:
+            kwargs['stdout_logging_method']("128")
         return 0
 
     with patch('mwaa.entrypoint.run_command') as mock:
         mock.side_effect = mock_run
         yield mock
-
-
-@pytest.mark.asyncio
-async def test_increase_pool_size_if_insufficient(mock_environ):
-    """Test pool size increase functionality"""
-    from unittest.mock import AsyncMock
-
-    # Track executed commands
-    called_commands = []
-
-    async def mock_run(cmd, env=None, stdout_logging_method=None):
-        called_commands.append(cmd)
-        if stdout_logging_method and "airflow pools get default_pool" in cmd:
-            stdout_logging_method("4000")  # Simulate the default pool size
-        return 0  # Simulate success
-
-    with patch('mwaa.entrypoint.run_command', new_callable=AsyncMock, side_effect=mock_run) as mock_cmd, \
-            patch('mwaa.entrypoint.get_statsd') as mock_statsd:
-        mock_stats = MagicMock()
-        mock_statsd.return_value = mock_stats
-
-        # Run the function
-        await increase_pool_size_if_insufficient(mock_environ)
-
-        # Ensure two commands were executed
-        assert len(called_commands) == 2, f"Expected 2 commands, got {len(called_commands)}: {called_commands}"
-
-        # Verify the first command retrieves the pool size
-        assert "airflow pools get default_pool" in called_commands[0], \
-            f"First command should be get pool, got: {called_commands[0]}"
-
-        # Verify the second command updates the pool size
-        assert "airflow pools set default_pool 10000" in called_commands[1], \
-            f"Second command should be set pool, got: {called_commands[1]}"
-
-        # Ensure the statsd increment function is called
-        mock_stats.incr.assert_called_once_with("mwaa.pool.increased_default_pool_size", 1)
 
 
 @pytest.mark.asyncio

--- a/tests/images/airflow/2.11.0/python/mwaa/test_entrypoint_2_11_0.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/test_entrypoint_2_11_0.py
@@ -10,7 +10,6 @@ from mwaa.entrypoint import (
     _setup_console_log_level,
     _configure_root_logger,
     airflow_db_migrate,
-    increase_pool_size_if_insufficient,
     create_airflow_user,
     create_queue,
     main
@@ -104,53 +103,14 @@ async def test_airflow_db_migrate(mock_db_utils):
 
 @pytest.fixture
 def mock_run_command():
-    """Mock run_command with AsyncMock"""
-
     async def mock_run(*args, **kwargs):
-        if 'stdout_logging_method' in kwargs and 'airflow pools get default_pool' in args[0]:
-            kwargs['stdout_logging_method']("4000")
+        if 'stdout_logging_method' in kwargs in args[0]:
+            kwargs['stdout_logging_method']("128")
         return 0
 
     with patch('mwaa.entrypoint.run_command') as mock:
         mock.side_effect = mock_run
         yield mock
-
-
-@pytest.mark.asyncio
-async def test_increase_pool_size_if_insufficient(mock_environ):
-    """Test pool size increase functionality"""
-    from unittest.mock import AsyncMock
-
-    # Track executed commands
-    called_commands = []
-
-    async def mock_run(cmd, env=None, stdout_logging_method=None):
-        called_commands.append(cmd)
-        if stdout_logging_method and "airflow pools get default_pool" in cmd:
-            stdout_logging_method("4000")  # Simulate the default pool size
-        return 0  # Simulate success
-
-    with patch('mwaa.entrypoint.run_command', new_callable=AsyncMock, side_effect=mock_run) as mock_cmd, \
-            patch('mwaa.entrypoint.get_statsd') as mock_statsd:
-        mock_stats = MagicMock()
-        mock_statsd.return_value = mock_stats
-
-        # Run the function
-        await increase_pool_size_if_insufficient(mock_environ)
-
-        # Ensure two commands were executed
-        assert len(called_commands) == 2, f"Expected 2 commands, got {len(called_commands)}: {called_commands}"
-
-        # Verify the first command retrieves the pool size
-        assert "airflow pools get default_pool" in called_commands[0], \
-            f"First command should be get pool, got: {called_commands[0]}"
-
-        # Verify the second command updates the pool size
-        assert "airflow pools set default_pool 10000" in called_commands[1], \
-            f"Second command should be set pool, got: {called_commands[1]}"
-
-        # Ensure the statsd increment function is called
-        mock_stats.incr.assert_called_once_with("mwaa.pool.increased_default_pool_size", 1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This reverts commit 48d052eeb72f5035233c6d1b9b0312745fe99038.

*Issue #, if available:*

*Description of changes:*
Reverting this change as it is causing unnecessary confusion as to why pool size config is getting reset on update. MWAA is now setting the pool size to 10000 on create which means the service itself is not adding an unnecessary bottle neck on the number of concurrent tasks which can run in an environment. Customer can feel free to change the pool size as desired. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
