### PR TITLE
AF 3.2.1 - support gunicorn server type

### DIFF
--- a/images/airflow/3.2.1/bootstrap/02-airflow/001-install-required-pip-packages.sh
+++ b/images/airflow/3.2.1/bootstrap/02-airflow/001-install-required-pip-packages.sh
@@ -8,6 +8,7 @@ source /bootstrap/common.sh
 REQUIRED_PACKAGES=(
     "apache-airflow-providers-amazon[aiobotocore]"
     "apache-airflow[celery,statsd]==${AIRFLOW_VERSION}"
+    "apache-airflow-core[gunicorn]==${AIRFLOW_VERSION}"
     "apache-airflow-providers-postgres"
     "apache-airflow-providers-fab"
     "celery[sqs]"

--- a/images/airflow/3.2.1/healthcheck.py
+++ b/images/airflow/3.2.1/healthcheck.py
@@ -64,10 +64,10 @@ def get_airflow_process_command(airflow_component: str) -> List[str]:
     # Use 'airflow api_server' instead of '/usr/local/airflow/.local/bin/airflow api-server' because setproctitle()
     # renames the process. See: airflow/cli/commands/api_server_command.py#L105 in Airflow source
     if airflow_component == "ADDITIONAL_WEBSERVER":
-        return ["airflow api_server"]
+        return ["airflow api_server", "gunicorn"]
 
     if airflow_component == "WEB_SERVER":
-        return ["airflow api_server"]
+        return ["airflow api_server", "gunicorn"]
 
     exit_with_status(ExitStatus.INVALID_AIRFLOW_COMPONENT)
     # This return will never be reached due to sys.exit() in exit_with_status

--- a/images/airflow/3.2.1/python/mwaa/config/airflow.py
+++ b/images/airflow/3.2.1/python/mwaa/config/airflow.py
@@ -122,7 +122,6 @@ def _get_opinionated_airflow_api_config() -> Dict[str, str]:
     """
 
     return {
-        "AIRFLOW__API__WORKERS": "2",
         "AIRFLOW__API__SERVER_TYPE": "gunicorn",
         "AIRFLOW__API__WORKER_REFRESH_INTERVAL": "43200",
         "AIRFLOW__API__WORKER_REFRESH_BATCH_SIZE": "1"

--- a/images/airflow/3.2.1/python/mwaa/config/airflow.py
+++ b/images/airflow/3.2.1/python/mwaa/config/airflow.py
@@ -111,7 +111,21 @@ def _get_opinionated_airflow_core_config() -> Dict[str, str]:
 
     return {
         "AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER": "True",
-        "AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES": "proxy,proxies",
+        "AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES": "proxy,proxies"
+    }
+
+def _get_opinionated_airflow_api_config() -> Dict[str, str]:
+    """
+    Retrieve the environment variables for Airflow's "api" configuration section.
+
+    :returns A dictionary containing the environment variables.
+    """
+
+    return {
+        "AIRFLOW__API__WORKERS": "2",
+        "AIRFLOW__API__SERVER_TYPE": "gunicorn",
+        "AIRFLOW__API__WORKER_REFRESH_INTERVAL": "43200",
+        "AIRFLOW__API__WORKER_REFRESH_BATCH_SIZE": "1"
     }
 
 
@@ -408,6 +422,7 @@ def get_opinionated_airflow_config() -> Dict[str, str]:
     """
     return {
         **_get_opinionated_airflow_core_config(),
+        **_get_opinionated_airflow_api_config(),
         **_get_opinionated_airflow_scheduler_config(),
         **_get_opinionated_airflow_secrets_config(),
         **_get_opinionated_airflow_usage_data_config(),

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_airflow.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_airflow.py
@@ -128,7 +128,6 @@ def test_get_opinionated_airflow_api_config():
     result = _get_opinionated_airflow_api_config()
 
     expected = {
-        "AIRFLOW__API__WORKERS": "2",
         "AIRFLOW__API__SERVER_TYPE": "gunicorn",
         "AIRFLOW__API__WORKER_REFRESH_INTERVAL": "43200",
         "AIRFLOW__API__WORKER_REFRESH_BATCH_SIZE": "1",

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_airflow.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_airflow.py
@@ -8,6 +8,7 @@ from mwaa.config.airflow import (
     _get_essential_airflow_executor_config,
     _get_essential_airflow_core_config,
     _get_opinionated_airflow_core_config,
+    _get_opinionated_airflow_api_config,
     get_user_airflow_config,
     _get_essential_airflow_db_config,
     _get_opinionated_airflow_db_config,
@@ -119,6 +120,38 @@ def test_get_opinionated_airflow_core_config():
 
     assert result["AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER"] == "True"
     assert result["AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES"] == "proxy,proxies"
+
+# ---------------------------------
+# Opinionated Airflow API Config Tests
+# ---------------------------------
+def test_get_opinionated_airflow_api_config():
+    result = _get_opinionated_airflow_api_config()
+
+    expected = {
+        "AIRFLOW__API__WORKERS": "2",
+        "AIRFLOW__API__SERVER_TYPE": "gunicorn",
+        "AIRFLOW__API__WORKER_REFRESH_INTERVAL": "43200",
+        "AIRFLOW__API__WORKER_REFRESH_BATCH_SIZE": "1",
+    }
+    assert result == expected
+
+
+def test_get_opinionated_airflow_api_config_keys_are_airflow_api_section():
+    """All keys must belong to the AIRFLOW__API__ section."""
+    result = _get_opinionated_airflow_api_config()
+
+    for key in result:
+        assert key.startswith("AIRFLOW__API__"), (
+            f"Key {key} does not belong to the AIRFLOW__API__ section"
+        )
+
+
+def test_get_opinionated_airflow_api_config_values_are_strings():
+    """All values must be strings (Airflow env-var convention)."""
+    result = _get_opinionated_airflow_api_config()
+
+    for key, value in result.items():
+        assert isinstance(value, str), f"Value for {key} is not a string: {type(value)}"
 
 # ---------------------------------
 # User Airflow Config Tests
@@ -556,6 +589,12 @@ def test_get_opinionated_airflow_config_merges(monkeypatch):
 
     monkeypatch.setattr(
         airflow,
+        "_get_opinionated_airflow_api_config",
+        lambda: {"API": "1"},
+    )
+
+    monkeypatch.setattr(
+        airflow,
         "_get_opinionated_airflow_scheduler_config",
         lambda: {"SCHEDULER": "1"},
     )
@@ -582,6 +621,7 @@ def test_get_opinionated_airflow_config_merges(monkeypatch):
 
     assert result == {
         "CORE": "1",
+        "API": "1",
         "SCHEDULER": "1",
         "SECRETS": "1",
         "USAGE": "1",


### PR DESCRIPTION
*Issue # (if available):*

*Description of changes:*
- Added support for server type = gunicorn for Airflow 3.2.1 image
- Added corresponding unit test
- We will add the number of workers based on environment class in the Applier and not here

*List any breaking changes for*
* *The Environment runtime*:
* *The local development experience*:


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.