### PR TITLE
Port logging tests from 2.11.0 to 3.x , with necessary changes

### DIFF
--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -233,7 +233,7 @@ def test_cloudwatch_remote_task_logger_get_handler(mock_boto3_client, mock_watch
     assert handler is handler2
 
 
-def test_cloudwatch_remote_task_logger_processors_property():
+def test_cloudwatch_remote_task_logger_processors_property(mock_boto3_client, mock_watchtower):
     """Test CloudWatchRemoteTaskLogger processors property returns tuple."""
     logger = CloudWatchRemoteTaskLogger(
         log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -1,0 +1,492 @@
+import logging
+import pytest
+import os
+import importlib
+import types
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch, Mock, MagicMock, ANY
+
+from mwaa.config.setup_environment import (
+    setup_environment_variables,
+    _execute_startup_script,
+    _export_env_variables,
+    _is_protected_os_environ,
+)
+from mwaa.subprocess.subprocess import Subprocess
+from mwaa.logging.cloudwatch_handlers import (
+    BaseLogHandler,
+    CloudWatchRemoteTaskLogger,
+    SubprocessLogHandler,
+    DagProcessorManagerLogHandler,
+    DagProcessingLogHandler
+)
+
+print(BaseLogHandler.__init__.__code__.co_varnames)
+
+@pytest.fixture
+def mock_handler():
+    return Mock()
+
+@pytest.fixture
+def mock_boto3_client():
+    with patch('boto3.client') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_watchtower():
+    with patch('mwaa.logging.cloudwatch_handlers.watchtower.CloudWatchLogHandler') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_fluent():
+    with patch('mwaa.logging.cloudwatch_handlers.fluent_handler.FluentHandler') as mock:
+        yield mock
+
+@pytest.fixture(autouse=True)
+def reload_module():
+    import importlib
+    import mwaa.logging.cloudwatch_handlers
+    importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+@pytest.fixture
+def base_logger(mock_handler):
+    logger = BaseLogHandler(
+        log_group_arn="arn:aws:logs:region:account:log-group:test",
+        kms_key_arn="arn:aws:kms:region:account:key/test",
+        enabled=True
+    )
+    logger.handler = mock_handler
+    logger.stats = Mock()
+    return logger
+
+
+
+def test_emit_skips_deprecated_metric_message(base_logger):  # updated parameter name
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="The basic metric validator will be deprecated",
+        args=(),
+        exc_info=None
+    )
+
+    base_logger.emit(record)
+    base_logger.handler.emit.assert_not_called()
+
+
+def test_emit_handles_normal_message(base_logger):  # updated parameter name
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="Normal message",
+        args=(),
+        exc_info=None
+    )
+
+    with patch.dict(os.environ, {'MWAA__LOGGING__AIRFLOW_TEST_LOG_LEVEL': 'INFO'}):
+        base_logger.emit(record)
+        base_logger.handler.emit.assert_called_once_with(record)
+
+
+def test_emit_respects_log_level(base_logger):
+    record = logging.LogRecord(
+        name="test",
+        level=logging.DEBUG,
+        pathname="",
+        lineno=0,
+        msg="Debug message",
+        args=(),
+        exc_info=None
+    )
+
+    with patch.dict(os.environ, {'MWAA__LOGGING__AIRFLOW_TEST_LOG_LEVEL': 'INFO'}):
+        base_logger.emit(record)
+        base_logger.handler.emit.assert_not_called()
+
+
+def test_emit_with_no_handler():
+    logger = BaseLogHandler(
+        log_group_arn="arn:aws:logs:region:account:log-group:test",
+        kms_key_arn="arn:aws:kms:region:account:key/test",
+        enabled=True
+    )
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="Test message",
+        args=(),
+        exc_info=None
+    )
+
+    try:
+        logger.emit(record)
+        assert True  # Test passes if no exception is raised
+    except Exception as e:
+        assert False, f"emit() raised an exception {e} when handler is not set"
+
+def test_emit_handles_exception(base_logger):
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="Test message",
+        args=(),
+        exc_info=None
+    )
+
+    base_logger.handler.emit.side_effect = Exception("Simulated error")
+
+    base_logger.logs_source = "TEST"  # Make sure this is set
+
+    with patch.object(BaseLogHandler, '_report_logging_error') as mock_report_error:
+        base_logger.emit(record)
+
+        # Verify that stats.incr was called with the correct error metric
+        base_logger.stats.incr.assert_called_once_with("mwaa.logging.TEST.emit_error", 1)
+
+        # Verify that _report_logging_error was called with the correct message
+        mock_report_error.assert_called_once_with("Failed to emit log record.")
+
+@pytest.mark.parametrize("use_non_critical_logging, expected_handler, unexpected_handler", [
+    ('false', 'watchtower', 'fluent'),
+    ('true', 'fluent', 'watchtower')
+])
+def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, use_non_critical_logging, expected_handler, unexpected_handler):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': use_non_critical_logging}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'test_source')
+
+        assert handler.handler is not None, "No handler was created"
+
+        if expected_handler == 'watchtower':
+            assert isinstance(handler.handler, mock_watchtower.return_value.__class__), "Created handler should be a Watchtower handler"
+            assert mock_watchtower.called, f"{expected_handler} handler should be created"
+            assert not mock_fluent.called, f"{unexpected_handler} handler should not be created"
+            mock_watchtower.assert_called_once_with(
+                log_group_name=handler.log_group_name,
+                log_stream_name='test_stream',
+                boto3_client=mock_boto3_client.return_value,
+                use_queues=True,
+                send_interval=10,
+                create_log_group=False
+            )
+        else:
+            assert isinstance(handler.handler, mock_fluent.return_value.__class__), "Created handler should be a Fluent handler"
+            assert mock_fluent.called, f"{expected_handler} handler should be created"
+            assert not mock_watchtower.called, f"{unexpected_handler} handler should not be created"
+            mock_fluent.assert_called_once_with(
+                'customer.logs',
+                host=ANY,
+                port=24224
+            )
+
+def test_cloudwatch_remote_task_logger_initialization(mock_boto3_client):
+    """Test CloudWatchRemoteTaskLogger initialization."""
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+    
+    assert logger.enabled is True
+    assert logger.log_level == logging.INFO
+    assert logger.log_group_name == 'test-Task'
+    assert logger.region_name == 'us-west-2'
+    assert logger.handler is None  # Handler is lazy-initialized
+
+
+def test_cloudwatch_remote_task_logger_get_handler(mock_boto3_client, mock_watchtower):
+    """Test CloudWatchRemoteTaskLogger handler initialization."""
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+    
+    handler = logger.get_handler()
+    
+    assert handler is not None
+    assert mock_watchtower.called
+    mock_watchtower.assert_called_once_with(
+        log_group_name='test-Task',
+        boto3_client=mock_boto3_client.return_value,
+        use_queues=True,
+        create_log_group=False,
+    )
+    
+    # Should return same handler on subsequent calls (cached)
+    handler2 = logger.get_handler()
+    assert handler is handler2
+
+
+def test_cloudwatch_remote_task_logger_processors_property():
+    """Test CloudWatchRemoteTaskLogger processors property returns tuple."""
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+    
+    processors = logger.processors
+    
+    assert isinstance(processors, tuple)
+    assert len(processors) == 1
+    assert callable(processors[0])
+
+
+def test_cloudwatch_remote_task_logger_emit_is_noop():
+    """Test that emit() is a no-op for CloudWatchRemoteTaskLogger."""
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+    
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="Test message",
+        args=(),
+        exc_info=None
+    )
+    
+    # Should not raise any exception
+    result = logger.emit(record)
+    assert result is None
+
+
+def test_cloudwatch_remote_task_logger_upload_is_noop():
+    """Test that upload() is a no-op for CloudWatchRemoteTaskLogger."""
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+    logger.handler = Mock()
+    
+    ti = MagicMock()
+    
+    # Should not raise any exception
+    result = logger.upload('/tmp/test.log', ti)
+    assert result is None
+    logger.handler.flush.assert_called_once()
+
+
+def test_cloudwatch_remote_task_logger_read(mock_boto3_client):
+    """Test CloudWatchRemoteTaskLogger read() method."""
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        mock_hook = Mock()
+        mock_hook_class.return_value = mock_hook
+        
+        # Mock log events
+        mock_hook.get_log_events.return_value = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "test message", "level": "info"}'
+            }
+        ]
+        
+        logger = CloudWatchRemoteTaskLogger(
+            log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+            kms_key_arn=None,
+            enabled=True,
+            log_level='INFO'
+        )
+        
+        # Mock task instance
+        ti = MagicMock()
+        ti.dag_id = 'test_dag'
+        ti.task_id = 'test_task'
+        ti.run_id = 'test_run'
+        ti.try_number = 1
+        ti.end_date = None
+        
+        # Mock get_dagrun
+        mock_dag_run = MagicMock()
+        mock_dag_run.logical_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        mock_dag_run.run_after = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        mock_dag_run.data_interval_start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        mock_dag_run.data_interval_end = datetime(2024, 1, 2, tzinfo=timezone.utc)
+        
+        # Mock get_log_template
+        mock_log_template = MagicMock()
+        mock_log_template.filename = "dag_id={dag_id}/run_id={run_id}/task_id={task_id}/attempt={try_number}.log"
+        mock_dag_run.get_log_template.return_value = mock_log_template
+        
+        ti.get_dagrun.return_value = mock_dag_run
+        
+        messages, metadata = logger.read(ti, 1)
+        
+        assert len(messages) >= 1
+        assert any('Reading remote log from Cloudwatch' in msg for msg in messages if isinstance(msg, str))
+
+
+def test_cloudwatch_remote_task_logger_event_to_dict_with_json():
+    """Test _event_to_dict with JSON message."""
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+    
+    event = {
+        'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+        'message': '{"event": "test", "level": "info"}'
+    }
+    
+    result = logger._event_to_dict(event)
+    
+    assert 'timestamp' in result
+    assert result['event'] == 'test'
+    assert result['level'] == 'info'
+
+
+def test_cloudwatch_remote_task_logger_event_to_dict_with_plain_text():
+    """Test _event_to_dict with plain text message."""
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+    
+    event = {
+        'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+        'message': 'plain text message'
+    }
+    
+    result = logger._event_to_dict(event)
+    
+    assert 'timestamp' in result
+    assert result['event'] == 'plain text message'
+
+
+def test_cloudwatch_remote_task_logger_ignored_patterns():
+    """Test that IGNORED_PATTERNS filters out dag_processor logs."""
+    import re
+    
+    # Test dag_processor pattern
+    dag_processor_stream = "dag_processor/2025-01-01/dags-folder/dag.py.log"
+    assert any(re.match(p, dag_processor_stream) for p in CloudWatchRemoteTaskLogger.IGNORED_PATTERNS)
+    
+    # Test that regular task log stream is not filtered
+    task_stream = "dag_id=test/run_id=test/task_id=test/attempt=1.log"
+    assert not any(re.match(p, task_stream) for p in CloudWatchRemoteTaskLogger.IGNORED_PATTERNS)
+
+
+def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = SubprocessLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_prefix',
+            'test_source',
+            True,
+            log_formatter=logging.Formatter('%(message)s')
+        )
+
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224
+        }
+
+def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = DagProcessorManagerLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_stream',
+            True
+        )
+
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224
+        }
+
+def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = DagProcessingLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_stream_template',
+            True
+        )
+
+        handler.set_context('test_dag.py')
+        
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224
+        }
+
+
+def test_cloudwatch_remote_task_logger_always_uses_watchtower_not_fluent(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        logger = CloudWatchRemoteTaskLogger(
+            log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+            kms_key_arn=None,
+            enabled=True,
+            log_level='INFO'
+        )
+
+        # Trigger handler initialisation (lazy)
+        logger.get_handler()
+
+        assert logger.handler is not None
+        assert mock_watchtower.called, "CloudWatchRemoteTaskLogger must use watchtower"
+        assert not mock_fluent.called, (
+            "CloudWatchRemoteTaskLogger must NOT use Fluent, "
+            "even with USE_NON_CRITICAL_LOGGING=true"
+        )
+        mock_watchtower.assert_called_once_with(
+            log_group_name='test-Task',
+            boto3_client=mock_boto3_client.return_value,
+            use_queues=True,
+            create_log_group=False,
+        )

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_subprocess.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_subprocess.py
@@ -1,0 +1,149 @@
+import pytest
+from unittest.mock import patch, Mock, call
+import os
+from io import BytesIO
+from subprocess import Popen
+from mwaa.subprocess.subprocess import Subprocess, _SUBPROCESS_LOG_POLL_IDLE_SLEEP_INTERVAL
+import time
+
+@pytest.fixture
+def subprocess_instance():
+    """Fixture to create a Subprocess instance with mock command"""
+    return Subprocess(cmd="test_command")
+
+@pytest.fixture
+def mock_process(mocker):
+    """Fixture to create a mock process"""
+    process = mocker.Mock(spec=Popen)
+    process.poll.side_effect = [None, None, 0]  # Process runs for 2 iterations then ends
+    process.stdout = mocker.Mock()
+    process.stdout.readline.return_value = b'test output\n'
+    return process
+
+@pytest.fixture
+def mock_logger(mocker):
+    """Fixture to create a mock logger"""
+    return mocker.Mock()
+
+
+def test_read_subprocess_log_stream_empty_stream(subprocess_instance):
+    """Test behavior when stream is None"""
+    # Create mock process with None stdout
+    mock_process = Mock(spec=Popen)
+    mock_process.stdout = None
+
+    subprocess_instance.process_logger = Mock()
+    subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    # Assert no logging calls were made
+    subprocess_instance.process_logger.info.assert_not_called()
+    subprocess_instance.process_logger.error.assert_not_called()
+    subprocess_instance.process_logger.warning.assert_not_called()
+
+
+def test_read_subprocess_log_stream_process_running(mocker, subprocess_instance, mock_process, mock_logger):
+    """Test that read_subprocess_log_stream correctly handles a running process"""
+    # Setup
+    subprocess_instance.process_logger = mock_logger
+    mock_process.stdout.closed = False
+
+    # Simulate the following sequence:
+    # 1. Read output line, process running
+    # 2. Read empty line, process running (triggers sleep)
+    # 3. Read empty line, process finished (breaks loop)
+    mock_process.poll.side_effect = [None, None, 0]
+    mock_process.stdout.readline.side_effect = [
+        b'test output\n',
+        b'',
+        b'',
+        b''
+    ]
+
+    # Act
+    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'INFO'}):
+        subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    # Assert
+    assert mock_process.poll.call_count == 3
+    mock_logger.info.assert_called_once_with('test output')
+
+
+def test_read_subprocess_log_stream_closed_stream(subprocess_instance):
+    """Test behavior when stream is closed"""
+    # Create and configure mock process
+    mock_process = Mock(spec=Popen)
+    mock_process.stdout = Mock()
+    mock_process.stdout.closed = True
+
+    subprocess_instance.process_logger = Mock()
+    subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    subprocess_instance.process_logger.info.assert_not_called()
+
+
+def test_read_subprocess_log_stream_process_terminated(subprocess_instance):
+    """Test behavior when process has terminated"""
+    # Create and configure mock process
+    mock_process = Mock(spec=Popen)
+    mock_process.stdout = BytesIO(b"final message\n")
+    mock_process.poll.return_value = 0
+
+    subprocess_instance.process_logger = Mock()
+
+    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'INFO'}):
+        subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    subprocess_instance.process_logger.info.assert_called_once_with("final message")
+
+
+def test_read_subprocess_log_stream_process_error(mocker, subprocess_instance, mock_process, mock_logger):
+    """Test that read_subprocess_log_stream correctly handles error log level"""
+    # Setup
+    subprocess_instance.process_logger = mock_logger
+    mock_process.stdout.closed = False
+
+    # Simulate the following sequence:
+    # 1. Read output line, process running
+    # 2. Read empty line, process running (triggers sleep)
+    # 3. Read empty line, process finished (breaks loop)
+    mock_process.poll.side_effect = [None, None, 0]
+    mock_process.stdout.readline.side_effect = [
+        b'test output\n',
+        b'',
+        b'',
+        b''
+    ]
+
+    # Act
+    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'ERROR'}):
+        subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    # Assert
+    assert mock_process.poll.call_count == 3
+    mock_logger.error.assert_called_once_with('test output')
+
+def test_read_subprocess_log_stream_process_warning(mocker, subprocess_instance, mock_process, mock_logger):
+    """Test that read_subprocess_log_stream correctly handles warning log level"""
+    # Setup
+    subprocess_instance.process_logger = mock_logger
+    mock_process.stdout.closed = False
+
+    # Simulate the following sequence:
+    # 1. Read output line, process running
+    # 2. Read empty line, process running (triggers sleep)
+    # 3. Read empty line, process finished (breaks loop)
+    mock_process.poll.side_effect = [None, None, 0]
+    mock_process.stdout.readline.side_effect = [
+        b'test output\n',
+        b'',
+        b'',
+        b''
+    ]
+
+    # Act
+    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'WARNING'}):
+        subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    # Assert
+    assert mock_process.poll.call_count == 3
+    mock_logger.warning.assert_called_once_with('test output')

--- a/tests/images/airflow/3.1.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.1.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -1,0 +1,477 @@
+import logging
+import pytest
+import os
+import importlib
+import types
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch, Mock, MagicMock, ANY
+
+from mwaa.config.setup_environment import (
+    setup_environment_variables,
+    _execute_startup_script,
+    _export_env_variables,
+    _is_protected_os_environ,
+)
+from mwaa.subprocess.subprocess import Subprocess
+from mwaa.logging.cloudwatch_handlers import (
+    BaseLogHandler,
+    CloudWatchRemoteTaskLogger,
+    SubprocessLogHandler,
+    DagProcessorManagerLogHandler,
+    DagProcessingLogHandler
+)
+
+print(BaseLogHandler.__init__.__code__.co_varnames)
+
+@pytest.fixture
+def mock_handler():
+    return Mock()
+
+@pytest.fixture
+def mock_boto3_client():
+    with patch('boto3.client') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_watchtower():
+    with patch('mwaa.logging.cloudwatch_handlers.watchtower.CloudWatchLogHandler') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_fluent():
+    with patch('mwaa.logging.cloudwatch_handlers.fluent_handler.FluentHandler') as mock:
+        yield mock
+
+@pytest.fixture(autouse=True)
+def reload_module():
+    import importlib
+    import mwaa.logging.cloudwatch_handlers
+    importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+@pytest.fixture
+def base_logger(mock_handler):
+    logger = BaseLogHandler(
+        log_group_arn="arn:aws:logs:region:account:log-group:test",
+        kms_key_arn="arn:aws:kms:region:account:key/test",
+        enabled=True
+    )
+    logger.handler = mock_handler
+    logger.stats = Mock()
+    return logger
+
+
+def test_emit_skips_deprecated_metric_message(base_logger):
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="The basic metric validator will be deprecated",
+        args=(),
+        exc_info=None
+    )
+
+    base_logger.emit(record)
+    base_logger.handler.emit.assert_not_called()
+
+
+def test_emit_handles_normal_message(base_logger):
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="Normal message",
+        args=(),
+        exc_info=None
+    )
+
+    with patch.dict(os.environ, {'MWAA__LOGGING__AIRFLOW_TEST_LOG_LEVEL': 'INFO'}):
+        base_logger.emit(record)
+        base_logger.handler.emit.assert_called_once_with(record)
+
+
+def test_emit_respects_log_level(base_logger):
+    record = logging.LogRecord(
+        name="test",
+        level=logging.DEBUG,
+        pathname="",
+        lineno=0,
+        msg="Debug message",
+        args=(),
+        exc_info=None
+    )
+
+    with patch.dict(os.environ, {'MWAA__LOGGING__AIRFLOW_TEST_LOG_LEVEL': 'INFO'}):
+        base_logger.emit(record)
+        base_logger.handler.emit.assert_not_called()
+
+
+def test_emit_with_no_handler():
+    logger = BaseLogHandler(
+        log_group_arn="arn:aws:logs:region:account:log-group:test",
+        kms_key_arn="arn:aws:kms:region:account:key/test",
+        enabled=True
+    )
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="Test message",
+        args=(),
+        exc_info=None
+    )
+
+    try:
+        logger.emit(record)
+        assert True
+    except Exception as e:
+        assert False, f"emit() raised an exception {e} when handler is not set"
+
+def test_emit_handles_exception(base_logger):
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="Test message",
+        args=(),
+        exc_info=None
+    )
+
+    base_logger.handler.emit.side_effect = Exception("Simulated error")
+
+    base_logger.logs_source = "TEST"  # Make sure this is set
+
+    with patch.object(BaseLogHandler, '_report_logging_error') as mock_report_error:
+        base_logger.emit(record)
+
+        # Verify that stats.incr was called with the correct error metric
+        base_logger.stats.incr.assert_called_once_with("mwaa.logging.TEST.emit_error", 1)
+
+        # Verify that _report_logging_error was called with the correct message
+        mock_report_error.assert_called_once_with("Failed to emit log record.")
+
+@pytest.mark.parametrize("use_non_critical_logging, expected_handler, unexpected_handler", [
+    ('false', 'watchtower', 'fluent'),
+    ('true', 'fluent', 'watchtower')
+])
+def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, use_non_critical_logging, expected_handler, unexpected_handler):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': use_non_critical_logging}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'test_source')
+
+        assert handler.handler is not None, "No handler was created"
+
+        if expected_handler == 'watchtower':
+            assert isinstance(handler.handler, mock_watchtower.return_value.__class__), "Created handler should be a Watchtower handler"
+            assert mock_watchtower.called, f"{expected_handler} handler should be created"
+            assert not mock_fluent.called, f"{unexpected_handler} handler should not be created"
+            mock_watchtower.assert_called_once_with(
+                log_group_name=handler.log_group_name,
+                log_stream_name='test_stream',
+                boto3_client=mock_boto3_client.return_value,
+                use_queues=True,
+                send_interval=10,
+                create_log_group=False
+            )
+        else:
+            assert isinstance(handler.handler, mock_fluent.return_value.__class__), "Created handler should be a Fluent handler"
+            assert mock_fluent.called, f"{expected_handler} handler should be created"
+            assert not mock_watchtower.called, f"{unexpected_handler} handler should not be created"
+            mock_fluent.assert_called_once_with(
+                'customer.logs',
+                host=ANY,
+                port=24224
+            )
+
+def test_cloudwatch_remote_task_logger_initialization(mock_boto3_client):
+    """Test CloudWatchRemoteTaskLogger initialization."""
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+
+    assert logger.enabled is True
+    assert logger.log_level == logging.INFO
+    assert logger.log_group_name == 'test-Task'
+    assert logger.region_name == 'us-west-2'
+    assert logger.handler is None
+
+
+def test_cloudwatch_remote_task_logger_get_handler(mock_boto3_client, mock_watchtower):
+    """Test CloudWatchRemoteTaskLogger handler initialization."""
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+
+    handler = logger.get_handler()
+
+    assert handler is not None
+    assert mock_watchtower.called
+    mock_watchtower.assert_called_once_with(
+        log_group_name='test-Task',
+        boto3_client=mock_boto3_client.return_value,
+        use_queues=True,
+        create_log_group=False,
+    )
+
+    handler2 = logger.get_handler()
+    assert handler is handler2
+
+
+def test_cloudwatch_remote_task_logger_processors_property():
+    """Test CloudWatchRemoteTaskLogger processors property returns tuple."""
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+
+    processors = logger.processors
+
+    assert isinstance(processors, tuple)
+    assert len(processors) == 1
+    assert callable(processors[0])
+
+
+def test_cloudwatch_remote_task_logger_emit_is_noop():
+    """Test that emit() is a no-op for CloudWatchRemoteTaskLogger."""
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="Test message",
+        args=(),
+        exc_info=None
+    )
+
+    result = logger.emit(record)
+    assert result is None
+
+
+def test_cloudwatch_remote_task_logger_upload_is_noop():
+    """Test that upload() is a no-op for CloudWatchRemoteTaskLogger."""
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+    logger.handler = Mock()
+
+    ti = MagicMock()
+
+    result = logger.upload('/tmp/test.log', ti)
+    assert result is None
+    logger.handler.flush.assert_called_once()
+
+
+def test_cloudwatch_remote_task_logger_read(mock_boto3_client):
+    """Test CloudWatchRemoteTaskLogger read() method."""
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        mock_hook = Mock()
+        mock_hook_class.return_value = mock_hook
+
+        mock_hook.get_log_events.return_value = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "test message", "level": "info"}'
+            }
+        ]
+
+        logger = CloudWatchRemoteTaskLogger(
+            log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+            kms_key_arn=None,
+            enabled=True,
+            log_level='INFO'
+        )
+
+        ti = MagicMock()
+        ti.dag_id = 'test_dag'
+        ti.task_id = 'test_task'
+        ti.run_id = 'test_run'
+        ti.try_number = 1
+        ti.end_date = None
+
+        mock_dag_run = MagicMock()
+        mock_dag_run.logical_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        mock_dag_run.run_after = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        mock_dag_run.data_interval_start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        mock_dag_run.data_interval_end = datetime(2024, 1, 2, tzinfo=timezone.utc)
+
+        mock_log_template = MagicMock()
+        mock_log_template.filename = "dag_id={dag_id}/run_id={run_id}/task_id={task_id}/attempt={try_number}.log"
+        mock_dag_run.get_log_template.return_value = mock_log_template
+
+        ti.get_dagrun.return_value = mock_dag_run
+
+        messages, metadata = logger.read(ti, 1)
+
+        assert len(messages) >= 1
+        assert any('Reading remote log from Cloudwatch' in msg for msg in messages if isinstance(msg, str))
+
+
+def test_cloudwatch_remote_task_logger_event_to_dict_with_json():
+    """Test _event_to_dict with JSON message."""
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+
+    event = {
+        'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+        'message': '{"event": "test", "level": "info"}'
+    }
+
+    result = logger._event_to_dict(event)
+
+    assert 'timestamp' in result
+    assert result['event'] == 'test'
+    assert result['level'] == 'info'
+
+
+def test_cloudwatch_remote_task_logger_event_to_dict_with_plain_text():
+    """Test _event_to_dict with plain text message."""
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+
+    event = {
+        'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+        'message': 'plain text message'
+    }
+
+    result = logger._event_to_dict(event)
+
+    assert 'timestamp' in result
+    assert result['event'] == 'plain text message'
+
+
+def test_cloudwatch_remote_task_logger_ignored_patterns():
+    """Test that IGNORED_PATTERNS filters out dag_processor logs."""
+    import re
+
+    dag_processor_stream = "dag_processor/2025-01-01/dags-folder/dag.py.log"
+    assert any(re.match(p, dag_processor_stream) for p in CloudWatchRemoteTaskLogger.IGNORED_PATTERNS)
+
+    task_stream = "dag_id=test/run_id=test/task_id=test/attempt=1.log"
+    assert not any(re.match(p, task_stream) for p in CloudWatchRemoteTaskLogger.IGNORED_PATTERNS)
+
+
+def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = SubprocessLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_prefix',
+            'test_source',
+            True,
+            log_formatter=logging.Formatter('%(message)s')
+        )
+
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224
+        }
+
+def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = DagProcessorManagerLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_stream',
+            True
+        )
+
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224
+        }
+
+def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = DagProcessingLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_stream_template',
+            True
+        )
+
+        handler.set_context('test_dag.py')
+
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224
+        }
+
+def test_cloudwatch_remote_task_logger_always_uses_watchtower_not_fluent(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        logger = CloudWatchRemoteTaskLogger(
+            log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+            kms_key_arn=None,
+            enabled=True,
+            log_level='INFO'
+        )
+
+        # Trigger handler initialisation (lazy)
+        logger.get_handler()
+
+        assert logger.handler is not None
+        assert mock_watchtower.called, "CloudWatchRemoteTaskLogger must use watchtower"
+        assert not mock_fluent.called, (
+            "CloudWatchRemoteTaskLogger must NOT use Fluent, "
+            "even with USE_NON_CRITICAL_LOGGING=true"
+        )
+        mock_watchtower.assert_called_once_with(
+            log_group_name='test-Task',
+            boto3_client=mock_boto3_client.return_value,
+            use_queues=True,
+            create_log_group=False,
+        )

--- a/tests/images/airflow/3.1.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.1.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -230,7 +230,7 @@ def test_cloudwatch_remote_task_logger_get_handler(mock_boto3_client, mock_watch
     assert handler is handler2
 
 
-def test_cloudwatch_remote_task_logger_processors_property():
+def test_cloudwatch_remote_task_logger_processors_property(mock_boto3_client, mock_watchtower):
     """Test CloudWatchRemoteTaskLogger processors property returns tuple."""
     logger = CloudWatchRemoteTaskLogger(
         log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',

--- a/tests/images/airflow/3.1.6/python/mwaa/logging/test_subprocess.py
+++ b/tests/images/airflow/3.1.6/python/mwaa/logging/test_subprocess.py
@@ -1,0 +1,149 @@
+import pytest
+from unittest.mock import patch, Mock, call
+import os
+from io import BytesIO
+from subprocess import Popen
+from mwaa.subprocess.subprocess import Subprocess, _SUBPROCESS_LOG_POLL_IDLE_SLEEP_INTERVAL
+import time
+
+@pytest.fixture
+def subprocess_instance():
+    """Fixture to create a Subprocess instance with mock command"""
+    return Subprocess(cmd="test_command")
+
+@pytest.fixture
+def mock_process(mocker):
+    """Fixture to create a mock process"""
+    process = mocker.Mock(spec=Popen)
+    process.poll.side_effect = [None, None, 0]  # Process runs for 2 iterations then ends
+    process.stdout = mocker.Mock()
+    process.stdout.readline.return_value = b'test output\n'
+    return process
+
+@pytest.fixture
+def mock_logger(mocker):
+    """Fixture to create a mock logger"""
+    return mocker.Mock()
+
+
+def test_read_subprocess_log_stream_empty_stream(subprocess_instance):
+    """Test behavior when stream is None"""
+    # Create mock process with None stdout
+    mock_process = Mock(spec=Popen)
+    mock_process.stdout = None
+
+    subprocess_instance.process_logger = Mock()
+    subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    # Assert no logging calls were made
+    subprocess_instance.process_logger.info.assert_not_called()
+    subprocess_instance.process_logger.error.assert_not_called()
+    subprocess_instance.process_logger.warning.assert_not_called()
+
+
+def test_read_subprocess_log_stream_process_running(mocker, subprocess_instance, mock_process, mock_logger):
+    """Test that read_subprocess_log_stream correctly handles a running process"""
+    # Setup
+    subprocess_instance.process_logger = mock_logger
+    mock_process.stdout.closed = False
+
+    # Simulate the following sequence:
+    # 1. Read output line, process running
+    # 2. Read empty line, process running (triggers sleep)
+    # 3. Read empty line, process finished (breaks loop)
+    mock_process.poll.side_effect = [None, None, 0]
+    mock_process.stdout.readline.side_effect = [
+        b'test output\n',
+        b'',
+        b'',
+        b''
+    ]
+
+    # Act
+    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'INFO'}):
+        subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    # Assert
+    assert mock_process.poll.call_count == 3
+    mock_logger.info.assert_called_once_with('test output')
+
+
+def test_read_subprocess_log_stream_closed_stream(subprocess_instance):
+    """Test behavior when stream is closed"""
+    # Create and configure mock process
+    mock_process = Mock(spec=Popen)
+    mock_process.stdout = Mock()
+    mock_process.stdout.closed = True
+
+    subprocess_instance.process_logger = Mock()
+    subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    subprocess_instance.process_logger.info.assert_not_called()
+
+
+def test_read_subprocess_log_stream_process_terminated(subprocess_instance):
+    """Test behavior when process has terminated"""
+    # Create and configure mock process
+    mock_process = Mock(spec=Popen)
+    mock_process.stdout = BytesIO(b"final message\n")
+    mock_process.poll.return_value = 0
+
+    subprocess_instance.process_logger = Mock()
+
+    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'INFO'}):
+        subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    subprocess_instance.process_logger.info.assert_called_once_with("final message")
+
+
+def test_read_subprocess_log_stream_process_error(mocker, subprocess_instance, mock_process, mock_logger):
+    """Test that read_subprocess_log_stream correctly handles error log level"""
+    # Setup
+    subprocess_instance.process_logger = mock_logger
+    mock_process.stdout.closed = False
+
+    # Simulate the following sequence:
+    # 1. Read output line, process running
+    # 2. Read empty line, process running (triggers sleep)
+    # 3. Read empty line, process finished (breaks loop)
+    mock_process.poll.side_effect = [None, None, 0]
+    mock_process.stdout.readline.side_effect = [
+        b'test output\n',
+        b'',
+        b'',
+        b''
+    ]
+
+    # Act
+    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'ERROR'}):
+        subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    # Assert
+    assert mock_process.poll.call_count == 3
+    mock_logger.error.assert_called_once_with('test output')
+
+def test_read_subprocess_log_stream_process_warning(mocker, subprocess_instance, mock_process, mock_logger):
+    """Test that read_subprocess_log_stream correctly handles warning log level"""
+    # Setup
+    subprocess_instance.process_logger = mock_logger
+    mock_process.stdout.closed = False
+
+    # Simulate the following sequence:
+    # 1. Read output line, process running
+    # 2. Read empty line, process running (triggers sleep)
+    # 3. Read empty line, process finished (breaks loop)
+    mock_process.poll.side_effect = [None, None, 0]
+    mock_process.stdout.readline.side_effect = [
+        b'test output\n',
+        b'',
+        b'',
+        b''
+    ]
+
+    # Act
+    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'WARNING'}):
+        subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    # Assert
+    assert mock_process.poll.call_count == 3
+    mock_logger.warning.assert_called_once_with('test output')


### PR DESCRIPTION
*Description of changes:*
- Ported tests from `2.11.0` to `3.0.6` and `3.1.6`
- New tests in test_cloudwatch_handler.py, to account for CloudWatchRemoteTaskLogger and remove the tests for TaskLogHandler in AF 3.x tests

## Testing

Changes are tested locally, validated that tests are passing for `3.0.6` and for `3.1.6`
