### PR TITLE
Mask sensitive proxy values in airflow config

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/config/airflow.py
+++ b/images/airflow/2.10.1/python/mwaa/config/airflow.py
@@ -85,6 +85,7 @@ def _get_opinionated_airflow_core_config() -> Dict[str, str]:
 
     return {
         "AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER": "True",
+        "AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES": "proxy,proxies",
     }
 
 

--- a/images/airflow/2.10.3/python/mwaa/config/airflow.py
+++ b/images/airflow/2.10.3/python/mwaa/config/airflow.py
@@ -85,6 +85,7 @@ def _get_opinionated_airflow_core_config() -> Dict[str, str]:
 
     return {
         "AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER": "True",
+        "AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES": "proxy,proxies",
     }
 
 

--- a/images/airflow/2.11.0/python/mwaa/config/airflow.py
+++ b/images/airflow/2.11.0/python/mwaa/config/airflow.py
@@ -85,6 +85,7 @@ def _get_opinionated_airflow_core_config() -> Dict[str, str]:
 
     return {
         "AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER": "True",
+        "AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES": "proxy,proxies",
     }
 
 

--- a/images/airflow/2.9.2/python/mwaa/config/airflow.py
+++ b/images/airflow/2.9.2/python/mwaa/config/airflow.py
@@ -85,6 +85,7 @@ def _get_opinionated_airflow_core_config() -> Dict[str, str]:
 
     return {
         "AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER": "True",
+        "AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES": "proxy,proxies",
     }
 
 

--- a/images/airflow/3.0.6/python/mwaa/config/airflow.py
+++ b/images/airflow/3.0.6/python/mwaa/config/airflow.py
@@ -94,6 +94,7 @@ def _get_opinionated_airflow_core_config() -> Dict[str, str]:
 
     return {
         "AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER": "True",
+        "AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES": "proxy,proxies",
     }
 
 

--- a/images/airflow/3.1.6/python/mwaa/config/airflow.py
+++ b/images/airflow/3.1.6/python/mwaa/config/airflow.py
@@ -94,6 +94,7 @@ def _get_opinionated_airflow_core_config() -> Dict[str, str]:
 
     return {
         "AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER": "True",
+        "AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES": "proxy,proxies",
     }
 
 

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_airflow.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_airflow.py
@@ -95,6 +95,7 @@ def test_get_opinionated_airflow_core_config():
     result = _get_opinionated_airflow_core_config()
 
     assert result["AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER"] == "True"
+    assert result["AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES"] == "proxy,proxies"
 
 # ---------------------------------
 # User Airflow Config Tests

--- a/tests/images/airflow/3.1.6/python/mwaa/config/test_airflow.py
+++ b/tests/images/airflow/3.1.6/python/mwaa/config/test_airflow.py
@@ -95,6 +95,7 @@ def test_get_opinionated_airflow_core_config():
     result = _get_opinionated_airflow_core_config()
 
     assert result["AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER"] == "True"
+    assert result["AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES"] == "proxy,proxies"
 
 # ---------------------------------
 # User Airflow Config Tests


### PR DESCRIPTION
*Description of changes*
+ Fix CVE identified to mask sensitive "proxy" and "proxies" info in connection by adding them to Airflow core config as default. Also updated the related unit tests.
+ Users can also choose to override this config accordingly.

*Testing*
+ Deployed 2.11.0 image and verified by running a DAG that (1) checks the core config is set; (2)shows masked proxy info. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
