### PR TITLE
Block multi-team deployments in Airflow 3.2.0

### DIFF
--- a/images/airflow/3.2.0/python/mwaa/config/airflow.py
+++ b/images/airflow/3.2.0/python/mwaa/config/airflow.py
@@ -92,6 +92,11 @@ def _get_essential_airflow_core_config() -> Dict[str, str]:
 
     return {
         "AIRFLOW__CORE__LOAD_EXAMPLES": "False",
+        # MWAA does not support Multi-Team Deployments (introduced in Airflow 3.2.0).
+        # Enabling this would break IAM-based auth, CeleryExecutor management, and
+        # environment-level secrets/connections/pools. Block until MWAA explicitly
+        # supports multi-team.
+        "AIRFLOW__CORE__MULTI_TEAM": "False",
         **api_server_url,
         **fernet_key,
     }

--- a/tests/images/airflow/3.2.0/python/mwaa/config/test_airflow.py
+++ b/tests/images/airflow/3.2.0/python/mwaa/config/test_airflow.py
@@ -95,6 +95,12 @@ def test_core_config_with_api_url_and_fernet(env_helper):
     assert result["AIRFLOW__CORE__EXECUTION_API_SERVER_URL"] == \
         "https://api.example.com/execution"
     
+def test_core_config_multi_team_always_false():
+    """MULTI_TEAM must always be False and present in essential config (not overridable)."""
+    result = _get_essential_airflow_core_config()
+    assert result["AIRFLOW__CORE__MULTI_TEAM"] == "False"
+
+
 def test_core_config_invalid_fernet(env_helper):
     env_helper.set({
         "MWAA__CORE__FERNET_KEY": "invalid-json"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
-  Adds AIRFLOW__CORE__MULTI_TEAM=False to the essential (non-overridable) config for Airflow 3.2.0. This prevents customers from enabling Multi-Team Deployments, a new feature introduced in Airflow 3.2.0 that is incompatible with MWAA's architecture. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
