### PR TITLE
add unit tests for config module in AF 3.0.6

### DIFF
--- a/tests/images/airflow/3.0.6/conftest.py
+++ b/tests/images/airflow/3.0.6/conftest.py
@@ -63,3 +63,16 @@ def clean_env() -> Generator[None, None, None]:
     # Restore original environment
     os.environ.clear()
     os.environ.update(original_env)
+
+@pytest.fixture
+def env_helper(monkeypatch):
+    class EnvHelper:
+        def set(self, vars):
+            for k, v in vars.items():
+                monkeypatch.setenv(k, v)
+
+        def delete(self, keys):
+            for k in keys:
+                monkeypatch.delenv(k, raising=False)
+
+    return EnvHelper()

--- a/tests/images/airflow/3.0.6/python/mwaa/config/__init__.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/__init__.py
@@ -1,0 +1,1 @@
+# Empty __init__.py file to make this directory a Python package

--- a/tests/images/airflow/3.0.6/python/mwaa/config/base_config_test.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/base_config_test.py
@@ -1,0 +1,16 @@
+
+import os
+from typing import Dict
+
+class BaseConfigTest:
+    """Base class for config tests with common utilities."""
+
+    def assert_config_keys(self, config: Dict[str, str], expected_keys: list) -> None:
+        """Assert that config contains expected keys."""
+        for key in expected_keys:
+            assert key in config, f"Expected key '{key}' not found in config"
+    
+    def assert_airflow_config_format(self, config: Dict[str, str]) -> None:
+        """Assert that config keys follow Airflow format."""
+        for key in config.keys():
+            assert key.startswith("AIRFLOW__"), f"Key '{key}' doesn't follow Airflow format"

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_airflow.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_airflow.py
@@ -1,0 +1,547 @@
+"""Tests for airflow configuration module."""
+
+import json
+import pytest
+
+from mwaa.config.airflow import (
+    _get_essential_airflow_executor_config,
+    _get_essential_airflow_core_config,
+    _get_opinionated_airflow_core_config,
+    get_user_airflow_config,
+    _get_essential_airflow_db_config,
+    _get_opinionated_airflow_db_config,
+    _get_essential_airflow_auth_config,
+    _get_essential_airflow_api_auth_config,
+    _get_essential_aiflow_execution_api_config,
+    _get_essential_airflow_logging_config,
+    _get_mwaa_cloudwatch_integration_config,
+    _get_essential_airflow_scheduler_config,
+    _get_opinionated_airflow_scheduler_config,
+    _get_opinionated_airflow_secrets_config,
+    _get_opinionated_airflow_usage_data_config,
+    _get_essential_airflow_webserver_config
+)
+
+# ---------------------------
+# Executor Config Tests
+# ---------------------------
+
+def test_local_executor_config():
+    result = _get_essential_airflow_executor_config("LocalExecutor")
+    assert result == {
+        "AIRFLOW__CORE__EXECUTOR": "LocalExecutor",
+    }
+
+@pytest.mark.parametrize("executor_name, expected_executor", [
+    ("LocalExecutor", "LocalExecutor"),
+    ("localexecutor", "LocalExecutor"),
+    ("CeleryExecutor", "CeleryExecutor"),
+    ("celeryexecutor", "CeleryExecutor"),
+])
+def test_essential_airflow_executor_config(monkeypatch, executor_name, expected_executor):
+    if expected_executor == "LocalExecutor":
+        result = _get_essential_airflow_executor_config(executor_name)
+        assert result == {"AIRFLOW__CORE__EXECUTOR": expected_executor}
+    elif expected_executor == "CeleryExecutor":
+         # Mock Celery dependencies
+        monkeypatch.setattr("mwaa.config.airflow.get_sqs_endpoint", lambda: "sqs://endpoint")
+        monkeypatch.setattr("mwaa.config.airflow.get_sqs_queue_name", lambda: "test-queue")
+        monkeypatch.setattr("mwaa.config.airflow.get_db_connection_string", lambda: "postgresql://db")
+
+        result = _get_essential_airflow_executor_config(executor_name)
+        assert result["AIRFLOW__CORE__EXECUTOR"] == expected_executor
+        assert result["AIRFLOW__CELERY__BROKER_URL"] == "sqs://endpoint"
+        assert result["AIRFLOW__OPERATORS__DEFAULT_QUEUE"] == "test-queue"
+        assert result["AIRFLOW__CELERY__RESULT_BACKEND"] == "db+postgresql://db"
+        assert result["AIRFLOW__CELERY__WORKER_ENABLE_REMOTE_CONTROL"] == "False"
+        assert result["AIRFLOW__CELERY_BROKER_TRANSPORT_OPTIONS__VISIBILITY_TIMEOUT"] == "43200"
+        assert result["AIRFLOW__CELERY__CELERY_CONFIG_OPTIONS"] == "mwaa.config.celery.MWAA_CELERY_CONFIG"
+
+@pytest.mark.parametrize("invalid_executor", ["UnknownExecutor", "unknownexecutor"])
+def test_invalid_executor(invalid_executor):
+    with pytest.raises(ValueError):
+        _get_essential_airflow_executor_config(invalid_executor)
+
+# ---------------------------
+# Core Config Tests
+# ---------------------------
+def test_core_config_with_api_url_and_fernet(env_helper):
+    env_helper.set({
+        "MWAA__CORE__FERNET_KEY": json.dumps({"FernetKey": "test-key"}),
+        "MWAA__CORE__API_SERVER_URL": "api.example.com"
+    })
+
+    result = _get_essential_airflow_core_config()
+
+    assert result["AIRFLOW__CORE__LOAD_EXAMPLES"] == "False"
+    assert result["AIRFLOW__CORE__FERNET_KEY"] == "test-key"
+    assert result["AIRFLOW__CORE__EXECUTION_API_SERVER_URL"] == \
+        "https://api.example.com/execution"
+    
+def test_core_config_invalid_fernet(env_helper):
+    env_helper.set({
+        "MWAA__CORE__FERNET_KEY": "invalid-json"
+    })
+
+    result = _get_essential_airflow_core_config()
+
+    assert "AIRFLOW__CORE__FERNET_KEY" not in result
+
+
+# ---------------------------------
+# Opinion Airflow Core Config Tests
+# ---------------------------------
+def test_get_opinionated_airflow_core_config():
+    result = _get_opinionated_airflow_core_config()
+
+    assert result["AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER"] == "True"
+
+# ---------------------------------
+# User Airflow Config Tests
+# ---------------------------------
+def test_get_user_airflow_config_valid_json(env_helper):
+    user_defined_config = {
+        "AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION": "false",
+        "AIRFLOW__CORE__LOAD_EXAMPLES": "false",
+    }
+
+    env_helper.set({
+        "MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS": json.dumps(user_defined_config)
+    })
+
+    result = get_user_airflow_config()
+
+    assert result == user_defined_config
+
+
+def test_get_user_airflow_config_invalid_json(env_helper):
+    env_helper.set({
+        "MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS": '{invalid_json}'
+    })
+
+    result = get_user_airflow_config()
+
+    # Should fail silently and return empty dict
+    assert result == {}
+
+def test_get_user_airflow_config_env_not_set():
+    result = get_user_airflow_config()
+
+    assert result == {}
+
+def test_get_user_airflow_config_empty_string(monkeypatch):
+    monkeypatch.setenv("MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS", "")
+
+    result = get_user_airflow_config()
+
+    # Empty string behaves like not set
+    assert result == {}
+
+# ---------------------------------
+# DB Config Tests
+# ---------------------------------
+def test_db_config(monkeypatch):
+    monkeypatch.setattr(
+        'mwaa.config.airflow.get_db_connection_string', lambda: "postgres://db"
+    )
+    result = _get_essential_airflow_db_config()
+    assert result == {
+        "AIRFLOW__DATABASE__SQL_ALCHEMY_CONN": "postgres://db"
+    }
+
+
+# ---------------------------------
+# Opinionated Airflow DB Config Tests
+# ---------------------------------
+def test_get_opinionated_airflow_db_config():
+    result = _get_opinionated_airflow_db_config()
+    assert result == {
+        "AIRFLOW__DATABASE__SQL_ALCHEMY_CONNECT_ARGS": "mwaa.config.database.MWAA_CONNECT_ARGS"
+    }
+
+# ---------------------------------
+# Auth Config Tests (Parametrized)
+# ---------------------------------
+@pytest.mark.parametrize(
+    "auth_env, expected_config",
+    [
+        (
+            "mwaa-iam",
+            {
+                "AIRFLOW__CORE__AUTH_MANAGER":
+                    "airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager",
+            },
+        ),
+        (
+            "MWAA-IAM",
+            {
+                "AIRFLOW__CORE__AUTH_MANAGER":
+                    "airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager",
+            },
+        ),
+        (
+            "",
+            {
+                "AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS": "admin:admin,viewer:viewer",
+                "AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS": "True",
+            },
+        ),
+        (
+            None,
+            {
+                "AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS": "admin:admin,viewer:viewer",
+                "AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS": "True",
+            },
+        ),
+    ],
+)
+def test_get_essential_airflow_auth_config(env_helper, auth_env, expected_config):
+    if auth_env is not None:
+        env_helper.set({"MWAA__CORE__AUTH_TYPE": auth_env})
+
+    result = _get_essential_airflow_auth_config()
+
+    assert result == expected_config
+
+
+# --------------------------------------------
+# Essential Airflow API Auth Config Tests 
+# --------------------------------------------
+def test_get_essential_airflow_api_auth_config(env_helper):
+    env_helper.set({
+        "MWAA__CORE__FERNET_KEY": json.dumps({"FernetKey": "test-key"}),
+    })
+
+    result = _get_essential_airflow_api_auth_config()
+
+    assert result["AIRFLOW__API_AUTH__JWT_SECRET"] == '{"FernetKey": "test-key"}'
+    assert result["AIRFLOW__API_AUTH__JWT_ALGORITHM"] == "HS256"
+
+
+# --------------------------------------------
+# Essential Airflow Execution API Config Tests 
+# --------------------------------------------
+def test_get_essential_aiflow_execution_api_config():
+    result = _get_essential_aiflow_execution_api_config()
+
+    assert result["AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME"] == "86400"
+
+# --------------------------------------------
+# Essential Airflow Logging Config Tests 
+# --------------------------------------------
+def test_get_essential_airflow_logging_config():
+    expected_logging_config = {
+        "AIRFLOW__LOGGING__LOGGING_CONFIG_CLASS": "mwaa.logging.config.LOGGING_CONFIG",
+        "AIRFLOW__LOGGING__COLORED_CONSOLE_LOG": "False"
+    }
+    result = _get_essential_airflow_logging_config()
+
+    assert result == expected_logging_config
+
+
+# --------------------------------------
+# CloudWatch Integration Config Tests
+# --------------------------------------
+@pytest.mark.parametrize("enabled_value", ["false", "False", "FALSE", "", None])
+def test_get_mwaa_cloudwatch_integration_config_disabled(env_helper, enabled_value):
+    _get_mwaa_cloudwatch_integration_config.cache_clear()
+    if enabled_value is not None:
+        env_helper.set({"MWAA__CLOUDWATCH_METRICS_INTEGRATION__ENABLED": enabled_value})
+    
+    result = _get_mwaa_cloudwatch_integration_config()
+    
+    assert result == {}
+    
+def test_cloudwatch_metrics_missing_section(monkeypatch):
+    from mwaa.config import airflow
+
+    _get_mwaa_cloudwatch_integration_config.cache_clear()
+
+    monkeypatch.setenv(
+        "MWAA__CLOUDWATCH_METRICS_INTEGRATION__ENABLED",
+        "true",
+    )
+
+    monkeypatch.setattr(airflow.conf, "getsection", lambda section: None)
+
+    with pytest.raises(RuntimeError):
+        _get_mwaa_cloudwatch_integration_config()
+
+def test_cloudwatch_metrics_enabled(env_helper, monkeypatch):
+    from mwaa.config import airflow
+
+    _get_mwaa_cloudwatch_integration_config.cache_clear()
+
+    env_helper.set({"MWAA__CLOUDWATCH_METRICS_INTEGRATION__ENABLED": "true"})
+
+    # Mock metrics section
+    monkeypatch.setattr(
+        airflow.conf,
+        "getsection",
+        lambda section: {"statsd_on": "False", "statsd_host": "x", "option1": "value1"},
+    )
+
+    monkeypatch.setattr(
+        airflow.conf,
+        "get_default_value",
+        lambda section, option: "default",
+    )
+
+    result = _get_mwaa_cloudwatch_integration_config()
+
+    assert result["AIRFLOW__METRICS__STATSD_ON"] == "True"  # forced override
+    assert result["AIRFLOW__METRICS__STATSD_HOST"] == "localhost"
+    assert result["AIRFLOW__METRICS__STATSD_PORT"] == "8125"
+    assert result["AIRFLOW__METRICS__STATSD_PREFIX"] == "airflow"
+    assert result["AIRFLOW__METRICS__OPTION1"] == "default"
+
+def test_cloudwatch_metrics_customer_config_write(monkeypatch, env_helper, tmp_path):
+    from mwaa.config import airflow
+
+    _get_mwaa_cloudwatch_integration_config.cache_clear()
+
+    env_helper.set({
+        "MWAA__CLOUDWATCH_METRICS_INTEGRATION__ENABLED": "true",
+        "MWAA__CLOUDWATCH_METRICS_INTEGRATION__CUSTOMER_CONFIG_PATH": str(tmp_path),
+    })
+
+    monkeypatch.setattr(
+        airflow.conf,
+        "getsection",
+        lambda section: {"statsd_on": "False"},
+    )
+
+    monkeypatch.setattr(
+        airflow.conf,
+        "get_default_value",
+        lambda section, option: "default",
+    )
+
+    monkeypatch.setattr(
+        airflow,
+        "get_user_airflow_config",
+        lambda: {
+            "AIRFLOW__METRICS__STATSD_ON": "False",
+        },
+    )
+
+    _get_mwaa_cloudwatch_integration_config()
+
+    # Ensure files were written
+    assert (tmp_path / "statsd_on.txt").exists()
+    assert (tmp_path / "metrics_block_list.txt").exists()
+    assert (tmp_path / "metrics_allow_list.txt").exists()
+
+# --------------------------------------------
+# Essential Airflow Scheduler Config Tests 
+# --------------------------------------------
+def test_get_essential_airflow_scheduler_config():
+    result = _get_essential_airflow_scheduler_config()
+    
+    assert result == {
+        "AIRFLOW__SCHEDULER__STANDALONE_DAG_PROCESSOR": "True",
+    }
+
+
+# --------------------------------------------
+# Opinionated Airflow Scheduler Config Tests 
+# --------------------------------------------
+def test_get_opinionated_airflow_scheduler_config():
+    result = _get_opinionated_airflow_scheduler_config()
+    
+    assert result == {
+        "AIRFLOW__SCHEDULER__SCHEDULE_AFTER_TASK_EXECUTION": "False",
+        "AIRFLOW__SCHEDULER__TASK_QUEUED_TIMEOUT": "1800.0",
+    }
+
+
+# --------------------------------------------
+# Opinionated Airflow Secrets Config Tests 
+# --------------------------------------------
+def test_get_opinionated_airflow_secrets_config():
+    result = _get_opinionated_airflow_secrets_config()
+    
+    expected_pattern = {"connections_lookup_pattern": "^(?!aws_default$).*$"}
+    expected_config = {
+        "AIRFLOW__SECRETS__BACKEND_KWARGS": json.dumps(expected_pattern),
+        "AIRFLOW__WORKERS__SECRETS_BACKEND_KWARGS": json.dumps(expected_pattern),
+    }
+    
+    assert result == expected_config
+
+
+# --------------------------------------------
+# Opinionated Airflow Usage Data Config Tests 
+# --------------------------------------------
+def test_get_opinionated_airflow_usage_data_config():
+    result = _get_opinionated_airflow_usage_data_config()
+    
+    assert result == {
+        "AIRFLOW__USAGE_DATA_COLLECTION__ENABLED": "False",
+    }
+
+# --------------------------------------------
+# Webserver Config Tests 
+# --------------------------------------------
+def test_webserver_config_no_secret():
+    result = _get_essential_airflow_webserver_config()
+
+    assert result == {
+        "AIRFLOW__FAB__CONFIG_FILE": "/python/mwaa/webserver/webserver_config.py",
+    }
+
+def test_webserver_config_valid_secret(env_helper):
+    env_helper.set({"MWAA__WEBSERVER__SECRET":  json.dumps({"secret_key": "super-secret"})})
+
+    result = _get_essential_airflow_webserver_config()
+
+    assert result == {
+        "AIRFLOW__FAB__CONFIG_FILE": "/python/mwaa/webserver/webserver_config.py",
+        "AIRFLOW__API__SECRET_KEY": "super-secret",
+    }
+
+def test_webserver_config_invalid_json(env_helper):
+    env_helper.set({"MWAA__WEBSERVER__SECRET": "{invalid-json}"})
+
+    result = _get_essential_airflow_webserver_config()
+
+    assert result == {
+        "AIRFLOW__FAB__CONFIG_FILE": "/python/mwaa/webserver/webserver_config.py",
+    }
+
+def test_webserver_config_missing_secret_key(env_helper):
+    env_helper.set({"MWAA__WEBSERVER__SECRET":  json.dumps({"wrong_key": "value"})})
+
+    result = _get_essential_airflow_webserver_config()
+
+    # KeyError is swallowed by broad except
+    assert result == {
+        "AIRFLOW__FAB__CONFIG_FILE": "/python/mwaa/webserver/webserver_config.py",
+    }
+
+# ---------------------------
+# Final Merge Tests
+# ---------------------------
+def test_get_essential_airflow_config_merges_all(monkeypatch):
+    from mwaa.config import airflow
+    # Clear cached cloudwatch if needed
+    if hasattr(airflow._get_mwaa_cloudwatch_integration_config, "cache_clear"):
+        airflow._get_mwaa_cloudwatch_integration_config.cache_clear()
+
+    monkeypatch.setattr(
+        airflow,
+        "_get_essential_airflow_executor_config",
+        lambda executor: {"EXECUTOR": executor},
+    )
+
+    monkeypatch.setattr(
+        airflow,
+        "_get_essential_airflow_core_config",
+        lambda: {"CORE": "1"},
+    )
+
+    monkeypatch.setattr(
+        airflow,
+        "_get_essential_airflow_db_config",
+        lambda: {"DB": "1"},
+    )
+
+    monkeypatch.setattr(
+        airflow,
+        "_get_essential_airflow_logging_config",
+        lambda: {"LOGGING": "1"},
+    )
+
+    monkeypatch.setattr(
+        airflow,
+        "_get_mwaa_cloudwatch_integration_config",
+        lambda: {"CLOUDWATCH": "1"},
+    )
+
+    monkeypatch.setattr(
+        airflow,
+        "_get_essential_airflow_scheduler_config",
+        lambda: {"SCHEDULER": "1"},
+    )
+
+    monkeypatch.setattr(
+        airflow,
+        "_get_essential_airflow_webserver_config",
+        lambda: {"WEBSERVER": "1"},
+    )
+
+    monkeypatch.setattr(
+        airflow,
+        "_get_essential_airflow_auth_config",
+        lambda: {"AUTH": "1"},
+    )
+
+    monkeypatch.setattr(
+        airflow,
+        "_get_essential_airflow_api_auth_config",
+        lambda: {"API_AUTH": "1"},
+    )
+
+    monkeypatch.setattr(
+        airflow,
+        "_get_essential_aiflow_execution_api_config",
+        lambda: {"EXEC_API": "1"},
+    )
+
+    result = airflow.get_essential_airflow_config("CeleryExecutor")
+
+    assert result == {
+        "EXECUTOR": "CeleryExecutor",
+        "CORE": "1",
+        "DB": "1",
+        "LOGGING": "1",
+        "CLOUDWATCH": "1",
+        "SCHEDULER": "1",
+        "WEBSERVER": "1",
+        "AUTH": "1",
+        "API_AUTH": "1",
+        "EXEC_API": "1",
+    }
+
+def test_get_opinionated_airflow_config_merges(monkeypatch):
+    from mwaa.config import airflow
+    
+    monkeypatch.setattr(
+        airflow,
+        "_get_opinionated_airflow_core_config",
+        lambda: {"CORE": "1"},
+    )
+
+    monkeypatch.setattr(
+        airflow,
+        "_get_opinionated_airflow_scheduler_config",
+        lambda: {"SCHEDULER": "1"},
+    )
+
+    monkeypatch.setattr(
+        airflow,
+        "_get_opinionated_airflow_secrets_config",
+        lambda: {"SECRETS": "1"},
+    )
+
+    monkeypatch.setattr(
+        airflow,
+        "_get_opinionated_airflow_usage_data_config",
+        lambda: {"USAGE": "1"},
+    )
+
+    monkeypatch.setattr(
+        airflow,
+        "_get_opinionated_airflow_db_config",
+        lambda: {"DB": "1"},
+    )
+
+    result = airflow.get_opinionated_airflow_config()
+
+    assert result == {
+        "CORE": "1",
+        "SCHEDULER": "1",
+        "SECRETS": "1",
+        "USAGE": "1",
+        "DB": "1",
+    }

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_aws.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_aws.py
@@ -1,0 +1,20 @@
+import os
+import pytest
+from mwaa.config.aws import get_aws_region
+
+@pytest.mark.parametrize(
+    "env_vars, expected", 
+    [
+        ({"AWS_REGION": "us-east-1"}, "us-east-1"),
+        ({"AWS_DEFAULT_REGION": "us-west-2"}, "us-west-2"),
+        ({"AWS_REGION": "us-east-1", "AWS_DEFAULT_REGION": "us-west-2"}, "us-east-1"),
+    ]
+)
+def test_get_aws_region_success(env_helper, env_vars, expected):
+    env_helper.set(env_vars)
+
+    assert get_aws_region() == expected
+
+def test_get_aws_region_raises_runtime_error():
+    with pytest.raises(RuntimeError, match="Region must be specified."):
+        get_aws_region()

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_celery.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_celery.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch
+
+def test_create_celery_config_happy_path():
+
+    with \
+        patch("mwaa.config.aws.get_aws_region", return_value="us-east-1"), \
+        patch("mwaa.config.sqs.should_use_ssl", return_value=True), \
+        patch("mwaa.config.sqs.get_sqs_queue_url", return_value="https://sqs.aws/test-queue"), \
+        patch("mwaa.config.sqs.get_sqs_queue_name", return_value="test-queue"), \
+        patch("mwaa.utils.qualified_name", return_value="mocked.transport.Transport"), \
+        patch("airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG", new={"broker_transport_options": {"visibility_timeout": 30}}):
+
+        from mwaa.config.celery import create_celery_config
+        
+        result = create_celery_config()
+
+        assert result["broker_transport"] == "mocked.transport.Transport"
+        assert result["broker_transport_options"]["region"] == "us-east-1"
+        assert result["broker_transport_options"]["is_secure"] is True
+        assert result["broker_transport_options"]["predefined_queues"]["test-queue"]["url"] == "https://sqs.aws/test-queue"
+        assert result["broker_transport_options"]["predefined_queues"]["default"]["url"] == "https://sqs.aws/test-queue"

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_database.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_database.py
@@ -1,0 +1,90 @@
+"""Tests for database configuration module."""
+
+import os
+import json
+import pytest
+from unittest.mock import patch
+from mwaa.config.database import (
+    get_db_credentials, 
+    get_db_connection_string, 
+    MWAA_CONNECT_ARGS
+)
+from .base_config_test import BaseConfigTest
+
+@pytest.fixture
+def sample_db_credentials():
+    return {
+        "MWAA__DB__POSTGRES_HOST": "localhost",
+        "MWAA__DB__POSTGRES_PORT": "5432",
+        "MWAA__DB__POSTGRES_DB": "airflow",
+        "MWAA__DB__POSTGRES_SSLMODE": "require",
+        "MWAA__DB__POSTGRES_USER": "airflow",
+        "MWAA__DB__POSTGRES_PASSWORD": "password"
+    }
+
+class TestDatabaseConfig(BaseConfigTest):
+
+    def test_db_credentials_from_json(self, env_helper):
+        """Test database credentials from JSON format."""
+        credentials = {"username": "testuser", "password": "testpass"}
+
+        env_helper.set({
+            "MWAA__DB__CREDENTIALS": json.dumps(credentials)
+        })
+        
+        user, password = get_db_credentials()
+        assert user == "testuser"
+        assert password == "testpass"
+
+    def test_db_credentials_from_separate_vars(self, env_helper):
+        """Test database credentials from separate environment variables."""
+        env_helper.set({
+            "MWAA__DB__POSTGRES_USER": "testuser",
+            "MWAA__DB__POSTGRES_PASSWORD": "testpass"
+        })
+        
+        user, password = get_db_credentials()
+        assert user == "testuser"
+        assert password == "testpass"
+
+    def test_db_credentials_missing(self, env_helper):
+        """Test error when database credentials are missing."""
+        # Ensure vars are not present
+        env_helper.delete(["MWAA__DB__CREDENTIALS", "MWAA__DB__POSTGRES_USER", "MWAA__DB__POSTGRES_PASSWORD"])
+       
+        with pytest.raises(RuntimeError, match="Couldn't find database credentials"):
+            get_db_credentials()
+
+    def test_connection_string_format(self, env_helper, sample_db_credentials):
+        """Test database connection string format."""
+        env_helper.set(sample_db_credentials)
+        
+        conn_string = get_db_connection_string()
+        
+        assert conn_string.startswith("postgresql+psycopg2://")
+        assert "airflow:password@localhost:5432/airflow" in conn_string
+        assert "sslmode=require" in conn_string
+    
+    def test_connection_args_structure(self):
+        """Test MWAA_CONNECT_ARGS structure."""
+        expected_keys = [
+            "connect_timeout", "keepalives", "keepalives_idle",
+            "keepalives_interval", "keepalives_count"
+        ]
+        
+        # Check exact keys match
+        self.assert_config_keys(MWAA_CONNECT_ARGS, expected_keys)
+        assert set(MWAA_CONNECT_ARGS.keys()) == set(expected_keys)
+        
+        # Check all values are integers
+        for key in expected_keys:
+            assert isinstance(MWAA_CONNECT_ARGS[key], int)
+
+    def test_connection_string_sets_default_sslmode(self, env_helper, sample_db_credentials):
+        """Test that sslmode defaults to 'require' when not set."""
+        creds = sample_db_credentials.copy()
+        creds.pop("MWAA__DB__POSTGRES_SSLMODE")  # remove sslmode
+        env_helper.set(creds)
+
+        with pytest.raises(RuntimeError, match="One or more of the required environment variables for configuring Postgres are not set."):
+            get_db_connection_string()

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_environ.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_environ.py
@@ -1,0 +1,34 @@
+import os
+from unittest.mock import patch
+import pytest
+
+from mwaa.config.environ import get_essential_environ, get_opinionated_environ
+
+def test_get_essential_environ_sets_correct_vars(env_helper):
+    # Set the AIRFLOW_VERSION env var
+    env_helper.set({"AIRFLOW_VERSION": "3.0.6"})
+
+    command = "webserver"
+    result = get_essential_environ(command)
+
+    assert result["MWAA_AIRFLOW_COMPONENT"] == command
+    assert result["MWAA_COMMAND"] == command
+    assert result["AWS_EXECUTION_ENV"] == "Amazon_MWAA_306"
+
+
+def test_get_opinionated_environ_includes_logging_args():
+    # Patch get_mwaa_logging_env_vars to return a custom log level
+    with patch(
+        "mwaa.config.environ.get_mwaa_logging_env_vars",
+        return_value=(None, "DEBUG", None)
+    ):
+        result = get_opinionated_environ()
+
+    # Gunicorn args should include the mocked log level
+    assert "GUNICORN_CMD_ARGS" in result
+    assert result["GUNICORN_CMD_ARGS"].endswith("DEBUG")
+
+    # Other defaults should be present
+    assert result["AIRFLOW_CONN_AWS_DEFAULT"] == "aws://"
+    assert "CLASSPATH" in result
+    assert result["SQLALCHEMY_SILENCE_UBER_WARNING"] == "1"

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_setup_environment.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_setup_environment.py
@@ -1,0 +1,267 @@
+# test_setup_environment.py
+import pytest
+import json
+import os
+from unittest.mock import patch, mock_open, MagicMock
+from datetime import timedelta
+from mwaa.config.setup_environment import (
+    setup_environment_variables,
+    _execute_startup_script,
+    _export_env_variables,
+    _is_protected_os_environ,
+)
+from mwaa.subprocess.subprocess import Subprocess  # Add this import
+
+
+@pytest.fixture
+def mock_environ(monkeypatch):
+    """Fixture for mocking os.environ"""
+    test_environ = {
+        "AIRFLOW_ENV_ID": "test-env-id",
+        "AIRFLOW_ENV_NAME": "test-env",
+        "AIRFLOW_HOME": "/usr/local/airflow",
+        "AWS_DEFAULT_REGION": "us-east-1",
+        "PYTHONPATH": "/usr/local/airflow/dags",
+        "MWAA__CORE__TEST": "test-value",
+        "MWAA__CORE__STARTUP_SCRIPT_PATH": "../../2.11.0/startup/startup.sh",
+        "MWAA__CORE__TESTING_MODE": "true"
+    }
+    monkeypatch.setattr(os, "environ", test_environ)
+    return test_environ
+
+
+@pytest.fixture
+def mock_config_functions(monkeypatch):
+    """Fixture for mocking all configuration related functions"""
+    mock_functions = {
+        "get_essential_airflow_config": MagicMock(return_value={"ESSENTIAL_CONFIG": "value1"}),
+        "get_opinionated_airflow_config": MagicMock(return_value={"OP_CONFIG": "value2"}),
+        "get_essential_environ": MagicMock(return_value={"ESSENTIAL_ENV": "value3"}),
+        "get_opinionated_environ": MagicMock(return_value={"OP_ENV": "value4"}),
+        "get_user_airflow_config": MagicMock(return_value={"USER_CONFIG": "value5"})
+    }
+
+    for func_name, mock_func in mock_functions.items():
+        monkeypatch.setattr(f"mwaa.config.setup_environment.{func_name}", mock_func)
+
+    return mock_functions
+
+
+@pytest.fixture
+def temp_home_dir(tmp_path):
+    """Fixture for creating temporary home directory with .bashrc and .bash_profile"""
+    bashrc = tmp_path / ".bashrc"
+    bash_profile = tmp_path / ".bash_profile"
+    bashrc.touch()
+    bash_profile.touch()
+    return tmp_path
+
+
+# ------------------------
+# Environment Configuration Tests
+# ------------------------
+
+@pytest.mark.parametrize(
+    "key,expected",
+    [
+        ("MWAA__CORE__TEST", True),
+        ("AIRFLOW_ENV_ID", True),
+        ("AWS_DEFAULT_REGION", True),
+        ("CUSTOM_VAR", False),
+        ("PYTHONPATH", True),
+        ("RANDOM_VAR", False),
+        ("MWAA__CUSTOM__VAR", True),
+    ]
+)
+def test_is_protected_os_environ(key, expected):
+    """Test protected environment variable checking"""
+    assert _is_protected_os_environ(key) == expected
+
+
+def test_export_env_variables(temp_home_dir):
+    """Test environment variable export to shell files"""
+    test_environ = {
+        "TEST_VAR1": "value1",
+        "TEST_VAR2": "value2 with space",
+        "TEST_VAR3": "value3!@#$"
+    }
+
+    with patch("os.path.expanduser", return_value=str(temp_home_dir)):
+        _export_env_variables(test_environ)
+
+    # Verify both files
+    for filename in [".bashrc", ".bash_profile"]:
+        file_path = temp_home_dir / filename
+        content = file_path.read_text()
+
+        assert 'export TEST_VAR1=value1\n' in content
+        assert "export TEST_VAR2='value2 with space'\n" in content
+        assert "export TEST_VAR3='value3!@#$'\n" in content
+
+
+def test_setup_environment_variables(mock_environ, mock_config_functions):
+    """Test complete environment variable setup"""
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script, \
+            patch("mwaa.config.setup_environment._export_env_variables") as mock_export:
+        mock_execute_script.return_value = {"STARTUP_VAR": "value6"}
+
+        result = setup_environment_variables("worker", "Local")
+
+        # Verify all configurations are present and correctly merged
+        assert result["ESSENTIAL_CONFIG"] == "value1"
+        assert result["OP_CONFIG"] == "value2"
+        assert result["ESSENTIAL_ENV"] == "value3"
+        assert result["OP_ENV"] == "value4"
+        assert result["USER_CONFIG"] == "value5"
+        assert result["STARTUP_VAR"] == "value6"
+
+        # Verify protected variables are preserved
+        assert result["AIRFLOW_ENV_ID"] == "test-env-id"
+        assert result["AIRFLOW_HOME"] == "/usr/local/airflow"
+        assert result["AWS_DEFAULT_REGION"] == "us-east-1"
+
+        # Verify export was called
+        mock_export.assert_called_once_with(result)
+
+
+# ------------------------
+# Startup Script Tests
+# ------------------------
+
+def test_no_startup_script_path():
+    """Test when MWAA__CORE__STARTUP_SCRIPT_PATH is not set"""
+    with patch.dict(os.environ, {}, clear=True):
+        result = _execute_startup_script("worker", {})
+        assert result == {}
+
+
+def test_startup_script_not_found():
+    """Test when startup script file doesn't exist"""
+    with patch.dict(os.environ, {"MWAA__CORE__STARTUP_SCRIPT_PATH": "/nonexistent/path"}), \
+            patch('os.path.isfile', return_value=False):
+        result = _execute_startup_script("worker", {})
+        assert result == {}
+
+
+def test_uses_mocked_env(mock_environ):
+    """Ensure environment variables are correctly set"""
+    assert mock_environ["MWAA__CORE__TESTING_MODE"] == "true"
+
+
+@pytest.mark.parametrize("cmd,expected_logger", [
+    ("worker", "worker_startup"),
+    ("scheduler", "scheduler_startup"),
+    ("hybrid", "worker_startup")
+])
+def test_startup_script_execution(cmd, expected_logger, mock_environ):
+    """Test successful startup script execution with different commands"""
+    customer_env = {"CUSTOM_VAR": "value"}
+
+    with patch('os.path.isfile', return_value=True), \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess:
+        # Configure mock subprocess
+        mock_process = MagicMock()
+        mock_process.start.return_value = 0
+        MockSubprocess.return_value = mock_process
+
+        with patch('builtins.open', mock_open(read_data='{"CUSTOM_VAR": "value"}')):
+            result = _execute_startup_script(cmd, mock_environ)
+
+            assert result == customer_env
+            # Verify Subprocess was instantiated twice (for script and verification)
+            assert MockSubprocess.call_count == 2
+            # Verify start was called on each instance
+            assert mock_process.start.call_count == 2
+
+
+def test_failed_env_vars_reading(mock_environ):
+    """Test when reading customer environment variables fails"""
+    with patch('os.path.isfile', return_value=True), \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess, \
+            patch('builtins.open') as mock_file:
+        # Configure mock subprocess
+        mock_process = MagicMock()
+        mock_process.start.return_value = 0
+        MockSubprocess.return_value = mock_process
+
+        # Configure file mock to raise exception
+        mock_file.side_effect = Exception("Failed to read file")
+
+        with pytest.raises(Exception) as exc_info:
+            _execute_startup_script("worker", mock_environ)
+
+        assert ("Failed to read customer's environment variables from startup script: "
+                "Failed to read file") in str(exc_info.value)
+
+
+
+def test_missing_customer_env_vars_file(mock_environ):
+    """Test when customer environment variables file is not created"""
+    with patch('os.path.isfile') as mock_isfile, \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess:
+        # Configure mock subprocess
+        mock_process = MagicMock()
+        mock_process.start.return_value = 0
+        MockSubprocess.return_value = mock_process
+
+        # First True for startup script, second False for env vars file
+        mock_isfile.side_effect = [True, False]
+
+        with pytest.raises(Exception) as exc_info:
+            _execute_startup_script("worker", mock_environ)
+
+        assert ("Failed to access customer environment variables file: Service was unable "
+                "to create or locate /tmp/customer_env_vars.json") in str(exc_info.value)
+        assert MockSubprocess.call_count == 2
+
+
+@pytest.mark.parametrize("subprocess_error", [
+    Exception("Process failed"),
+    TimeoutError("Process timed out")
+])
+def test_subprocess_execution_errors(subprocess_error, mock_environ):
+    """Test handling of subprocess execution errors"""
+    with patch('os.path.isfile', return_value=True), \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess:
+        # Configure mock subprocess to raise error
+        mock_process = MagicMock()
+        mock_process.start.side_effect = subprocess_error
+        MockSubprocess.return_value = mock_process
+
+        with pytest.raises(type(subprocess_error)) as exc_info:
+            _execute_startup_script("worker", mock_environ)
+
+        assert str(subprocess_error) == str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "command,executor_type",
+    [
+        ("worker", "Local"),
+        ("scheduler", "Celery"),
+        ("webserver", "Local"),
+        ("hybrid", "Celery")
+    ]
+)
+def test_setup_environment_variables_different_commands(
+        command,
+        executor_type,
+        mock_environ,
+        mock_config_functions
+):
+    """Test environment setup with different commands and executor types"""
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script:
+        mock_execute_script.return_value = {}
+
+        result = setup_environment_variables(command, executor_type)
+
+        # Verify essential configurations are present
+        assert "ESSENTIAL_CONFIG" in result
+        assert "ESSENTIAL_ENV" in result
+
+        # Verify the execute_startup_script was called correctly
+        mock_execute_script.assert_called_once()
+        args, _ = mock_execute_script.call_args
+        assert args[0] == command
+        # Verify the environment dict was passed (without checking exact contents)
+        assert isinstance(args[1], dict)

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_sqs.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_sqs.py
@@ -1,0 +1,207 @@
+"""Tests for SQS configuration module."""
+
+from urllib.parse import urlparse
+import pytest
+from unittest.mock import patch, MagicMock
+
+from mwaa.config.sqs import (
+    _change_protocol_to_sqs,
+    get_sqs_default_endpoint,
+    get_sqs_endpoint,
+    _get_queue_name_from_url,
+    get_sqs_queue_url,
+    get_sqs_queue_name,
+    should_create_queue,
+    should_use_ssl,
+)
+
+from .base_config_test import BaseConfigTest
+
+
+class TestSQSConfig(BaseConfigTest):
+
+    # ---------------------------------------------------------
+    # _change_protocol_to_sqs
+    # ---------------------------------------------------------
+    @pytest.mark.parametrize(
+        "input_url, expected_netloc, expected_path",
+        [
+            pytest.param(
+                "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+                "sqs.us-east-1.amazonaws.com",
+                "/123456789012/test-queue",
+                id="aws_https_url",
+            ),
+            pytest.param(
+                "http://localhost:9324/queue/test-queue",
+                "localhost:9324",
+                "/queue/test-queue",
+                id="localstack_http_url",
+            ),
+        ],
+    )
+    def test_change_protocol_to_sqs(self, input_url, expected_netloc, expected_path):
+        result = _change_protocol_to_sqs(input_url)
+        parsed = urlparse(result)
+
+        assert parsed.scheme == "sqs"
+        assert parsed.netloc == expected_netloc
+        assert parsed.path == expected_path
+
+
+    # ---------------------------------------------------------
+    # get_sqs_default_endpoint
+    # ---------------------------------------------------------
+    def test_get_sqs_default_endpoint(self):
+        with patch("mwaa.config.sqs.boto3.Session") as mock_session, \
+             patch("mwaa.config.sqs.get_aws_region", return_value="us-east-1"):
+
+            mock_client = MagicMock()
+            mock_client.meta.endpoint_url = "https://sqs.us-east-1.amazonaws.com"
+            mock_session.return_value.client.return_value = mock_client
+
+            result = get_sqs_default_endpoint()
+
+            mock_session.assert_called_once_with(region_name="us-east-1")
+            mock_session.return_value.client.assert_called_once_with("sqs")
+            assert result == "https://sqs.us-east-1.amazonaws.com"
+
+
+    # ---------------------------------------------------------
+    # get_sqs_endpoint
+    # ---------------------------------------------------------
+    def test_get_sqs_endpoint_custom(self, env_helper):
+        env_helper.set({
+            "MWAA__SQS__CUSTOM_ENDPOINT": "http://localhost:9324/queue"
+        })
+
+        result = get_sqs_endpoint()
+        assert result.startswith("sqs://")
+
+    def test_get_sqs_endpoint_default(self, env_helper):
+        env_helper.delete(["MWAA__SQS__CUSTOM_ENDPOINT"])
+
+        with patch("mwaa.config.sqs.get_sqs_default_endpoint") as mock_default:
+            mock_default.return_value = "https://sqs.us-east-1.amazonaws.com"
+
+            result = get_sqs_endpoint()
+
+            assert result.startswith("sqs://")
+            mock_default.assert_called_once()
+
+
+    # ---------------------------------------------------------
+    # _get_queue_name_from_url
+    # ---------------------------------------------------------
+    @pytest.mark.parametrize(
+        "queue_url, expected_name",
+        [
+            ("https://sqs.us-east-1.amazonaws.com/123456789012/test-queue", "test-queue"),
+            ("http://localhost:9324/queue/test-queue", "test-queue"),
+        ],
+    )
+    def test_get_queue_name_from_url(self, queue_url, expected_name):
+        assert _get_queue_name_from_url(queue_url) == expected_name
+
+    @pytest.mark.parametrize(
+        "invalid_url",
+        [
+            "sqs://invalid-url",      # invalid protocol
+            "ftp://example.com/q",    # invalid protocol
+            # "https://",               # invalid structure
+            "just-a-string",
+        ],
+    )
+    def test_get_queue_name_from_url_invalid(self, invalid_url):
+        with pytest.raises(RuntimeError, match="Failed to extract queue name"):
+            _get_queue_name_from_url(invalid_url)
+
+
+    # ---------------------------------------------------------
+    # get_sqs_queue_url
+    # ---------------------------------------------------------
+    def test_get_sqs_queue_url(self, env_helper):
+        env_helper.set({
+            "MWAA__SQS__QUEUE_URL": "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue"
+        })
+
+        assert get_sqs_queue_url() == \
+            "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue"
+
+    def test_get_sqs_queue_url_missing(self, env_helper):
+        env_helper.delete(["MWAA__SQS__QUEUE_URL"])
+
+        with pytest.raises(RuntimeError):
+            get_sqs_queue_url()
+
+
+    # ---------------------------------------------------------
+    # get_sqs_queue_name
+    # ---------------------------------------------------------
+    def test_get_sqs_queue_name(self, env_helper):
+        env_helper.set({
+            "MWAA__SQS__QUEUE_URL": "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue"
+        })
+
+        assert get_sqs_queue_name() == "test-queue"
+
+    def test_get_sqs_queue_name_calls_parser(self, env_helper):
+        env_helper.set({
+            "MWAA__SQS__QUEUE_URL": "https://example.com/test"
+        })
+
+        with patch("mwaa.config.sqs._get_queue_name_from_url") as mock_parser:
+            mock_parser.return_value = "test"
+
+            result = get_sqs_queue_name()
+
+            assert result == "test"
+            mock_parser.assert_called_once()
+
+
+    # ---------------------------------------------------------
+    # should_create_queue
+    # ---------------------------------------------------------
+    @pytest.mark.parametrize(
+        "env_value, expected",
+        [
+            ("true", True),
+            ("false", False),
+            ("TRUE", True),
+            ("anything", False),
+            (None, False),
+        ],
+    )
+    def test_should_create_queue(self, env_helper, env_value, expected):
+        if env_value is not None:
+            env_helper.set({
+                "MWAA__SQS__CREATE_QUEUE": env_value
+            })
+        else:
+            env_helper.delete(["MWAA__SQS__CREATE_QUEUE"])
+
+        assert should_create_queue() == expected
+
+
+    # ---------------------------------------------------------
+    # should_use_ssl
+    # ---------------------------------------------------------
+    @pytest.mark.parametrize(
+        "env_value, expected",
+        [
+            ("true", True),
+            ("false", False),
+            ("TRUE", True),
+            ("anything", False),
+            (None, True),
+        ],
+    )
+    def test_should_use_ssl(self, env_helper, env_value, expected):
+        if env_value is not None:
+            env_helper.set({
+                "MWAA__SQS__USE_SSL": env_value
+            })
+        else:
+            env_helper.delete(["MWAA__SQS__USE_SSL"])
+
+        assert should_use_ssl() == expected


### PR DESCRIPTION
*Issue # (if available):*

*Description of changes:*
- add unit tests for config module in AF 3.0.6
- all same as 3.1.6 with only airflow version change

*List any breaking changes for*
* *The Environment runtime*:
* *The local development experience*:


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.