### PR TITLE
Enable reading of triggerer execution logs in Task Log UI for 3.x

### DIFF
--- a/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
@@ -438,7 +438,7 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         all_logs: LogMessages = []
         for stream_name in triggerer_streams:
             all_logs.append(
-                f"*** Reading triggerer logs from: {stream_name}"
+                f"Reading triggerer logs from: {stream_name}"
             )
             try:
                 events = self.get_cloudwatch_logs(stream_name, task_instance)
@@ -446,7 +446,7 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
                     all_logs.append(StructuredLogMessage.model_validate(log))
             except Exception as e:
                 all_logs.append(
-                    f"*** Failed to read triggerer logs from: {stream_name}: {e}"
+                    f"Failed to read triggerer logs from: {stream_name}: {e}"
                 )
         return all_logs
 
@@ -466,7 +466,7 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
             triggerer_logs = self._read_triggerer_logs(triggerer_streams, task_instance)
         except Exception as e:
             triggerer_logs = [
-                f"*** Failed to read triggerer logs: {e}"
+                f"Failed to read triggerer logs: {e}"
             ]
 
         return messages + logs + triggerer_logs, metadata

--- a/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
@@ -288,6 +288,8 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         # Dag processor log (from loading DagBag) with stream name dag_processor/2025-01-01/dags-folder/dag.py.log
         re.compile(r"^dag_processor/")
     ]
+    # Pattern to match triggerer log streams: {base_stream}.trigger.{numeric_id}.log
+    TRIGGERER_STREAM_PATTERN = re.compile(r"\.trigger\.\d+\.log$")
 
     def __init__(
         self,
@@ -385,6 +387,69 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         self.flush()
         return
 
+    def _discover_triggerer_streams(self, base_stream_name: str) -> list[str]:
+        """
+        Discover triggerer log streams associated with a task instance.
+
+        Uses describe_log_streams with a prefix filter to find streams matching
+        the pattern: {base_stream_name}.trigger.{numeric_id}.log
+
+        :param base_stream_name: The primary task log stream name.
+        :returns: List of triggerer stream names, or empty list if none found.
+        """
+        try:
+            log_group = self.log_group_arn.rsplit(":", 1)[1]
+            prefix = base_stream_name + ".trigger."
+            streams: list[str] = []
+            kwargs = {
+                "logGroupName": log_group,
+                "logStreamNamePrefix": prefix,
+            }
+            while True:
+                response = self.hook.conn.describe_log_streams(**kwargs)
+                for stream in response.get("logStreams", []):
+                    name = stream.get("logStreamName", "")
+                    if self.TRIGGERER_STREAM_PATTERN.search(name):
+                        streams.append(name)
+                next_token = response.get("nextToken")
+                if not next_token:
+                    break
+                kwargs["nextToken"] = next_token
+            return streams
+        except Exception:
+            return []
+
+    def _read_triggerer_logs(
+        self, triggerer_streams: list[str], task_instance
+    ) -> LogMessages:
+        """
+        Read log events from all discovered triggerer streams.
+
+        For each stream, prepends a header indicating the source stream,
+        reads events via get_cloudwatch_logs, and converts them to
+        StructuredLogMessage objects.
+
+        :param triggerer_streams: List of triggerer log stream names.
+        :param task_instance: The task instance to get logs about.
+        :returns: List of log messages (StructuredLogMessage objects with headers).
+        """
+        from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+        all_logs: LogMessages = []
+        for stream_name in triggerer_streams:
+            all_logs.append(
+                f"*** Reading triggerer logs from: {stream_name}"
+            )
+            try:
+                events = self.get_cloudwatch_logs(stream_name, task_instance)
+                for log in events:
+                    all_logs.append(StructuredLogMessage.model_validate(log))
+            except Exception as e:
+                all_logs.append(
+                    f"*** Failed to read triggerer logs from: {stream_name}: {e}"
+                )
+        return all_logs
+
     def read(
         self, task_instance, try_number, metadata=None
     ) -> tuple[LogMessages, LogMetadata]:
@@ -395,7 +460,16 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         """
         stream_name = self._render_filename(task_instance, try_number).replace(":", "_")
         messages, logs = self._read_remote_logs(stream_name, task_instance)
-        return messages + logs, metadata
+
+        try:
+            triggerer_streams = self._discover_triggerer_streams(stream_name)
+            triggerer_logs = self._read_triggerer_logs(triggerer_streams, task_instance)
+        except Exception as e:
+            triggerer_logs = [
+                f"*** Failed to read triggerer logs: {e}"
+            ]
+
+        return messages + logs + triggerer_logs, metadata
 
     def _read_remote_logs(self, relative_path, ti: RuntimeTI) -> tuple[LogSourceInfo, LogMessages | None]:
         messages = [

--- a/images/airflow/3.2.0/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.2.0/python/mwaa/logging/cloudwatch_handlers.py
@@ -288,6 +288,8 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         # Dag processor log (from loading DagBag) with stream name dag_processor/2025-01-01/dags-folder/dag.py.log
         re.compile(r"^dag_processor/")
     ]
+    # Pattern to match triggerer log streams: {base_stream}.trigger.{numeric_id}.log
+    TRIGGERER_STREAM_PATTERN = re.compile(r"\.trigger\.\d+\.log$")
 
     def __init__(
         self,
@@ -391,6 +393,71 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         self.flush()
         return
 
+    def _discover_triggerer_streams(self, base_stream_name: str) -> list[str]:
+        """
+        Discover triggerer log streams associated with a task instance.
+
+        Uses describe_log_streams with a prefix filter to find streams matching
+        the pattern: {base_stream_name}.trigger.{numeric_id}.log
+
+        :param base_stream_name: The primary task log stream name.
+        :returns: List of triggerer stream names, or empty list if none found.
+        """
+        try:
+            log_group = self.log_group_arn.rsplit(":", 1)[1]
+            prefix = base_stream_name + ".trigger."
+            streams: list[str] = []
+            kwargs = {
+                "logGroupName": log_group,
+                "logStreamNamePrefix": prefix,
+            }
+            while True:
+                response = self.hook.conn.describe_log_streams(**kwargs)
+                for stream in response.get("logStreams", []):
+                    name = stream.get("logStreamName", "")
+                    if self.TRIGGERER_STREAM_PATTERN.search(name):
+                        streams.append(name)
+                next_token = response.get("nextToken")
+                if not next_token:
+                    break
+                kwargs["nextToken"] = next_token
+            return streams
+        except Exception:
+            return []
+
+    def _read_triggerer_logs(
+        self, triggerer_streams: list[str], task_instance
+    ) -> list[StructuredLogMessage]:
+        """
+        Read log events from all discovered triggerer streams.
+
+        For each stream, prepends a header indicating the source stream,
+        reads events via get_cloudwatch_logs, and converts them to
+        StructuredLogMessage objects.
+
+        :param triggerer_streams: List of triggerer log stream names.
+        :param task_instance: The task instance to get logs about.
+        :returns: Flat list of StructuredLogMessage objects from all streams.
+        """
+        all_logs: list[StructuredLogMessage] = []
+        for stream_name in triggerer_streams:
+            all_logs.append(
+                StructuredLogMessage(
+                    event=f"*** Reading triggerer logs from: {stream_name}"
+                )
+            )
+            try:
+                events = self.get_cloudwatch_logs(stream_name, task_instance)
+                for log in events:
+                    all_logs.append(StructuredLogMessage.model_validate(log))
+            except Exception as e:
+                all_logs.append(
+                    StructuredLogMessage(
+                        event=f"*** Failed to read triggerer logs from: {stream_name}: {e}"
+                    )
+                )
+        return all_logs
+
     def read(
         self, task_instance, try_number, metadata=None
     ) -> tuple[list[StructuredLogMessage], LogMetadata]:
@@ -403,9 +470,24 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         """
         stream_name = self._render_filename(task_instance, try_number).replace(":", "_")
         messages, logs = self._read_remote_logs(stream_name, task_instance)
+
+        try:
+            triggerer_streams = self._discover_triggerer_streams(stream_name)
+            triggerer_logs = self._read_triggerer_logs(triggerer_streams, task_instance)
+        except Exception as e:
+            triggerer_logs = [
+                StructuredLogMessage(
+                    event=f"*** Failed to read triggerer logs: {e}"
+                )
+            ]
+
+        # TODO: Add ::group::/::endgroup:: markers to enable collapsible log sections in the UI.
+        # Airflow's FileTaskHandler._read() wraps log source details and sections with these markers,
+        # but our CloudWatch-based read() currently returns flat log lists without them.
+        # Details: https://app.asana.com/1/8442528107068/project/1212634437759616/task/1214036597979786?focus=true
         out_metadata = dict(metadata) if metadata else {}
         out_metadata["end_of_log"] = True
-        return messages + logs, out_metadata
+        return messages + logs + triggerer_logs, out_metadata
 
     def _read_remote_logs(self, relative_path, ti: RuntimeTI) -> tuple[list[StructuredLogMessage], list[StructuredLogMessage]]:
         try:

--- a/images/airflow/3.2.0/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.2.0/python/mwaa/logging/cloudwatch_handlers.py
@@ -443,7 +443,7 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         for stream_name in triggerer_streams:
             all_logs.append(
                 StructuredLogMessage(
-                    event=f"*** Reading triggerer logs from: {stream_name}"
+                    event=f"Reading triggerer logs from: {stream_name}"
                 )
             )
             try:
@@ -453,7 +453,7 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
             except Exception as e:
                 all_logs.append(
                     StructuredLogMessage(
-                        event=f"*** Failed to read triggerer logs from: {stream_name}: {e}"
+                        event=f"Failed to read triggerer logs from: {stream_name}: {e}"
                     )
                 )
         return all_logs
@@ -477,7 +477,7 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         except Exception as e:
             triggerer_logs = [
                 StructuredLogMessage(
-                    event=f"*** Failed to read triggerer logs: {e}"
+                    event=f"Failed to read triggerer logs: {e}"
                 )
             ]
 

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -585,7 +585,7 @@ def test_read_with_one_triggerer_stream(mock_boto3_client):
         messages, metadata = logger.read(ti, 1)
 
         events_text = [_get_event_text(msg) for msg in messages]
-        assert any(f"*** Reading triggerer logs from: {triggerer_stream}" in e for e in events_text)
+        assert any(f"Reading triggerer logs from: {triggerer_stream}" in e for e in events_text)
         assert any("triggerer log line" in e for e in events_text)
 
 
@@ -699,7 +699,7 @@ def test_read_excludes_non_matching_triggerer_streams(mock_boto3_client):
         messages, metadata = logger.read(ti, 1)
 
         events_text = [_get_event_text(msg) for msg in messages]
-        assert not any("*** Reading triggerer logs from:" in e for e in events_text)
+        assert not any("Reading triggerer logs from:" in e for e in events_text)
 
 
 @pytest.mark.parametrize("stream_suffix", [

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -490,3 +490,257 @@ def test_cloudwatch_remote_task_logger_always_uses_watchtower_not_fluent(mock_bo
             use_queues=True,
             create_log_group=False,
         )
+
+
+def _make_task_instance_mock():
+    ti = MagicMock()
+    ti.dag_id = 'test_dag'
+    ti.task_id = 'test_task'
+    ti.run_id = 'test_run'
+    ti.try_number = 1
+    ti.end_date = None
+
+    mock_dag_run = MagicMock()
+    mock_dag_run.logical_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    mock_dag_run.run_after = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    mock_dag_run.data_interval_start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    mock_dag_run.data_interval_end = datetime(2024, 1, 2, tzinfo=timezone.utc)
+
+    mock_log_template = MagicMock()
+    mock_log_template.filename = "dag_id={dag_id}/run_id={run_id}/task_id={task_id}/attempt={try_number}.log"
+    mock_dag_run.get_log_template.return_value = mock_log_template
+
+    ti.get_dagrun.return_value = mock_dag_run
+    return ti
+
+
+def _make_logger_with_hook(mock_hook_class, log_events):
+    mock_hook = Mock()
+    mock_hook_class.return_value = mock_hook
+    mock_hook.get_log_events.return_value = log_events
+
+    logger = CloudWatchRemoteTaskLogger(
+        log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+        kms_key_arn=None,
+        enabled=True,
+        log_level='INFO'
+    )
+    return logger
+
+
+def _get_event_text(msg):
+    if isinstance(msg, str):
+        return msg
+    return getattr(msg, 'event', str(msg))
+
+
+def test_read_with_no_triggerer_streams(mock_boto3_client):
+    """Test read() with no triggerer streams returns only task logs."""
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        task_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "task log line", "level": "info"}'
+            }
+        ]
+        logger = _make_logger_with_hook(mock_hook_class, task_events)
+        logger.hook.conn.describe_log_streams.return_value = {'logStreams': []}
+        ti = _make_task_instance_mock()
+
+        messages, metadata = logger.read(ti, 1)
+
+        for msg in messages:
+            assert "triggerer" not in _get_event_text(msg).lower()
+
+
+def test_read_with_one_triggerer_stream(mock_boto3_client):
+    """Test read() with one triggerer stream returns task logs + header + triggerer logs."""
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        task_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "task log line", "level": "info"}'
+            }
+        ]
+        triggerer_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 1, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "triggerer log line", "level": "info"}'
+            }
+        ]
+        logger = _make_logger_with_hook(mock_hook_class, task_events)
+
+        triggerer_stream = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.42.log'
+        logger.hook.conn.describe_log_streams.return_value = {
+            'logStreams': [{'logStreamName': triggerer_stream}]
+        }
+        mock_hook = mock_hook_class.return_value
+        def get_log_events_side_effect(**kwargs):
+            if '.trigger.' in kwargs.get('log_stream_name', ''):
+                return triggerer_events
+            return task_events
+        mock_hook.get_log_events.side_effect = get_log_events_side_effect
+
+        ti = _make_task_instance_mock()
+        messages, metadata = logger.read(ti, 1)
+
+        events_text = [_get_event_text(msg) for msg in messages]
+        assert any(f"*** Reading triggerer logs from: {triggerer_stream}" in e for e in events_text)
+        assert any("triggerer log line" in e for e in events_text)
+
+
+def test_read_with_multiple_triggerer_streams(mock_boto3_client):
+    """Test read() with multiple triggerer streams returns all streams' events."""
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        task_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "task log line", "level": "info"}'
+            }
+        ]
+        stream1 = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.1.log'
+        stream2 = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.2.log'
+
+        logger = _make_logger_with_hook(mock_hook_class, task_events)
+        logger.hook.conn.describe_log_streams.return_value = {
+            'logStreams': [{'logStreamName': stream1}, {'logStreamName': stream2}]
+        }
+        mock_hook = mock_hook_class.return_value
+        def get_log_events_side_effect(**kwargs):
+            stream = kwargs.get('log_stream_name', '')
+            if stream == stream1:
+                return [{'timestamp': int(datetime(2024, 1, 1, 12, 1, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                         'message': '{"event": "stream1_event", "level": "info"}'}]
+            elif stream == stream2:
+                return [{'timestamp': int(datetime(2024, 1, 1, 12, 2, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                         'message': '{"event": "stream2_event", "level": "info"}'}]
+            return task_events
+        mock_hook.get_log_events.side_effect = get_log_events_side_effect
+
+        ti = _make_task_instance_mock()
+        messages, metadata = logger.read(ti, 1)
+
+        events_text = [_get_event_text(msg) for msg in messages]
+        assert any("stream1_event" in e for e in events_text)
+        assert any("stream2_event" in e for e in events_text)
+
+
+def test_read_describe_log_streams_failure(mock_boto3_client):
+    """Test describe_log_streams failure still returns task logs."""
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        task_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "task log line", "level": "info"}'
+            }
+        ]
+        logger = _make_logger_with_hook(mock_hook_class, task_events)
+        logger.hook.conn.describe_log_streams.side_effect = Exception("CloudWatch API error")
+
+        ti = _make_task_instance_mock()
+        messages, metadata = logger.read(ti, 1)
+
+        events_text = [_get_event_text(msg) for msg in messages]
+        assert any("task log line" in e for e in events_text)
+
+
+def test_read_get_log_events_failure_for_triggerer_stream(mock_boto3_client):
+    """Test get_log_events failure for one triggerer stream skips it and continues."""
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        task_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "task log line", "level": "info"}'
+            }
+        ]
+        stream_fail = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.10.log'
+        stream_ok = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.20.log'
+
+        logger = _make_logger_with_hook(mock_hook_class, task_events)
+        logger.hook.conn.describe_log_streams.return_value = {
+            'logStreams': [{'logStreamName': stream_fail}, {'logStreamName': stream_ok}]
+        }
+        mock_hook = mock_hook_class.return_value
+        def get_log_events_side_effect(**kwargs):
+            stream = kwargs.get('log_stream_name', '')
+            if stream == stream_fail:
+                raise Exception("Stream read error")
+            elif stream == stream_ok:
+                return [{'timestamp': int(datetime(2024, 1, 1, 12, 2, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                         'message': '{"event": "ok_triggerer_event", "level": "info"}'}]
+            return task_events
+        mock_hook.get_log_events.side_effect = get_log_events_side_effect
+
+        ti = _make_task_instance_mock()
+        messages, metadata = logger.read(ti, 1)
+
+        events_text = [_get_event_text(msg) for msg in messages]
+        assert any("ok_triggerer_event" in e for e in events_text)
+        assert any("Failed to read triggerer logs from" in e for e in events_text)
+
+
+def test_read_excludes_non_matching_triggerer_streams(mock_boto3_client):
+    """Test streams not matching regex pattern are excluded."""
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        task_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "task log line", "level": "info"}'
+            }
+        ]
+        bad_stream = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.abc.log'
+
+        logger = _make_logger_with_hook(mock_hook_class, task_events)
+        logger.hook.conn.describe_log_streams.return_value = {
+            'logStreams': [{'logStreamName': bad_stream}]
+        }
+
+        ti = _make_task_instance_mock()
+        messages, metadata = logger.read(ti, 1)
+
+        events_text = [_get_event_text(msg) for msg in messages]
+        assert not any("*** Reading triggerer logs from:" in e for e in events_text)
+
+
+@pytest.mark.parametrize("stream_suffix", [
+    ".trigger.1.log",
+    ".trigger.123.log",
+    ".trigger.999999.log",
+])
+def test_triggerer_pattern_matches_valid_streams(stream_suffix):
+    """Valid triggerer stream suffixes must be matched by TRIGGERER_STREAM_PATTERN."""
+    assert CloudWatchRemoteTaskLogger.TRIGGERER_STREAM_PATTERN.search(stream_suffix) is not None
+
+
+@pytest.mark.parametrize("stream_suffix", [
+    ".trigger.abc.log",
+    ".trigger..log",
+    ".triggerX.1.log",
+    ".trigger.1.txt",
+    ".trigger.log",
+])
+def test_triggerer_pattern_rejects_invalid_streams(stream_suffix):
+    """Invalid triggerer stream suffixes must NOT be matched by TRIGGERER_STREAM_PATTERN."""
+    assert CloudWatchRemoteTaskLogger.TRIGGERER_STREAM_PATTERN.search(stream_suffix) is None
+
+
+def test_discover_triggerer_streams_follows_pagination(mock_boto3_client):
+    """_discover_triggerer_streams must follow nextToken pagination."""
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        logger = _make_logger_with_hook(mock_hook_class, [])
+
+        stream_page1 = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.1.log'
+        stream_page2 = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.2.log'
+
+        logger.hook.conn.describe_log_streams.side_effect = [
+            {'logStreams': [{'logStreamName': stream_page1}], 'nextToken': 'token123'},
+            {'logStreams': [{'logStreamName': stream_page2}]},
+        ]
+
+        base_stream = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log'
+        streams = logger._discover_triggerer_streams(base_stream)
+
+        assert stream_page1 in streams
+        assert stream_page2 in streams
+        assert len(streams) == 2
+        assert logger.hook.conn.describe_log_streams.call_count == 2

--- a/tests/images/airflow/3.2.0/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.2.0/python/mwaa/logging/test_cloudwatch_handler.py
@@ -641,7 +641,7 @@ def test_read_with_one_triggerer_stream(mock_boto3_client):
             )
         # Check header is present
         header_found = any(
-            f"*** Reading triggerer logs from: {triggerer_stream}" in msg.event
+            f"Reading triggerer logs from: {triggerer_stream}" in msg.event
             for msg in messages
         )
         assert header_found, "Expected triggerer header not found in output"
@@ -860,7 +860,7 @@ def test_read_excludes_non_matching_triggerer_streams(mock_boto3_client):
             "Events from non-matching streams should not appear in output"
         )
         # No triggerer header should appear since all streams were filtered out
-        assert not any("*** Reading triggerer logs from:" in e for e in events_text), (
+        assert not any("Reading triggerer logs from:" in e for e in events_text), (
             "No triggerer header should appear when all streams are filtered out"
         )
 

--- a/tests/images/airflow/3.2.0/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.2.0/python/mwaa/logging/test_cloudwatch_handler.py
@@ -566,3 +566,352 @@ def test_cloudwatch_remote_task_logger_always_uses_watchtower_not_fluent(mock_bo
             use_queues=True,
             create_log_group=False,
         )
+
+
+def test_read_with_no_triggerer_streams(mock_boto3_client):
+    """Test read() with no triggerer streams returns only task logs (no error, no header)."""
+    from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        task_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "task log line", "level": "info"}'
+            }
+        ]
+        logger = _make_logger_with_hook(mock_hook_class, task_events)
+        # Mock describe_log_streams to return no triggerer streams
+        logger.hook.conn.describe_log_streams.return_value = {
+            'logStreams': []
+        }
+        ti = _make_task_instance_mock()
+
+        messages, metadata = logger.read(ti, 1)
+
+        # All items must be StructuredLogMessage
+        for msg in messages:
+            assert isinstance(msg, StructuredLogMessage), (
+                f"Expected StructuredLogMessage, got {type(msg).__name__}: {msg}"
+            )
+        # No triggerer text should appear
+        for msg in messages:
+            assert "triggerer" not in msg.event.lower(), (
+                f"Unexpected triggerer text in output: {msg.event}"
+            )
+
+
+def test_read_with_one_triggerer_stream(mock_boto3_client):
+    """Test read() with one triggerer stream returns task logs + header + triggerer logs."""
+    from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        task_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "task log line", "level": "info"}'
+            }
+        ]
+        triggerer_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 1, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "triggerer log line", "level": "info"}'
+            }
+        ]
+        logger = _make_logger_with_hook(mock_hook_class, task_events)
+
+        triggerer_stream = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.42.log'
+        logger.hook.conn.describe_log_streams.return_value = {
+            'logStreams': [{'logStreamName': triggerer_stream}]
+        }
+        # Return different events for task stream vs triggerer stream
+        mock_hook = mock_hook_class.return_value
+        def get_log_events_side_effect(**kwargs):
+            if '.trigger.' in kwargs.get('log_stream_name', ''):
+                return triggerer_events
+            return task_events
+        mock_hook.get_log_events.side_effect = get_log_events_side_effect
+
+        ti = _make_task_instance_mock()
+        messages, metadata = logger.read(ti, 1)
+
+        # All items must be StructuredLogMessage
+        for msg in messages:
+            assert isinstance(msg, StructuredLogMessage), (
+                f"Expected StructuredLogMessage, got {type(msg).__name__}: {msg}"
+            )
+        # Check header is present
+        header_found = any(
+            f"*** Reading triggerer logs from: {triggerer_stream}" in msg.event
+            for msg in messages
+        )
+        assert header_found, "Expected triggerer header not found in output"
+        # Check triggerer event is present
+        triggerer_event_found = any(
+            "triggerer log line" in msg.event for msg in messages
+        )
+        assert triggerer_event_found, "Expected triggerer log event not found in output"
+
+
+def test_read_with_multiple_triggerer_streams(mock_boto3_client):
+    """Test read() with multiple triggerer streams returns all streams' events."""
+    from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        task_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "task log line", "level": "info"}'
+            }
+        ]
+        stream1 = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.1.log'
+        stream2 = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.2.log'
+        stream3 = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.3.log'
+
+        triggerer_events_1 = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 1, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "triggerer_stream_1_event", "level": "info"}'
+            }
+        ]
+        triggerer_events_2 = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 2, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "triggerer_stream_2_event", "level": "info"}'
+            }
+        ]
+        triggerer_events_3 = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 3, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "triggerer_stream_3_event", "level": "info"}'
+            }
+        ]
+
+        logger = _make_logger_with_hook(mock_hook_class, task_events)
+        logger.hook.conn.describe_log_streams.return_value = {
+            'logStreams': [
+                {'logStreamName': stream1},
+                {'logStreamName': stream2},
+                {'logStreamName': stream3},
+            ]
+        }
+
+        mock_hook = mock_hook_class.return_value
+        def get_log_events_side_effect(**kwargs):
+            stream = kwargs.get('log_stream_name', '')
+            if stream == stream1:
+                return triggerer_events_1
+            elif stream == stream2:
+                return triggerer_events_2
+            elif stream == stream3:
+                return triggerer_events_3
+            return task_events
+        mock_hook.get_log_events.side_effect = get_log_events_side_effect
+
+        ti = _make_task_instance_mock()
+        messages, metadata = logger.read(ti, 1)
+
+        # All items must be StructuredLogMessage
+        for msg in messages:
+            assert isinstance(msg, StructuredLogMessage), (
+                f"Expected StructuredLogMessage, got {type(msg).__name__}: {msg}"
+            )
+        # All three streams' events must appear
+        events_text = [msg.event for msg in messages]
+        assert any("triggerer_stream_1_event" in e for e in events_text), "Stream 1 events missing"
+        assert any("triggerer_stream_2_event" in e for e in events_text), "Stream 2 events missing"
+        assert any("triggerer_stream_3_event" in e for e in events_text), "Stream 3 events missing"
+
+
+def test_read_describe_log_streams_failure(mock_boto3_client):
+    """Test describe_log_streams failure still returns task logs + error message."""
+    from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        task_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "task log line", "level": "info"}'
+            }
+        ]
+        logger = _make_logger_with_hook(mock_hook_class, task_events)
+        # Make describe_log_streams raise an exception
+        logger.hook.conn.describe_log_streams.side_effect = Exception("CloudWatch API error")
+
+        ti = _make_task_instance_mock()
+        messages, metadata = logger.read(ti, 1)
+
+        # All items must be StructuredLogMessage
+        for msg in messages:
+            assert isinstance(msg, StructuredLogMessage), (
+                f"Expected StructuredLogMessage, got {type(msg).__name__}: {msg}"
+            )
+        # Task logs should still be present
+        task_log_found = any("task log line" in msg.event for msg in messages)
+        assert task_log_found, "Task logs should still be returned on describe_log_streams failure"
+
+
+def test_read_get_log_events_failure_for_triggerer_stream(mock_boto3_client):
+    """Test get_log_events failure for one triggerer stream skips it and continues with others."""
+    from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        task_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "task log line", "level": "info"}'
+            }
+        ]
+        stream_fail = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.10.log'
+        stream_ok = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.20.log'
+
+        triggerer_ok_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 2, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "ok_triggerer_event", "level": "info"}'
+            }
+        ]
+
+        logger = _make_logger_with_hook(mock_hook_class, task_events)
+        logger.hook.conn.describe_log_streams.return_value = {
+            'logStreams': [
+                {'logStreamName': stream_fail},
+                {'logStreamName': stream_ok},
+            ]
+        }
+
+        mock_hook = mock_hook_class.return_value
+        def get_log_events_side_effect(**kwargs):
+            stream = kwargs.get('log_stream_name', '')
+            if stream == stream_fail:
+                raise Exception("Stream read error")
+            elif stream == stream_ok:
+                return triggerer_ok_events
+            return task_events
+        mock_hook.get_log_events.side_effect = get_log_events_side_effect
+
+        ti = _make_task_instance_mock()
+        messages, metadata = logger.read(ti, 1)
+
+        # All items must be StructuredLogMessage
+        for msg in messages:
+            assert isinstance(msg, StructuredLogMessage), (
+                f"Expected StructuredLogMessage, got {type(msg).__name__}: {msg}"
+            )
+        events_text = [msg.event for msg in messages]
+        # The second stream's events should be present
+        assert any("ok_triggerer_event" in e for e in events_text), (
+            "Second triggerer stream events should be present"
+        )
+        # An error message for the failed stream should be present
+        assert any("Failed to read triggerer logs from" in e and stream_fail in e for e in events_text), (
+            "Error message for failed triggerer stream should be present"
+        )
+
+
+def test_read_excludes_non_matching_triggerer_streams(mock_boto3_client):
+    """Test streams not matching regex pattern are excluded."""
+    from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        task_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "task log line", "level": "info"}'
+            }
+        ]
+        # These streams do NOT match the .trigger.{digits}.log pattern
+        bad_stream_1 = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.abc.log'
+        bad_stream_2 = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger..log'
+
+        bad_events = [
+            {
+                'timestamp': int(datetime(2024, 1, 1, 12, 1, 0, tzinfo=timezone.utc).timestamp() * 1000),
+                'message': '{"event": "bad_stream_event", "level": "info"}'
+            }
+        ]
+
+        logger = _make_logger_with_hook(mock_hook_class, task_events)
+        logger.hook.conn.describe_log_streams.return_value = {
+            'logStreams': [
+                {'logStreamName': bad_stream_1},
+                {'logStreamName': bad_stream_2},
+            ]
+        }
+
+        mock_hook = mock_hook_class.return_value
+        def get_log_events_side_effect(**kwargs):
+            stream = kwargs.get('log_stream_name', '')
+            if stream in (bad_stream_1, bad_stream_2):
+                return bad_events
+            return task_events
+        mock_hook.get_log_events.side_effect = get_log_events_side_effect
+
+        ti = _make_task_instance_mock()
+        messages, metadata = logger.read(ti, 1)
+
+        # All items must be StructuredLogMessage
+        for msg in messages:
+            assert isinstance(msg, StructuredLogMessage), (
+                f"Expected StructuredLogMessage, got {type(msg).__name__}: {msg}"
+            )
+        # Non-matching stream events should NOT appear
+        events_text = [msg.event for msg in messages]
+        assert not any("bad_stream_event" in e for e in events_text), (
+            "Events from non-matching streams should not appear in output"
+        )
+        # No triggerer header should appear since all streams were filtered out
+        assert not any("*** Reading triggerer logs from:" in e for e in events_text), (
+            "No triggerer header should appear when all streams are filtered out"
+        )
+
+@pytest.mark.parametrize("stream_suffix", [
+    ".trigger.1.log",
+    ".trigger.123.log",
+    ".trigger.999999.log",
+])
+def test_triggerer_pattern_matches_valid_streams(stream_suffix):
+    """Valid triggerer stream suffixes must be matched by TRIGGERER_STREAM_PATTERN."""
+    assert CloudWatchRemoteTaskLogger.TRIGGERER_STREAM_PATTERN.search(stream_suffix) is not None, (
+        f"Expected pattern to match '{stream_suffix}'"
+    )
+
+
+@pytest.mark.parametrize("stream_suffix", [
+    ".trigger.abc.log",
+    ".trigger..log",
+    ".triggerX.1.log",
+    ".trigger.1.txt",
+    ".trigger.log",
+])
+def test_triggerer_pattern_rejects_invalid_streams(stream_suffix):
+    """Invalid triggerer stream suffixes must NOT be matched by TRIGGERER_STREAM_PATTERN."""
+    assert CloudWatchRemoteTaskLogger.TRIGGERER_STREAM_PATTERN.search(stream_suffix) is None, (
+        f"Expected pattern to NOT match '{stream_suffix}'"
+    )
+
+
+def test_discover_triggerer_streams_follows_pagination(mock_boto3_client):
+    """_discover_triggerer_streams must follow nextToken pagination to collect all streams."""
+    with patch('mwaa.logging.cloudwatch_handlers.AwsLogsHook') as mock_hook_class:
+        logger = _make_logger_with_hook(mock_hook_class, [])
+
+        stream_page1 = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.1.log'
+        stream_page2 = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log.trigger.2.log'
+
+        logger.hook.conn.describe_log_streams.side_effect = [
+            {
+                'logStreams': [{'logStreamName': stream_page1}],
+                'nextToken': 'token123',
+            },
+            {
+                'logStreams': [{'logStreamName': stream_page2}],
+            },
+        ]
+
+        base_stream = 'dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log'
+        streams = logger._discover_triggerer_streams(base_stream)
+
+        assert stream_page1 in streams
+        assert stream_page2 in streams
+        assert len(streams) == 2
+        assert logger.hook.conn.describe_log_streams.call_count == 2


### PR DESCRIPTION
*Description of changes:*
Add triggerer logs in the Task log UI with it's matching task

When logs are loading in the UI, we now query for triggerer execution logs that match the task displayed. If found , triggerer logs are sent back with the task logs , and both are displayed in the UI

# Testing

Unit tests added

Example of triggerer execution logs in UI ( the sleeping logs ) in AF 3.2:

<img width="1715" height="963" alt="image" src="https://github.com/user-attachments/assets/2b8fe2fc-78ef-43fd-b59f-d37d772ce3cc" />

