### PR TITLE
Change sql connect args to optional

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/config/airflow.py
+++ b/images/airflow/2.10.1/python/mwaa/config/airflow.py
@@ -123,6 +123,18 @@ def _get_essential_airflow_db_config() -> Dict[str, str]:
     conn_string = get_db_connection_string()
     return {
         "AIRFLOW__DATABASE__SQL_ALCHEMY_CONN": conn_string,
+    }
+
+def _get_opinionated_airflow_db_config() -> Dict[str, str]:
+    """
+    Retrieve the environment variables for Airflow's "database" configuration section.
+
+    The difference between this and _get_essential_airflow_db_config is that the config set
+    here can be overridden by the user.
+
+    :returns A dictionary containing the environment variables.
+    """
+    return {
         "AIRFLOW__DATABASE__SQL_ALCHEMY_CONNECT_ARGS": "mwaa.config.database.MWAA_CONNECT_ARGS",
     }
 
@@ -334,4 +346,5 @@ def get_opinionated_airflow_config() -> Dict[str, str]:
         **_get_opinionated_airflow_scheduler_config(),
         **_get_opinionated_airflow_secrets_config(),
         **_get_opinionated_airflow_usage_data_config(),
+        **_get_opinionated_airflow_db_config(),
     }

--- a/images/airflow/2.10.3/python/mwaa/config/airflow.py
+++ b/images/airflow/2.10.3/python/mwaa/config/airflow.py
@@ -123,6 +123,18 @@ def _get_essential_airflow_db_config() -> Dict[str, str]:
     conn_string = get_db_connection_string()
     return {
         "AIRFLOW__DATABASE__SQL_ALCHEMY_CONN": conn_string,
+    }
+
+def _get_opinionated_airflow_db_config() -> Dict[str, str]:
+    """
+    Retrieve the environment variables for Airflow's "database" configuration section.
+
+    The difference between this and _get_essential_airflow_db_config is that the config set
+    here can be overridden by the user.
+
+    :returns A dictionary containing the environment variables.
+    """
+    return {
         "AIRFLOW__DATABASE__SQL_ALCHEMY_CONNECT_ARGS": "mwaa.config.database.MWAA_CONNECT_ARGS",
     }
 
@@ -334,4 +346,5 @@ def get_opinionated_airflow_config() -> Dict[str, str]:
         **_get_opinionated_airflow_scheduler_config(),
         **_get_opinionated_airflow_secrets_config(),
         **_get_opinionated_airflow_usage_data_config(),
+        **_get_opinionated_airflow_db_config(),
     }

--- a/images/airflow/2.11.0/python/mwaa/config/airflow.py
+++ b/images/airflow/2.11.0/python/mwaa/config/airflow.py
@@ -123,6 +123,18 @@ def _get_essential_airflow_db_config() -> Dict[str, str]:
     conn_string = get_db_connection_string()
     return {
         "AIRFLOW__DATABASE__SQL_ALCHEMY_CONN": conn_string,
+    }
+
+def _get_opinionated_airflow_db_config() -> Dict[str, str]:
+    """
+    Retrieve the environment variables for Airflow's "database" configuration section.
+
+    The difference between this and _get_essential_airflow_db_config is that the config set
+    here can be overridden by the user.
+
+    :returns A dictionary containing the environment variables.
+    """
+    return {
         "AIRFLOW__DATABASE__SQL_ALCHEMY_CONNECT_ARGS": "mwaa.config.database.MWAA_CONNECT_ARGS",
     }
 
@@ -334,4 +346,5 @@ def get_opinionated_airflow_config() -> Dict[str, str]:
         **_get_opinionated_airflow_scheduler_config(),
         **_get_opinionated_airflow_secrets_config(),
         **_get_opinionated_airflow_usage_data_config(),
+        **_get_opinionated_airflow_db_config(),
     }

--- a/images/airflow/2.9.2/python/mwaa/config/airflow.py
+++ b/images/airflow/2.9.2/python/mwaa/config/airflow.py
@@ -123,6 +123,18 @@ def _get_essential_airflow_db_config() -> Dict[str, str]:
     conn_string = get_db_connection_string()
     return {
         "AIRFLOW__DATABASE__SQL_ALCHEMY_CONN": conn_string,
+    }
+
+def _get_opinionated_airflow_db_config() -> Dict[str, str]:
+    """
+    Retrieve the environment variables for Airflow's "database" configuration section.
+
+    The difference between this and _get_essential_airflow_db_config is that the config set
+    here can be overridden by the user.
+
+    :returns A dictionary containing the environment variables.
+    """
+    return {
         "AIRFLOW__DATABASE__SQL_ALCHEMY_CONNECT_ARGS": "mwaa.config.database.MWAA_CONNECT_ARGS",
     }
 
@@ -320,4 +332,5 @@ def get_opinionated_airflow_config() -> Dict[str, str]:
         **_get_opinionated_airflow_core_config(),
         **_get_opinionated_airflow_scheduler_config(),
         **_get_opinionated_airflow_secrets_config(),
+        **_get_opinionated_airflow_db_config(),
     }

--- a/images/airflow/3.0.6/python/mwaa/config/airflow.py
+++ b/images/airflow/3.0.6/python/mwaa/config/airflow.py
@@ -132,6 +132,18 @@ def _get_essential_airflow_db_config() -> Dict[str, str]:
     conn_string = get_db_connection_string()
     return {
         "AIRFLOW__DATABASE__SQL_ALCHEMY_CONN": conn_string,
+    }
+
+def _get_opinionated_airflow_db_config() -> Dict[str, str]:
+    """
+    Retrieve the environment variables for Airflow's "database" configuration section.
+
+    The difference between this and _get_essential_airflow_db_config is that the config set
+    here can be overridden by the user.
+
+    :returns A dictionary containing the environment variables.
+    """
+    return {
         "AIRFLOW__DATABASE__SQL_ALCHEMY_CONNECT_ARGS": "mwaa.config.database.MWAA_CONNECT_ARGS",
     }
 
@@ -368,4 +380,5 @@ def get_opinionated_airflow_config() -> Dict[str, str]:
         **_get_opinionated_airflow_scheduler_config(),
         **_get_opinionated_airflow_secrets_config(),
         **_get_opinionated_airflow_usage_data_config(),
+        **_get_opinionated_airflow_db_config(),
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A follow up to the PR https://github.com/aws/amazon-mwaa-docker-images/pull/376. There might be a case where customers are already using this sql connect args config. Changing it to optional so that it doesn't change existing customer environment behavior.

Tested using 3.0.6 environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
