### PR TITLE
Fix for missing task logs in UI

### DIFF
--- a/images/airflow/3.1.6/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.1.6/python/mwaa/logging/cloudwatch_handlers.py
@@ -415,7 +415,7 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         except Exception as e:
             messages = [
                 StructuredLogMessage(
-                    event=f"Reading remote log from Cloudwatch log_group: {self.log_group_arn} log_stream: {relative_path}"
+                    event=f"Failed to read remote log from Cloudwatch log_group: {self.log_group_arn} log_stream: {relative_path}"
                 ),
                 StructuredLogMessage(event=str(e)),
             ]

--- a/images/airflow/3.1.6/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.1.6/python/mwaa/logging/cloudwatch_handlers.py
@@ -30,7 +30,7 @@ from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
 from airflow.providers.amazon.aws.utils import datetime_to_epoch_utc_ms
 from airflow.sdk.types import RuntimeTaskInstanceProtocol as RuntimeTI
 from airflow.utils.helpers import parse_template_string, render_template
-from airflow.utils.log.file_task_handler import LogMessages, LogSourceInfo, LogMetadata
+from airflow.utils.log.file_task_handler import LogMetadata, StructuredLogMessage
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session, NEW_SESSION
 from mypy_boto3_logs.client import CloudWatchLogsClient
@@ -387,32 +387,41 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
 
     def read(
         self, task_instance, try_number, metadata=None
-    ) -> tuple[LogMessages, LogMetadata]:
+    ) -> tuple[list[StructuredLogMessage], LogMetadata]:
         """
-            Invoked by airflow-core/src/airflow/utils/log/log_reader.py when console tries to load task log. This is
-            the reason why we set Task logging handler to this class even though the actual log writing is done through
-            remote logging processor.
+        Invoked by airflow-core/src/airflow/utils/log/log_reader.py when the UI loads task logs.
+
+        Returns StructuredLogMessage objects (not plain strings) so that the NDJSON streaming
+        path in read_log_stream() can call .model_dump_json() on each item without crashing.
+        Also always sets end_of_log=True so the streaming loop terminates.
         """
         stream_name = self._render_filename(task_instance, try_number).replace(":", "_")
         messages, logs = self._read_remote_logs(stream_name, task_instance)
-        return messages + logs, metadata
+        out_metadata = dict(metadata) if metadata else {}
+        out_metadata["end_of_log"] = True
+        return messages + logs, out_metadata
 
-    def _read_remote_logs(self, relative_path, ti: RuntimeTI) -> tuple[LogSourceInfo, LogMessages | None]:
-        messages = [
-            f"Reading remote log from Cloudwatch log_group: {self.log_group_arn} log_stream: {relative_path}"
-        ]
+    def _read_remote_logs(self, relative_path, ti: RuntimeTI) -> tuple[list[StructuredLogMessage], list[StructuredLogMessage]]:
         try:
-            from airflow.utils.log.file_task_handler import StructuredLogMessage
-
+            messages = [
+                StructuredLogMessage(
+                    event=f"Reading remote log from Cloudwatch log_group: {self.log_group_arn} log_stream: {relative_path}"
+                )
+            ]
             logs = [
                 StructuredLogMessage.model_validate(log)
                 for log in self.get_cloudwatch_logs(relative_path, ti)
             ]
         except Exception as e:
-            logs = None
-            messages.append(str(e))
+            messages = [
+                StructuredLogMessage(
+                    event=f"Reading remote log from Cloudwatch log_group: {self.log_group_arn} log_stream: {relative_path}"
+                ),
+                StructuredLogMessage(event=str(e)),
+            ]
+            logs = []
 
-        return messages, logs or []
+        return messages, logs
 
     @provide_session
     def _render_filename(self, ti: TaskInstance, try_number: int, session=NEW_SESSION) -> str:

--- a/tests/images/airflow/3.1.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.1.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -286,18 +286,123 @@ def test_cloudwatch_remote_task_logger_upload_is_noop():
     logger.handler.flush.assert_called_once()
 
 
-def test_cloudwatch_remote_task_logger_read(mock_boto3_client):
-    """Test CloudWatchRemoteTaskLogger read() method."""
-    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
-        mock_hook = Mock()
-        mock_hook_class.return_value = mock_hook
+def _make_task_instance_mock():
+    """Helper to create a mock TaskInstance with standard test values."""
+    ti = MagicMock()
+    ti.dag_id = 'test_dag'
+    ti.task_id = 'test_task'
+    ti.run_id = 'test_run'
+    ti.try_number = 1
+    ti.end_date = None
 
-        mock_hook.get_log_events.return_value = [
+    mock_dag_run = MagicMock()
+    mock_dag_run.logical_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    mock_dag_run.run_after = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    mock_dag_run.data_interval_start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    mock_dag_run.data_interval_end = datetime(2024, 1, 2, tzinfo=timezone.utc)
+
+    mock_log_template = MagicMock()
+    mock_log_template.filename = "dag_id={dag_id}/run_id={run_id}/task_id={task_id}/attempt={try_number}.log"
+    mock_dag_run.get_log_template.return_value = mock_log_template
+
+    ti.get_dagrun.return_value = mock_dag_run
+    return ti
+
+
+def _make_logger_with_hook(mock_hook_class, log_events):
+    """Helper to create a CloudWatchRemoteTaskLogger with a mocked AwsLogsHook."""
+    mock_hook = Mock()
+    mock_hook_class.return_value = mock_hook
+    mock_hook.get_log_events.return_value = log_events
+
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+    return logger
+
+
+def test_cloudwatch_remote_task_logger_read(mock_boto3_client):
+    """Test CloudWatchRemoteTaskLogger read() returns StructuredLogMessage objects."""
+    from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        logger = _make_logger_with_hook(mock_hook_class, [
             {
                 'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
                 'message': '{"event": "test message", "level": "info"}'
             }
-        ]
+        ])
+        ti = _make_task_instance_mock()
+
+        messages, metadata = logger.read(ti, 1)
+
+        assert len(messages) >= 2  # at least 1 info message + 1 log entry
+        for msg in messages:
+            assert isinstance(msg, StructuredLogMessage), (
+                f"Expected StructuredLogMessage, got {type(msg).__name__}: {msg}"
+            )
+
+
+def test_read_returns_end_of_log_true_in_metadata(mock_boto3_client):
+    """Test that read() always sets end_of_log=True in metadata.
+
+    This is critical for Airflow 3.1.6 where the UI sends Accept: application/x-ndjson,
+    causing the server to use read_log_stream() which loops until end_of_log is True.
+    Without this, the stream loops forever.
+    """
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        logger = _make_logger_with_hook(mock_hook_class, [])
+        ti = _make_task_instance_mock()
+
+        # Test with no initial metadata
+        _, metadata = logger.read(ti, 1)
+        assert metadata["end_of_log"] is True
+
+        # Test with existing metadata dict (should not lose other keys)
+        _, metadata = logger.read(ti, 1, metadata={"offset": 42})
+        assert metadata["end_of_log"] is True
+        assert metadata["offset"] == 42
+
+
+def test_read_messages_are_ndjson_serializable(mock_boto3_client):
+    """Test that all messages from read() can be serialized via model_dump_json().
+
+    The NDJSON streaming path calls .model_dump_json() on every item returned by read().
+    If any item is a plain string instead of StructuredLogMessage, it crashes.
+    """
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        logger = _make_logger_with_hook(mock_hook_class, [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "line one", "level": "info"}'
+            },
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 1, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': 'plain text line'
+            },
+        ])
+        ti = _make_task_instance_mock()
+
+        messages, _ = logger.read(ti, 1)
+
+        for msg in messages:
+            # This is exactly what the NDJSON streaming path does
+            json_str = msg.model_dump_json()
+            assert isinstance(json_str, str)
+            assert len(json_str) > 0
+
+
+def test_read_remote_logs_error_returns_structured_messages(mock_boto3_client):
+    """Test that _read_remote_logs wraps error messages as StructuredLogMessage too."""
+    from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        mock_hook = Mock()
+        mock_hook_class.return_value = mock_hook
+        mock_hook.get_log_events.side_effect = Exception("CloudWatch unavailable")
 
         logger = CloudWatchRemoteTaskLogger(
             log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
@@ -305,30 +410,16 @@ def test_cloudwatch_remote_task_logger_read(mock_boto3_client):
             enabled=True,
             log_level='INFO'
         )
-
-        ti = MagicMock()
-        ti.dag_id = 'test_dag'
-        ti.task_id = 'test_task'
-        ti.run_id = 'test_run'
-        ti.try_number = 1
-        ti.end_date = None
-
-        mock_dag_run = MagicMock()
-        mock_dag_run.logical_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
-        mock_dag_run.run_after = datetime(2024, 1, 1, tzinfo=timezone.utc)
-        mock_dag_run.data_interval_start = datetime(2024, 1, 1, tzinfo=timezone.utc)
-        mock_dag_run.data_interval_end = datetime(2024, 1, 2, tzinfo=timezone.utc)
-
-        mock_log_template = MagicMock()
-        mock_log_template.filename = "dag_id={dag_id}/run_id={run_id}/task_id={task_id}/attempt={try_number}.log"
-        mock_dag_run.get_log_template.return_value = mock_log_template
-
-        ti.get_dagrun.return_value = mock_dag_run
+        ti = _make_task_instance_mock()
 
         messages, metadata = logger.read(ti, 1)
 
-        assert len(messages) >= 1
-        assert any('Reading remote log from Cloudwatch' in msg for msg in messages if isinstance(msg, str))
+        assert metadata["end_of_log"] is True
+        assert len(messages) >= 2  # info message + error message
+        for msg in messages:
+            assert isinstance(msg, StructuredLogMessage)
+        # The error message should contain the exception text
+        assert any("CloudWatch unavailable" in msg.event for msg in messages if hasattr(msg, 'event'))
 
 
 def test_cloudwatch_remote_task_logger_event_to_dict_with_json():


### PR DESCRIPTION
*Description of changes:*

Fix for task logs not appearing in the UI

- Changed the return for `_read_remote_logs` , it was return both StructuredLogMesssage and plain strings in the list, which was causing issue with the api call change from 'json' to 'ndjson'
- Added `end_of_log` to the metadata, because otherwise the UI is in a state of constantly loading the logs.

## Root Cause
The root cause for this issue was a change in Airflow from 3.0.6 to 3.1.6
Here in [useLogs](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/ui/src/queries/useLogs.tsx#L203), a change was made from accept `application/json` to `application/x-ndjson`
This made it so it we couldn't return a mix of strings and StructuredLogMessages

Due to the change to 'ndjson' , [a different function](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/api_fastapi/core_api/routes/public/log.py#L147) is called in [log_reader.py](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/utils/log/log_reader.py) , which enters a 'while True' loop
'end_of_log' needs to be set to return from that loop

## Testing

Unit tests added for these changes

Local deployment shows the logs now appearing in the UI

<img width="1662" height="973" alt="image" src="https://github.com/user-attachments/assets/4b32e506-6556-489f-bc00-259a0fff063a" />

And to be sure , I tested with a long running dag, and the behaviors stays the same in 3.0.6 and 3.1.6
The logs show up every 60 secs when the task is still running:
<img width="1662" height="973" alt="image" src="https://github.com/user-attachments/assets/372eed5b-4ccc-453a-9869-cb97f277202c" />

