### PR TITLE
Fix missing permission update in migrate_with_downgrade

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.10.1/python/mwaa/database/migrate_with_downgrade.py
@@ -92,6 +92,7 @@ def _ensure_rds_iam_user():
                     conn.execute(text(f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'))
                     conn.execute(text(f"GRANT ALL ON SCHEMA public TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f"GRANT ALL ON ALL TABLES IN SCHEMA public TO {DB_IAM_USERNAME}"))
+                    conn.execute(text(f"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f"GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"))


### PR DESCRIPTION
*Description of changes:*
Add GRANT ALL ON ALL SEQUENCE IN SCHEMA [...] which was missing in 2.10.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
