### PR TITLE
Add error handling for conditional creation of directory when mounted

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -33,8 +33,11 @@ def _fix_shared_log_volume_permissions():
         # Ensure the dag_processor log directory exists so Fluent Bit's tail
         # input does not error when scanning the glob. The directory is not
         # guaranteed to exist at container start.
-        dag_processor_dir = os.path.join(log_dir, "dag_processor")
-        os.makedirs(dag_processor_dir, exist_ok=True)
+        try:
+            dag_processor_dir = os.path.join(log_dir, "dag_processor")
+            os.makedirs(dag_processor_dir, exist_ok=True)
+        except Exception as e:
+            print(f"WARNING: Could not create {dag_processor_dir}: {e}")
 
 _fix_shared_log_volume_permissions()
 

--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -33,8 +33,8 @@ def _fix_shared_log_volume_permissions():
         # Ensure the dag_processor log directory exists so Fluent Bit's tail
         # input does not error when scanning the glob. The directory is not
         # guaranteed to exist at container start.
+        dag_processor_dir = os.path.join(log_dir, "dag_processor")
         try:
-            dag_processor_dir = os.path.join(log_dir, "dag_processor")
             os.makedirs(dag_processor_dir, exist_ok=True)
         except Exception as e:
             print(f"WARNING: Could not create {dag_processor_dir}: {e}")

--- a/images/airflow/2.10.3/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.3/python/mwaa/entrypoint.py
@@ -33,8 +33,11 @@ def _fix_shared_log_volume_permissions():
         # Ensure the dag_processor log directory exists so Fluent Bit's tail
         # input does not error when scanning the glob. The directory is not
         # guaranteed to exist at container start.
-        dag_processor_dir = os.path.join(log_dir, "dag_processor")
-        os.makedirs(dag_processor_dir, exist_ok=True)
+        try:
+            dag_processor_dir = os.path.join(log_dir, "dag_processor")
+            os.makedirs(dag_processor_dir, exist_ok=True)
+        except Exception as e:
+            print(f"WARNING: Could not create {dag_processor_dir}: {e}")
 
 _fix_shared_log_volume_permissions()
 

--- a/images/airflow/2.10.3/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.3/python/mwaa/entrypoint.py
@@ -33,8 +33,8 @@ def _fix_shared_log_volume_permissions():
         # Ensure the dag_processor log directory exists so Fluent Bit's tail
         # input does not error when scanning the glob. The directory is not
         # guaranteed to exist at container start.
+        dag_processor_dir = os.path.join(log_dir, "dag_processor")
         try:
-            dag_processor_dir = os.path.join(log_dir, "dag_processor")
             os.makedirs(dag_processor_dir, exist_ok=True)
         except Exception as e:
             print(f"WARNING: Could not create {dag_processor_dir}: {e}")

--- a/images/airflow/2.11.0/python/mwaa/entrypoint.py
+++ b/images/airflow/2.11.0/python/mwaa/entrypoint.py
@@ -33,8 +33,11 @@ def _fix_shared_log_volume_permissions():
         # Ensure the dag_processor log directory exists so Fluent Bit's tail
         # input does not error when scanning the glob. The directory is not
         # guaranteed to exist at container start.
-        dag_processor_dir = os.path.join(log_dir, "dag_processor")
-        os.makedirs(dag_processor_dir, exist_ok=True)
+        try:
+            dag_processor_dir = os.path.join(log_dir, "dag_processor")
+            os.makedirs(dag_processor_dir, exist_ok=True)
+        except Exception as e:
+            print(f"WARNING: Could not create {dag_processor_dir}: {e}")
 
 _fix_shared_log_volume_permissions()
 

--- a/images/airflow/2.11.0/python/mwaa/entrypoint.py
+++ b/images/airflow/2.11.0/python/mwaa/entrypoint.py
@@ -33,8 +33,8 @@ def _fix_shared_log_volume_permissions():
         # Ensure the dag_processor log directory exists so Fluent Bit's tail
         # input does not error when scanning the glob. The directory is not
         # guaranteed to exist at container start.
+        dag_processor_dir = os.path.join(log_dir, "dag_processor")
         try:
-            dag_processor_dir = os.path.join(log_dir, "dag_processor")
             os.makedirs(dag_processor_dir, exist_ok=True)
         except Exception as e:
             print(f"WARNING: Could not create {dag_processor_dir}: {e}")

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -33,8 +33,11 @@ def _fix_shared_log_volume_permissions():
         # Ensure the dag_processor log directory exists so Fluent Bit's tail
         # input does not error when scanning the glob. The directory is not
         # guaranteed to exist at container start.
-        dag_processor_dir = os.path.join(log_dir, "dag_processor")
-        os.makedirs(dag_processor_dir, exist_ok=True)
+        try:
+            dag_processor_dir = os.path.join(log_dir, "dag_processor")
+            os.makedirs(dag_processor_dir, exist_ok=True)
+        except Exception as e:
+            print(f"WARNING: Could not create {dag_processor_dir}: {e}")
 
 _fix_shared_log_volume_permissions()
 

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -33,8 +33,8 @@ def _fix_shared_log_volume_permissions():
         # Ensure the dag_processor log directory exists so Fluent Bit's tail
         # input does not error when scanning the glob. The directory is not
         # guaranteed to exist at container start.
+        dag_processor_dir = os.path.join(log_dir, "dag_processor")
         try:
-            dag_processor_dir = os.path.join(log_dir, "dag_processor")
             os.makedirs(dag_processor_dir, exist_ok=True)
         except Exception as e:
             print(f"WARNING: Could not create {dag_processor_dir}: {e}")

--- a/images/airflow/3.0.6/python/mwaa/entrypoint.py
+++ b/images/airflow/3.0.6/python/mwaa/entrypoint.py
@@ -33,8 +33,11 @@ def _fix_shared_log_volume_permissions():
         # Ensure the dag_processor log directory exists so Fluent Bit's tail
         # input does not error when scanning the glob. The directory is not
         # guaranteed to exist at container start.
-        dag_processor_dir = os.path.join(log_dir, "dag_processor")
-        os.makedirs(dag_processor_dir, exist_ok=True)
+        try:
+            dag_processor_dir = os.path.join(log_dir, "dag_processor")
+            os.makedirs(dag_processor_dir, exist_ok=True)
+        except Exception as e:
+            print(f"WARNING: Could not create {dag_processor_dir}: {e}")
 
 _fix_shared_log_volume_permissions()
 

--- a/images/airflow/3.0.6/python/mwaa/entrypoint.py
+++ b/images/airflow/3.0.6/python/mwaa/entrypoint.py
@@ -33,8 +33,8 @@ def _fix_shared_log_volume_permissions():
         # Ensure the dag_processor log directory exists so Fluent Bit's tail
         # input does not error when scanning the glob. The directory is not
         # guaranteed to exist at container start.
+        dag_processor_dir = os.path.join(log_dir, "dag_processor")
         try:
-            dag_processor_dir = os.path.join(log_dir, "dag_processor")
             os.makedirs(dag_processor_dir, exist_ok=True)
         except Exception as e:
             print(f"WARNING: Could not create {dag_processor_dir}: {e}")

--- a/images/airflow/3.2.0/python/mwaa/entrypoint.py
+++ b/images/airflow/3.2.0/python/mwaa/entrypoint.py
@@ -33,8 +33,11 @@ def _fix_shared_log_volume_permissions():
         # Ensure the dag_processor log directory exists so Fluent Bit's tail
         # input does not error when scanning the glob. The directory is not
         # guaranteed to exist at container start.
-        dag_processor_dir = os.path.join(log_dir, "dag_processor")
-        os.makedirs(dag_processor_dir, exist_ok=True)
+        try:
+            dag_processor_dir = os.path.join(log_dir, "dag_processor")
+            os.makedirs(dag_processor_dir, exist_ok=True)
+        except Exception as e:
+            print(f"WARNING: Could not create {dag_processor_dir}: {e}")
 
 _fix_shared_log_volume_permissions()
 

--- a/images/airflow/3.2.0/python/mwaa/entrypoint.py
+++ b/images/airflow/3.2.0/python/mwaa/entrypoint.py
@@ -33,8 +33,8 @@ def _fix_shared_log_volume_permissions():
         # Ensure the dag_processor log directory exists so Fluent Bit's tail
         # input does not error when scanning the glob. The directory is not
         # guaranteed to exist at container start.
+        dag_processor_dir = os.path.join(log_dir, "dag_processor")
         try:
-            dag_processor_dir = os.path.join(log_dir, "dag_processor")
             os.makedirs(dag_processor_dir, exist_ok=True)
         except Exception as e:
             print(f"WARNING: Could not create {dag_processor_dir}: {e}")

--- a/tests/images/airflow/2.10.1/python/mwaa/test_entrypoint_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/test_entrypoint_2_10_1.py
@@ -266,13 +266,17 @@ def test_mark_as_unhealthy_error(mock_environ):
 def test_fix_shared_log_volume_permissions_on_mount(mock_environ):
     """Test _fix_shared_log_volume_permissions runs chown when path is a mount point."""
     with patch('os.path.ismount', return_value=True) as mock_ismount, \
-         patch('subprocess.run') as mock_run:
+         patch('subprocess.run') as mock_run, \
+         patch('os.makedirs') as mock_makedirs:
         entrypoint._fix_shared_log_volume_permissions()
 
         mock_ismount.assert_called_once_with('/usr/local/airflow/logs')
         mock_run.assert_called_once_with(
             ['sudo', 'chown', '-R', 'airflow:', '/usr/local/airflow/logs'],
             check=True,
+        )
+        mock_makedirs.assert_called_once_with(
+            '/usr/local/airflow/logs/dag_processor', exist_ok=True
         )
 
 
@@ -289,6 +293,20 @@ def test_fix_shared_log_volume_permissions_not_mount(mock_environ):
 def test_fix_shared_log_volume_permissions_chown_failure(mock_environ):
     """Test _fix_shared_log_volume_permissions handles chown failure gracefully."""
     with patch('os.path.ismount', return_value=True), \
-         patch('subprocess.run', side_effect=Exception('Permission denied')):
+         patch('subprocess.run', side_effect=Exception('Permission denied')), \
+         patch('os.makedirs') as mock_makedirs:
+        # Should not raise — just prints a warning
+        entrypoint._fix_shared_log_volume_permissions()
+        # dag_processor dir creation should still be attempted after chown failure
+        mock_makedirs.assert_called_once_with(
+            '/usr/local/airflow/logs/dag_processor', exist_ok=True
+        )
+
+
+def test_fix_shared_log_volume_permissions_dag_processor_dir_failure(mock_environ):
+    """Test _fix_shared_log_volume_permissions handles dag_processor mkdir failure gracefully."""
+    with patch('os.path.ismount', return_value=True), \
+         patch('subprocess.run'), \
+         patch('os.makedirs', side_effect=OSError('Read-only file system')):
         # Should not raise — just prints a warning
         entrypoint._fix_shared_log_volume_permissions()

--- a/tests/images/airflow/2.10.3/python/mwaa/test_entrypoint_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/test_entrypoint_2_10_3.py
@@ -266,13 +266,17 @@ def test_mark_as_unhealthy_error(mock_environ):
 def test_fix_shared_log_volume_permissions_on_mount(mock_environ):
     """Test _fix_shared_log_volume_permissions runs chown when path is a mount point."""
     with patch('os.path.ismount', return_value=True) as mock_ismount, \
-         patch('subprocess.run') as mock_run:
+         patch('subprocess.run') as mock_run, \
+         patch('os.makedirs') as mock_makedirs:
         entrypoint._fix_shared_log_volume_permissions()
 
         mock_ismount.assert_called_once_with('/usr/local/airflow/logs')
         mock_run.assert_called_once_with(
             ['sudo', 'chown', '-R', 'airflow:', '/usr/local/airflow/logs'],
             check=True,
+        )
+        mock_makedirs.assert_called_once_with(
+            '/usr/local/airflow/logs/dag_processor', exist_ok=True
         )
 
 
@@ -289,6 +293,20 @@ def test_fix_shared_log_volume_permissions_not_mount(mock_environ):
 def test_fix_shared_log_volume_permissions_chown_failure(mock_environ):
     """Test _fix_shared_log_volume_permissions handles chown failure gracefully."""
     with patch('os.path.ismount', return_value=True), \
-         patch('subprocess.run', side_effect=Exception('Permission denied')):
+         patch('subprocess.run', side_effect=Exception('Permission denied')), \
+         patch('os.makedirs') as mock_makedirs:
+        # Should not raise — just prints a warning
+        entrypoint._fix_shared_log_volume_permissions()
+        # dag_processor dir creation should still be attempted after chown failure
+        mock_makedirs.assert_called_once_with(
+            '/usr/local/airflow/logs/dag_processor', exist_ok=True
+        )
+
+
+def test_fix_shared_log_volume_permissions_dag_processor_dir_failure(mock_environ):
+    """Test _fix_shared_log_volume_permissions handles dag_processor mkdir failure gracefully."""
+    with patch('os.path.ismount', return_value=True), \
+         patch('subprocess.run'), \
+         patch('os.makedirs', side_effect=OSError('Read-only file system')):
         # Should not raise — just prints a warning
         entrypoint._fix_shared_log_volume_permissions()

--- a/tests/images/airflow/2.11.0/python/mwaa/test_entrypoint_2_11_0.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/test_entrypoint_2_11_0.py
@@ -266,13 +266,17 @@ def test_mark_as_unhealthy_error(mock_environ):
 def test_fix_shared_log_volume_permissions_on_mount(mock_environ):
     """Test _fix_shared_log_volume_permissions runs chown when path is a mount point."""
     with patch('os.path.ismount', return_value=True) as mock_ismount, \
-         patch('subprocess.run') as mock_run:
+         patch('subprocess.run') as mock_run, \
+         patch('os.makedirs') as mock_makedirs:
         entrypoint._fix_shared_log_volume_permissions()
 
         mock_ismount.assert_called_once_with('/usr/local/airflow/logs')
         mock_run.assert_called_once_with(
             ['sudo', 'chown', '-R', 'airflow:', '/usr/local/airflow/logs'],
             check=True,
+        )
+        mock_makedirs.assert_called_once_with(
+            '/usr/local/airflow/logs/dag_processor', exist_ok=True
         )
 
 
@@ -289,6 +293,20 @@ def test_fix_shared_log_volume_permissions_not_mount(mock_environ):
 def test_fix_shared_log_volume_permissions_chown_failure(mock_environ):
     """Test _fix_shared_log_volume_permissions handles chown failure gracefully."""
     with patch('os.path.ismount', return_value=True), \
-         patch('subprocess.run', side_effect=Exception('Permission denied')):
+         patch('subprocess.run', side_effect=Exception('Permission denied')), \
+         patch('os.makedirs') as mock_makedirs:
+        # Should not raise — just prints a warning
+        entrypoint._fix_shared_log_volume_permissions()
+        # dag_processor dir creation should still be attempted after chown failure
+        mock_makedirs.assert_called_once_with(
+            '/usr/local/airflow/logs/dag_processor', exist_ok=True
+        )
+
+
+def test_fix_shared_log_volume_permissions_dag_processor_dir_failure(mock_environ):
+    """Test _fix_shared_log_volume_permissions handles dag_processor mkdir failure gracefully."""
+    with patch('os.path.ismount', return_value=True), \
+         patch('subprocess.run'), \
+         patch('os.makedirs', side_effect=OSError('Read-only file system')):
         # Should not raise — just prints a warning
         entrypoint._fix_shared_log_volume_permissions()

--- a/tests/images/airflow/2.9.2/python/mwaa/test_entrypoint_2_9_2.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/test_entrypoint_2_9_2.py
@@ -266,13 +266,17 @@ def test_mark_as_unhealthy_error(mock_environ):
 def test_fix_shared_log_volume_permissions_on_mount(mock_environ):
     """Test _fix_shared_log_volume_permissions runs chown when path is a mount point."""
     with patch('os.path.ismount', return_value=True) as mock_ismount, \
-         patch('subprocess.run') as mock_run:
+         patch('subprocess.run') as mock_run, \
+         patch('os.makedirs') as mock_makedirs:
         entrypoint._fix_shared_log_volume_permissions()
 
         mock_ismount.assert_called_once_with('/usr/local/airflow/logs')
         mock_run.assert_called_once_with(
             ['sudo', 'chown', '-R', 'airflow:', '/usr/local/airflow/logs'],
             check=True,
+        )
+        mock_makedirs.assert_called_once_with(
+            '/usr/local/airflow/logs/dag_processor', exist_ok=True
         )
 
 
@@ -289,6 +293,20 @@ def test_fix_shared_log_volume_permissions_not_mount(mock_environ):
 def test_fix_shared_log_volume_permissions_chown_failure(mock_environ):
     """Test _fix_shared_log_volume_permissions handles chown failure gracefully."""
     with patch('os.path.ismount', return_value=True), \
-         patch('subprocess.run', side_effect=Exception('Permission denied')):
+         patch('subprocess.run', side_effect=Exception('Permission denied')), \
+         patch('os.makedirs') as mock_makedirs:
+        # Should not raise — just prints a warning
+        entrypoint._fix_shared_log_volume_permissions()
+        # dag_processor dir creation should still be attempted after chown failure
+        mock_makedirs.assert_called_once_with(
+            '/usr/local/airflow/logs/dag_processor', exist_ok=True
+        )
+
+
+def test_fix_shared_log_volume_permissions_dag_processor_dir_failure(mock_environ):
+    """Test _fix_shared_log_volume_permissions handles dag_processor mkdir failure gracefully."""
+    with patch('os.path.ismount', return_value=True), \
+         patch('subprocess.run'), \
+         patch('os.makedirs', side_effect=OSError('Read-only file system')):
         # Should not raise — just prints a warning
         entrypoint._fix_shared_log_volume_permissions()

--- a/tests/images/airflow/3.0.6/python/mwaa/test_entrypoint.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/test_entrypoint.py
@@ -287,13 +287,17 @@ def test_mark_as_unhealthy_error(mock_environ):
 def test_fix_shared_log_volume_permissions_on_mount(mock_environ):
     """Test _fix_shared_log_volume_permissions runs chown when path is a mount point."""
     with patch('os.path.ismount', return_value=True) as mock_ismount, \
-         patch('subprocess.run') as mock_run:
+         patch('subprocess.run') as mock_run, \
+         patch('os.makedirs') as mock_makedirs:
         entrypoint._fix_shared_log_volume_permissions()
 
         mock_ismount.assert_called_once_with('/usr/local/airflow/logs')
         mock_run.assert_called_once_with(
             ['sudo', 'chown', '-R', 'airflow:', '/usr/local/airflow/logs'],
             check=True,
+        )
+        mock_makedirs.assert_called_once_with(
+            '/usr/local/airflow/logs/dag_processor', exist_ok=True
         )
 
 
@@ -310,7 +314,21 @@ def test_fix_shared_log_volume_permissions_not_mount(mock_environ):
 def test_fix_shared_log_volume_permissions_chown_failure(mock_environ):
     """Test _fix_shared_log_volume_permissions handles chown failure gracefully."""
     with patch('os.path.ismount', return_value=True), \
-         patch('subprocess.run', side_effect=Exception('Permission denied')):
+         patch('subprocess.run', side_effect=Exception('Permission denied')), \
+         patch('os.makedirs') as mock_makedirs:
+        # Should not raise — just logs a warning
+        entrypoint._fix_shared_log_volume_permissions()
+        # dag_processor dir creation should still be attempted after chown failure
+        mock_makedirs.assert_called_once_with(
+            '/usr/local/airflow/logs/dag_processor', exist_ok=True
+        )
+
+
+def test_fix_shared_log_volume_permissions_dag_processor_dir_failure(mock_environ):
+    """Test _fix_shared_log_volume_permissions handles dag_processor mkdir failure gracefully."""
+    with patch('os.path.ismount', return_value=True), \
+         patch('subprocess.run'), \
+         patch('os.makedirs', side_effect=OSError('Read-only file system')):
         # Should not raise — just logs a warning
         entrypoint._fix_shared_log_volume_permissions()
 

--- a/tests/images/airflow/3.2.0/python/mwaa/test_entrypoint.py
+++ b/tests/images/airflow/3.2.0/python/mwaa/test_entrypoint.py
@@ -290,13 +290,17 @@ def test_mark_as_unhealthy_error(mock_environ):
 def test_fix_shared_log_volume_permissions_on_mount(mock_environ):
     """Test _fix_shared_log_volume_permissions runs chown when path is a mount point."""
     with patch('os.path.ismount', return_value=True) as mock_ismount, \
-         patch('subprocess.run') as mock_run:
+         patch('subprocess.run') as mock_run, \
+         patch('os.makedirs') as mock_makedirs:
         entrypoint._fix_shared_log_volume_permissions()
 
         mock_ismount.assert_called_once_with('/usr/local/airflow/logs')
         mock_run.assert_called_once_with(
             ['sudo', 'chown', '-R', 'airflow:', '/usr/local/airflow/logs'],
             check=True,
+        )
+        mock_makedirs.assert_called_once_with(
+            '/usr/local/airflow/logs/dag_processor', exist_ok=True
         )
 
 
@@ -313,7 +317,21 @@ def test_fix_shared_log_volume_permissions_not_mount(mock_environ):
 def test_fix_shared_log_volume_permissions_chown_failure(mock_environ):
     """Test _fix_shared_log_volume_permissions handles chown failure gracefully."""
     with patch('os.path.ismount', return_value=True), \
-         patch('subprocess.run', side_effect=Exception('Permission denied')):
+         patch('subprocess.run', side_effect=Exception('Permission denied')), \
+         patch('os.makedirs') as mock_makedirs:
+        # Should not raise — just logs a warning
+        entrypoint._fix_shared_log_volume_permissions()
+        # dag_processor dir creation should still be attempted after chown failure
+        mock_makedirs.assert_called_once_with(
+            '/usr/local/airflow/logs/dag_processor', exist_ok=True
+        )
+
+
+def test_fix_shared_log_volume_permissions_dag_processor_dir_failure(mock_environ):
+    """Test _fix_shared_log_volume_permissions handles dag_processor mkdir failure gracefully."""
+    with patch('os.path.ismount', return_value=True), \
+         patch('subprocess.run'), \
+         patch('os.makedirs', side_effect=OSError('Read-only file system')):
         # Should not raise — just logs a warning
         entrypoint._fix_shared_log_volume_permissions()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add simple error handling around the new line that create a directory in the case the log folder is mounted

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
