### PR TITLE
Fix filtering log levels for Airflow 3.2.1+ structlog

### DIFF
--- a/images/airflow/3.2.1/python/mwaa/subprocess/subprocess.py
+++ b/images/airflow/3.2.1/python/mwaa/subprocess/subprocess.py
@@ -61,12 +61,14 @@ _LEVEL_MAP = {
 }
 
 
-def _parse_log_level(line: str) -> int:
+def _parse_log_level(line: str) -> Optional[int]:
     """
     Parse the log level from a subprocess output line.
 
-    Supports both structlog format and standard Airflow log format.
-    Returns logging.INFO if the level cannot be determined.
+    Supports both structlog and standard Airflow log formats. Returns ``None``
+    when no level prefix is present so the caller can inherit the last
+    recognized level (for example, a traceback body that follows an ``[error]``
+    header).
     """
     # Try structlog format first (most common in Airflow 3.1+)
     m = _STRUCTLOG_LEVEL_RE.search(line)
@@ -76,7 +78,7 @@ def _parse_log_level(line: str) -> int:
     m = _STANDARD_LOG_LEVEL_RE.search(line)
     if m:
         return logging.getLevelName(m.group(1))
-    return logging.INFO
+    return None
 
 
 _ALL_SUBPROCESSES: List["Subprocess"] = []
@@ -242,15 +244,18 @@ class Subprocess:
         If stream is empty but process is still running then sleep
         for small duration to avoid wasted cpu resources.
 
-        Log lines are parsed to extract their actual severity level and filtered
-        against the configured AIRFLOW_CONSOLE_LOG_LEVEL threshold. This is necessary
-        because Airflow 3.x uses structlog which outputs all levels to stdout
-        regardless of configuration.
+        Log lines are parsed to extract their severity level and filtered
+        against the configured AIRFLOW_CONSOLE_LOG_LEVEL threshold, because
+        Airflow 3.x uses structlog which outputs all levels to stdout
+        regardless of configuration. Lines without a recognizable level
+        prefix inherit the last recognized level so multi-line messages
+        (for example, tracebacks) are not split across thresholds.
         """
         stream = process.stdout
         configured_level = logging.getLevelName(
             os.environ.get('AIRFLOW_CONSOLE_LOG_LEVEL', 'INFO')
         )
+        last_level = logging.INFO
         while True:
             if not stream or stream.closed:
                 break
@@ -262,7 +267,12 @@ class Subprocess:
                     time.sleep(_SUBPROCESS_LOG_POLL_IDLE_SLEEP_INTERVAL.total_seconds())
             else:
                 decoded_line = line.decode("utf-8", errors="replace").rstrip()
-                line_level = _parse_log_level(decoded_line)
+                parsed_level = _parse_log_level(decoded_line)
+                if parsed_level is not None:
+                    last_level = parsed_level
+                    line_level = parsed_level
+                else:
+                    line_level = last_level
                 if line_level >= configured_level:
                     if line_level >= logging.ERROR:
                         self.process_logger.error(decoded_line)

--- a/images/airflow/3.2.1/python/mwaa/subprocess/subprocess.py
+++ b/images/airflow/3.2.1/python/mwaa/subprocess/subprocess.py
@@ -16,6 +16,7 @@ import atexit
 import fcntl
 import logging
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -38,6 +39,44 @@ _SUBPROCESS_LOG_POLL_IDLE_SLEEP_INTERVAL = timedelta(milliseconds=100)
 
 
 module_logger = logging.getLogger(__name__)
+
+
+# Patterns to extract log level from subprocess output lines.
+# Airflow standard format: "[2025-01-01 00:00:00 +0000] {module.py:123} INFO - message"
+_STANDARD_LOG_LEVEL_RE = re.compile(
+    r"\}\s*(DEBUG|INFO|WARNING|ERROR|CRITICAL)\s*[-–]"
+)
+# Structlog format: "2026-05-06T01:00:14.610844Z [info     ] message"
+# The level is in brackets with optional trailing spaces after a timestamp.
+_STRUCTLOG_LEVEL_RE = re.compile(
+    r"\[(debug|info|warning|error|critical)\s*\]"
+)
+
+_LEVEL_MAP = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
+
+
+def _parse_log_level(line: str) -> int:
+    """
+    Parse the log level from a subprocess output line.
+
+    Supports both structlog format and standard Airflow log format.
+    Returns logging.INFO if the level cannot be determined.
+    """
+    # Try structlog format first (most common in Airflow 3.1+)
+    m = _STRUCTLOG_LEVEL_RE.search(line)
+    if m:
+        return _LEVEL_MAP.get(m.group(1).lower(), logging.INFO)
+    # Try standard Airflow format (legacy)
+    m = _STANDARD_LOG_LEVEL_RE.search(line)
+    if m:
+        return logging.getLevelName(m.group(1))
+    return logging.INFO
 
 
 _ALL_SUBPROCESSES: List["Subprocess"] = []
@@ -202,8 +241,16 @@ class Subprocess:
         until process has terminated and stream is empty.
         If stream is empty but process is still running then sleep
         for small duration to avoid wasted cpu resources.
+
+        Log lines are parsed to extract their actual severity level and filtered
+        against the configured AIRFLOW_CONSOLE_LOG_LEVEL threshold. This is necessary
+        because Airflow 3.x uses structlog which outputs all levels to stdout
+        regardless of configuration.
         """
         stream = process.stdout
+        configured_level = logging.getLevelName(
+            os.environ.get('AIRFLOW_CONSOLE_LOG_LEVEL', 'INFO')
+        )
         while True:
             if not stream or stream.closed:
                 break
@@ -214,14 +261,14 @@ class Subprocess:
                 else:
                     time.sleep(_SUBPROCESS_LOG_POLL_IDLE_SLEEP_INTERVAL.total_seconds())
             else:
-                log_level = os.environ['AIRFLOW_CONSOLE_LOG_LEVEL']
                 decoded_line = line.decode("utf-8", errors="replace").rstrip()
-                match log_level:
-                    case "ERROR":
+                line_level = _parse_log_level(decoded_line)
+                if line_level >= configured_level:
+                    if line_level >= logging.ERROR:
                         self.process_logger.error(decoded_line)
-                    case "WARNING":
+                    elif line_level >= logging.WARNING:
                         self.process_logger.warning(decoded_line)
-                    case _:
+                    else:
                         self.process_logger.info(decoded_line)
     
     def _get_subprocess_status(self, process: Popen[Any]):

--- a/tests/images/airflow/3.2.1/python/mwaa/logging/test_subprocess.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/logging/test_subprocess.py
@@ -33,9 +33,10 @@ class TestParseLogLevel:
         ("[2025-01-01 00:00:00 +0000] {scheduler_job_runner.py:123} INFO - msg", logging.INFO),
         ("[2025-01-01 00:00:00 +0000] {scheduler_job_runner.py:123} WARNING - msg", logging.WARNING),
         ("[2025-01-01 00:00:00 +0000] {scheduler_job_runner.py:123} ERROR - msg", logging.ERROR),
-        # Unrecognized defaults to INFO
-        ("Some random output without a level indicator", logging.INFO),
-        ("================================================================================", logging.INFO),
+        # Unrecognized returns None so the caller can inherit the last recognized level.
+        ("Some random output without a level indicator", None),
+        ("================================================================================", None),
+        ("Traceback (most recent call last):", None),
     ])
     def test_parse_log_level(self, line, expected):
         assert _parse_log_level(line) == expected
@@ -56,7 +57,11 @@ class TestReadSubprocessLogStream:
         subprocess_instance.process_logger.info.assert_not_called()
 
     def test_mixed_levels_filtered_at_warning(self, subprocess_instance):
-        """Only WARNING+ lines pass when threshold is WARNING"""
+        """Only WARNING+ lines pass when threshold is WARNING.
+
+        The trailing unrecognized line inherits ERROR from the preceding
+        legacy ERROR line.
+        """
         mock_process = Mock(spec=Popen)
         mock_process.stdout = BytesIO(
             b"2026-05-06T01:00:14Z [info     ] should be filtered\n"
@@ -74,7 +79,8 @@ class TestReadSubprocessLogStream:
 
         subprocess_instance.process_logger.info.assert_not_called()
         assert subprocess_instance.process_logger.warning.call_count == 1
-        assert subprocess_instance.process_logger.error.call_count == 2
+        # 2 explicit ERROR lines + 1 unrecognized line inheriting ERROR.
+        assert subprocess_instance.process_logger.error.call_count == 3
 
     def test_all_lines_pass_at_info_level(self, subprocess_instance):
         """All lines pass when threshold is INFO (including unrecognized)"""
@@ -110,3 +116,57 @@ class TestReadSubprocessLogStream:
 
         assert mock_process.poll.call_count == 3
         subprocess_instance.process_logger.warning.assert_called_once()
+
+    def test_traceback_continuation_after_error_header_at_warning(self, subprocess_instance):
+        """Traceback lines after an [error] header inherit ERROR and survive WARNING."""
+        mock_process = Mock(spec=Popen)
+        mock_process.stdout = BytesIO(
+            b"2026-05-06T01:00:14Z [error    ] boom\n"
+            b"Traceback (most recent call last):\n"
+            b'  File "<test>", line 1, in <module>\n'
+            b'    raise ValueError("simulated failure")\n'
+            b"ValueError: simulated failure\n"
+        )
+        mock_process.poll.return_value = 0
+
+        subprocess_instance.process_logger = Mock()
+        with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'WARNING'}):
+            subprocess_instance._read_subprocess_log_stream(mock_process)
+
+        assert subprocess_instance.process_logger.error.call_count == 5
+        subprocess_instance.process_logger.info.assert_not_called()
+        subprocess_instance.process_logger.warning.assert_not_called()
+
+    @pytest.mark.parametrize("threshold,expected_info,expected_warning,expected_error", [
+        # Routing: DEBUG/INFO -> .info(), WARNING -> .warning(), ERROR/CRITICAL -> .error().
+        # Lines below `configured_level` are dropped before routing.
+        ("DEBUG",    2, 1, 2),
+        ("INFO",     1, 1, 2),
+        ("WARNING",  0, 1, 2),
+        ("ERROR",    0, 0, 2),
+        # [critical] passes and is routed via .error() (levelno=40); the
+        # downstream handler configured at CRITICAL=50 will drop it. No
+        # CRITICAL bucket in _read_subprocess_log_stream.
+        ("CRITICAL", 0, 0, 1),
+    ])
+    def test_threshold_sweep(
+        self, subprocess_instance, threshold, expected_info, expected_warning, expected_error
+    ):
+        """Filter behavior across all five AIRFLOW_CONSOLE_LOG_LEVEL values."""
+        mock_process = Mock(spec=Popen)
+        mock_process.stdout = BytesIO(
+            b"2026-05-06T01:00:14Z [debug    ] d\n"
+            b"2026-05-06T01:00:14Z [info     ] i\n"
+            b"2026-05-06T01:00:14Z [warning  ] w\n"
+            b"2026-05-06T01:00:14Z [error    ] e\n"
+            b"2026-05-06T01:00:14Z [critical ] c\n"
+        )
+        mock_process.poll.return_value = 0
+
+        subprocess_instance.process_logger = Mock()
+        with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': threshold}):
+            subprocess_instance._read_subprocess_log_stream(mock_process)
+
+        assert subprocess_instance.process_logger.info.call_count == expected_info
+        assert subprocess_instance.process_logger.warning.call_count == expected_warning
+        assert subprocess_instance.process_logger.error.call_count == expected_error

--- a/tests/images/airflow/3.2.1/python/mwaa/logging/test_subprocess.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/logging/test_subprocess.py
@@ -1,149 +1,112 @@
 import pytest
-from unittest.mock import patch, Mock, call
+from unittest.mock import patch, Mock
 import os
+import logging
 from io import BytesIO
 from subprocess import Popen
-from mwaa.subprocess.subprocess import Subprocess, _SUBPROCESS_LOG_POLL_IDLE_SLEEP_INTERVAL
-import time
+from mwaa.subprocess.subprocess import (
+    Subprocess,
+    _parse_log_level,
+)
+
 
 @pytest.fixture
 def subprocess_instance():
-    """Fixture to create a Subprocess instance with mock command"""
     return Subprocess(cmd="test_command")
 
-@pytest.fixture
-def mock_process(mocker):
-    """Fixture to create a mock process"""
-    process = mocker.Mock(spec=Popen)
-    process.poll.side_effect = [None, None, 0]  # Process runs for 2 iterations then ends
-    process.stdout = mocker.Mock()
-    process.stdout.readline.return_value = b'test output\n'
-    return process
 
-@pytest.fixture
-def mock_logger(mocker):
-    """Fixture to create a mock logger"""
-    return mocker.Mock()
+class TestParseLogLevel:
+    """Tests for _parse_log_level: structlog (padded), structlog (compact), legacy, and fallback."""
 
-
-def test_read_subprocess_log_stream_empty_stream(subprocess_instance):
-    """Test behavior when stream is None"""
-    # Create mock process with None stdout
-    mock_process = Mock(spec=Popen)
-    mock_process.stdout = None
-
-    subprocess_instance.process_logger = Mock()
-    subprocess_instance._read_subprocess_log_stream(mock_process)
-
-    # Assert no logging calls were made
-    subprocess_instance.process_logger.info.assert_not_called()
-    subprocess_instance.process_logger.error.assert_not_called()
-    subprocess_instance.process_logger.warning.assert_not_called()
+    @pytest.mark.parametrize("line,expected", [
+        # Structlog with timestamp and padding (production format in 3.1+)
+        ("2026-05-06T01:00:14.610844Z [info     ] Filling up the DagBag", logging.INFO),
+        ("2026-05-06T01:00:14.610844Z [warning  ] Something concerning", logging.WARNING),
+        ("2026-05-06T01:00:14.610844Z [error    ] Failed to process", logging.ERROR),
+        ("2026-05-06T01:00:14.610844Z [critical ] Fatal error", logging.CRITICAL),
+        ("2026-05-06T01:00:14.610844Z [debug    ] Verbose output", logging.DEBUG),
+        # Structlog compact (no padding)
+        ("[info] request finished [http.access]", logging.INFO),
+        ("[warning] something concerning [some.logger]", logging.WARNING),
+        ("[error] something failed [some.logger]", logging.ERROR),
+        # Legacy Airflow format
+        ("[2025-01-01 00:00:00 +0000] {scheduler_job_runner.py:123} INFO - msg", logging.INFO),
+        ("[2025-01-01 00:00:00 +0000] {scheduler_job_runner.py:123} WARNING - msg", logging.WARNING),
+        ("[2025-01-01 00:00:00 +0000] {scheduler_job_runner.py:123} ERROR - msg", logging.ERROR),
+        # Unrecognized defaults to INFO
+        ("Some random output without a level indicator", logging.INFO),
+        ("================================================================================", logging.INFO),
+    ])
+    def test_parse_log_level(self, line, expected):
+        assert _parse_log_level(line) == expected
 
 
-def test_read_subprocess_log_stream_process_running(mocker, subprocess_instance, mock_process, mock_logger):
-    """Test that read_subprocess_log_stream correctly handles a running process"""
-    # Setup
-    subprocess_instance.process_logger = mock_logger
-    mock_process.stdout.closed = False
+class TestReadSubprocessLogStream:
+    """Tests for _read_subprocess_log_stream filtering behavior."""
 
-    # Simulate the following sequence:
-    # 1. Read output line, process running
-    # 2. Read empty line, process running (triggers sleep)
-    # 3. Read empty line, process finished (breaks loop)
-    mock_process.poll.side_effect = [None, None, 0]
-    mock_process.stdout.readline.side_effect = [
-        b'test output\n',
-        b'',
-        b'',
-        b''
-    ]
+    def test_null_and_closed_stream(self, subprocess_instance):
+        """No logging when stream is None or closed"""
+        subprocess_instance.process_logger = Mock()
 
-    # Act
-    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'INFO'}):
-        subprocess_instance._read_subprocess_log_stream(mock_process)
+        for stdout in [None, Mock(closed=True)]:
+            mock_process = Mock(spec=Popen)
+            mock_process.stdout = stdout
+            subprocess_instance._read_subprocess_log_stream(mock_process)
 
-    # Assert
-    assert mock_process.poll.call_count == 3
-    mock_logger.info.assert_called_once_with('test output')
+        subprocess_instance.process_logger.info.assert_not_called()
 
+    def test_mixed_levels_filtered_at_warning(self, subprocess_instance):
+        """Only WARNING+ lines pass when threshold is WARNING"""
+        mock_process = Mock(spec=Popen)
+        mock_process.stdout = BytesIO(
+            b"2026-05-06T01:00:14Z [info     ] should be filtered\n"
+            b"2026-05-06T01:00:15Z [warning  ] should pass as warning\n"
+            b"2026-05-06T01:00:16Z [error    ] should pass as error\n"
+            b"[2025-01-01 00:00:00 +0000] {m.py:1} INFO - filtered legacy\n"
+            b"[2025-01-01 00:00:00 +0000] {m.py:2} ERROR - pass legacy\n"
+            b"Some unrecognized line\n"
+        )
+        mock_process.poll.return_value = 0
 
-def test_read_subprocess_log_stream_closed_stream(subprocess_instance):
-    """Test behavior when stream is closed"""
-    # Create and configure mock process
-    mock_process = Mock(spec=Popen)
-    mock_process.stdout = Mock()
-    mock_process.stdout.closed = True
+        subprocess_instance.process_logger = Mock()
+        with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'WARNING'}):
+            subprocess_instance._read_subprocess_log_stream(mock_process)
 
-    subprocess_instance.process_logger = Mock()
-    subprocess_instance._read_subprocess_log_stream(mock_process)
+        subprocess_instance.process_logger.info.assert_not_called()
+        assert subprocess_instance.process_logger.warning.call_count == 1
+        assert subprocess_instance.process_logger.error.call_count == 2
 
-    subprocess_instance.process_logger.info.assert_not_called()
+    def test_all_lines_pass_at_info_level(self, subprocess_instance):
+        """All lines pass when threshold is INFO (including unrecognized)"""
+        mock_process = Mock(spec=Popen)
+        mock_process.stdout = BytesIO(
+            b"2026-05-06T01:00:14Z [info     ] structlog info\n"
+            b"Some random output\n"
+        )
+        mock_process.poll.return_value = 0
 
+        subprocess_instance.process_logger = Mock()
+        with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'INFO'}):
+            subprocess_instance._read_subprocess_log_stream(mock_process)
 
-def test_read_subprocess_log_stream_process_terminated(subprocess_instance):
-    """Test behavior when process has terminated"""
-    # Create and configure mock process
-    mock_process = Mock(spec=Popen)
-    mock_process.stdout = BytesIO(b"final message\n")
-    mock_process.poll.return_value = 0
+        assert subprocess_instance.process_logger.info.call_count == 2
 
-    subprocess_instance.process_logger = Mock()
+    def test_empty_reads_while_running(self, mocker, subprocess_instance):
+        """Empty reads while process is running trigger sleep, not exit"""
+        mock_process = mocker.Mock(spec=Popen)
+        mock_process.stdout = mocker.Mock()
+        mock_process.stdout.closed = False
+        mock_process.poll.side_effect = [None, None, 0]
+        mock_process.stdout.readline.side_effect = [
+            b"2026-05-06T01:00:14Z [warning  ] test\n",
+            b'',
+            b'',
+            b''
+        ]
 
-    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'INFO'}):
-        subprocess_instance._read_subprocess_log_stream(mock_process)
+        subprocess_instance.process_logger = Mock()
+        with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'WARNING'}):
+            subprocess_instance._read_subprocess_log_stream(mock_process)
 
-    subprocess_instance.process_logger.info.assert_called_once_with("final message")
-
-
-def test_read_subprocess_log_stream_process_error(mocker, subprocess_instance, mock_process, mock_logger):
-    """Test that read_subprocess_log_stream correctly handles error log level"""
-    # Setup
-    subprocess_instance.process_logger = mock_logger
-    mock_process.stdout.closed = False
-
-    # Simulate the following sequence:
-    # 1. Read output line, process running
-    # 2. Read empty line, process running (triggers sleep)
-    # 3. Read empty line, process finished (breaks loop)
-    mock_process.poll.side_effect = [None, None, 0]
-    mock_process.stdout.readline.side_effect = [
-        b'test output\n',
-        b'',
-        b'',
-        b''
-    ]
-
-    # Act
-    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'ERROR'}):
-        subprocess_instance._read_subprocess_log_stream(mock_process)
-
-    # Assert
-    assert mock_process.poll.call_count == 3
-    mock_logger.error.assert_called_once_with('test output')
-
-def test_read_subprocess_log_stream_process_warning(mocker, subprocess_instance, mock_process, mock_logger):
-    """Test that read_subprocess_log_stream correctly handles warning log level"""
-    # Setup
-    subprocess_instance.process_logger = mock_logger
-    mock_process.stdout.closed = False
-
-    # Simulate the following sequence:
-    # 1. Read output line, process running
-    # 2. Read empty line, process running (triggers sleep)
-    # 3. Read empty line, process finished (breaks loop)
-    mock_process.poll.side_effect = [None, None, 0]
-    mock_process.stdout.readline.side_effect = [
-        b'test output\n',
-        b'',
-        b'',
-        b''
-    ]
-
-    # Act
-    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'WARNING'}):
-        subprocess_instance._read_subprocess_log_stream(mock_process)
-
-    # Assert
-    assert mock_process.poll.call_count == 3
-    mock_logger.warning.assert_called_once_with('test output')
+        assert mock_process.poll.call_count == 3
+        subprocess_instance.process_logger.warning.assert_called_once()


### PR DESCRIPTION
# Description
Airflow 3.1+ uses structlog which outputs all levels to stdout, ignoring `AIRFLOW_CONSOLE_LOG_LEVEL`. The previous code only controlled which logger method to call but never filtered lines below the threshold.

This adds `_parse_log_level()` to extract severity from both structlog (`[info     ]`) and legacy (`{module.py:123} INFO -`) formats, then drops lines below the configured threshold in `_read_subprocess_log_stream()`.

# Testing
Unit tests rewritten to cover parsing and filtering behavior.
Verified with local image.

Example of filtering for warning: 
<img width="1462" height="544" alt="image" src="https://github.com/user-attachments/assets/6903610c-58cc-44a6-b65f-58225ec5f0f9" />
