### PR TITLE
Revert "Add localhost/ prefix to local image refs to prevent Docker Hub fallback"

### DIFF
--- a/images/airflow/3.2.1/Dockerfile.derivatives.j2
+++ b/images/airflow/3.2.1/Dockerfile.derivatives.j2
@@ -1,4 +1,4 @@
-FROM localhost/amazon-mwaa-docker-images/airflow:3.2.1-base
+FROM amazon-mwaa-docker-images/airflow:3.2.1-base
 
 {% if bootstrapping_scripts_dev %}
 

--- a/images/airflow/3.2.1/Dockerfiles/Dockerfile
+++ b/images/airflow/3.2.1/Dockerfiles/Dockerfile
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM localhost/amazon-mwaa-docker-images/airflow:3.2.1-base
+FROM amazon-mwaa-docker-images/airflow:3.2.1-base
 
 USER airflow
 

--- a/images/airflow/3.2.1/Dockerfiles/Dockerfile-dev
+++ b/images/airflow/3.2.1/Dockerfiles/Dockerfile-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM localhost/amazon-mwaa-docker-images/airflow:3.2.1-base
+FROM amazon-mwaa-docker-images/airflow:3.2.1-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer
+++ b/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM localhost/amazon-mwaa-docker-images/airflow:3.2.1-base
+FROM amazon-mwaa-docker-images/airflow:3.2.1-base
 
 USER airflow
 

--- a/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer-dev
+++ b/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM localhost/amazon-mwaa-docker-images/airflow:3.2.1-base
+FROM amazon-mwaa-docker-images/airflow:3.2.1-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer-privileged
+++ b/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer-privileged
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM localhost/amazon-mwaa-docker-images/airflow:3.2.1-base
+FROM amazon-mwaa-docker-images/airflow:3.2.1-base
 
 USER root
 

--- a/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer-privileged-dev
+++ b/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer-privileged-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM localhost/amazon-mwaa-docker-images/airflow:3.2.1-base
+FROM amazon-mwaa-docker-images/airflow:3.2.1-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/3.2.1/build.ps1
+++ b/images/airflow/3.2.1/build.ps1
@@ -102,7 +102,7 @@ if ($GenerateBom -eq "True") {
 # ---------------------------------------------------------------------------
 # Build base image
 # ---------------------------------------------------------------------------
-& $ContainerRuntime build -f .\Dockerfiles\Dockerfile.base -t localhost/amazon-mwaa-docker-images/airflow:3.2.1-base .\
+& $ContainerRuntime build -f .\Dockerfiles\Dockerfile.base -t amazon-mwaa-docker-images/airflow:3.2.1-base .\
 if ($LASTEXITCODE -ne 0) { throw "Failed to build base image." }
 
 # ---------------------------------------------------------------------------

--- a/images/airflow/3.2.1/build.sh
+++ b/images/airflow/3.2.1/build.sh
@@ -23,7 +23,7 @@ if [[ "$GENERATE_BILL_OF_MATERIALS" == "True" ]]; then
 fi
 
 # Build the base image.
-${CONTAINER_RUNTIME} build -f ./Dockerfiles/Dockerfile.base -t localhost/amazon-mwaa-docker-images/airflow:3.2.1-base ./
+${CONTAINER_RUNTIME} build -f ./Dockerfiles/Dockerfile.base -t amazon-mwaa-docker-images/airflow:3.2.1-base ./
 
 
 # Build the derivatives.


### PR DESCRIPTION
Reverts aws/amazon-mwaa-docker-images#483

Currently causing `[FATAL tini (6)] exec migrate-db failed: No such file or directory` with ImageBuild. The fix will be taken on at a later time. 