### PR TITLE
Pre-create dag_processor dir on shared log mount

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -30,6 +30,12 @@ def _fix_shared_log_volume_permissions():
         except Exception as e:
             print(f"WARNING: Could not fix ownership of {log_dir}: {e}")
 
+        # Ensure the dag_processor log directory exists so Fluent Bit's tail
+        # input does not error when scanning the glob. The directory is not
+        # guaranteed to exist at container start.
+        dag_processor_dir = os.path.join(log_dir, "dag_processor")
+        os.makedirs(dag_processor_dir, exist_ok=True)
+
 _fix_shared_log_volume_permissions()
 
 # Setup logging first thing to make sure all logs happen under the right setup. The

--- a/images/airflow/2.10.3/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.3/python/mwaa/entrypoint.py
@@ -30,6 +30,12 @@ def _fix_shared_log_volume_permissions():
         except Exception as e:
             print(f"WARNING: Could not fix ownership of {log_dir}: {e}")
 
+        # Ensure the dag_processor log directory exists so Fluent Bit's tail
+        # input does not error when scanning the glob. The directory is not
+        # guaranteed to exist at container start.
+        dag_processor_dir = os.path.join(log_dir, "dag_processor")
+        os.makedirs(dag_processor_dir, exist_ok=True)
+
 _fix_shared_log_volume_permissions()
 
 # Setup logging first thing to make sure all logs happen under the right setup. The

--- a/images/airflow/2.11.0/python/mwaa/entrypoint.py
+++ b/images/airflow/2.11.0/python/mwaa/entrypoint.py
@@ -30,6 +30,12 @@ def _fix_shared_log_volume_permissions():
         except Exception as e:
             print(f"WARNING: Could not fix ownership of {log_dir}: {e}")
 
+        # Ensure the dag_processor log directory exists so Fluent Bit's tail
+        # input does not error when scanning the glob. The directory is not
+        # guaranteed to exist at container start.
+        dag_processor_dir = os.path.join(log_dir, "dag_processor")
+        os.makedirs(dag_processor_dir, exist_ok=True)
+
 _fix_shared_log_volume_permissions()
 
 # Setup logging first thing to make sure all logs happen under the right setup. The

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -30,6 +30,12 @@ def _fix_shared_log_volume_permissions():
         except Exception as e:
             print(f"WARNING: Could not fix ownership of {log_dir}: {e}")
 
+        # Ensure the dag_processor log directory exists so Fluent Bit's tail
+        # input does not error when scanning the glob. The directory is not
+        # guaranteed to exist at container start.
+        dag_processor_dir = os.path.join(log_dir, "dag_processor")
+        os.makedirs(dag_processor_dir, exist_ok=True)
+
 _fix_shared_log_volume_permissions()
 
 # Setup logging first thing to make sure all logs happen under the right setup. The

--- a/images/airflow/3.0.6/python/mwaa/entrypoint.py
+++ b/images/airflow/3.0.6/python/mwaa/entrypoint.py
@@ -30,6 +30,12 @@ def _fix_shared_log_volume_permissions():
         except Exception as e:
             print(f"WARNING: Could not fix ownership of {log_dir}: {e}")
 
+        # Ensure the dag_processor log directory exists so Fluent Bit's tail
+        # input does not error when scanning the glob. The directory is not
+        # guaranteed to exist at container start.
+        dag_processor_dir = os.path.join(log_dir, "dag_processor")
+        os.makedirs(dag_processor_dir, exist_ok=True)
+
 _fix_shared_log_volume_permissions()
 
 # Setup logging first thing to make sure all logs happen under the right setup. The

--- a/images/airflow/3.2.0/python/mwaa/entrypoint.py
+++ b/images/airflow/3.2.0/python/mwaa/entrypoint.py
@@ -30,6 +30,12 @@ def _fix_shared_log_volume_permissions():
         except Exception as e:
             print(f"WARNING: Could not fix ownership of {log_dir}: {e}")
 
+        # Ensure the dag_processor log directory exists so Fluent Bit's tail
+        # input does not error when scanning the glob. The directory is not
+        # guaranteed to exist at container start.
+        dag_processor_dir = os.path.join(log_dir, "dag_processor")
+        os.makedirs(dag_processor_dir, exist_ok=True)
+
 _fix_shared_log_volume_permissions()
 
 # Setup logging first thing to make sure all logs happen under the right setup. The


### PR DESCRIPTION
*Description of changes:*
Pre-create dag_processing folder when mounted.

This is to prevent a trove of error messages looking for this 

<img width="1428" height="121" alt="image" src="https://github.com/user-attachments/assets/57ffca56-0190-4a13-b9c2-9771137299ea" />

# Testing

Manually tested, errors don't appear in 2.11 when folder is mounted, nor in 3.2 when folder is mounted and DAGProcessing is disabled.

Tested in 3.2 to not break when DAGProcessing is enabled and folder is mounted