### PR TITLE
Clarify PowerShell 5.1 support for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Airflow should be up and running now. You can access the web server on your loca
 
 ---
 
-### Windows (PowerShell 5.1)
+### Windows (PowerShell 5.1) [Not supported by AWS MWAA Service Team]
 
 #### Prerequisites
 


### PR DESCRIPTION
Added note about AWS MWAA Service Team not supporting PowerShell 5.1.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
