### PR TITLE
Fix Non-Critical Logging deadlock issue caused by usage of non fork-safe locks

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -33,71 +33,14 @@ from fluent import asynchandler as fluent_handler
 from fluent import asyncsender
 
 # Our imports
+from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
 from mwaa.logging.utils import parse_arn, throttle
 from mwaa.utils.statsd import get_statsd
 
 USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 
-
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
-
-
-class ForkSafeFluentSender(asyncsender.FluentSender):
-    """
-    A FluentSender subclass that is safe to inherit across fork().
-
-    The base FluentSender uses threading.Lock and Queue (which also uses
-    threading.Lock internally). These locks are not fork-safe: if a thread
-    holds one at fork time, the child inherits it locked with no thread to
-    release it, causing a permanent deadlock on futex.
-
-    This subclass registers an os.register_at_fork() callback that
-    reinitializes these locks in the child process after fork. This follows
-    the same pattern Python's logging.Handler uses to make its RLock
-    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Use a weakref so this callback doesn't prevent the sender from being
-        # garbage collected. os.register_at_fork callbacks are never unregistered,
-        # so a strong reference would keep the sender alive forever.
-        weak_self = weakref.ref(self)
-        # Register a callback that Python will invoke in the child process
-        # immediately after fork(), before any user code runs. This gives us
-        # a chance to reset inherited thread-unsafe state.
-        os.register_at_fork(
-            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
-        )
-
-    @staticmethod
-    def _reinit_after_fork(weak_self):
-        self = weak_self()
-        if self is None:
-            return
-        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
-        #    have held this lock at fork time. The child inherits it locked,
-        #    but the owning thread doesn't exist in the child.
-        self.lock = threading.Lock()
-        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
-        #    internally (Queue.mutex). The _send_loop thread holds this during
-        #    get(). Same deadlock risk as self.lock.
-        self._queue = Queue(maxsize=self._queue_maxsize)
-        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
-        #    sender can never deliver anything. This makes _send() return False
-        #    immediately instead of accumulating data in a queue nothing drains.
-        self._closed = True
-        # 4. Close inherited socket: Prevents the child from sharing a TCP
-        #    connection with the parent, which would corrupt data on the wire.
-        self._close()
-
-
-class ForkSafeFluentHandler(fluent_handler.FluentHandler):
-    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
-
-    def getSenderClass(self):
-        return ForkSafeFluentSender
 
 
 # fmt: off

--- a/images/airflow/2.10.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -12,10 +12,7 @@ import logging
 import os
 import re
 import sys
-import threading
 import traceback
-import weakref
-from queue import Queue
 
 # 3rd party imports
 from airflow.models.taskinstance import TaskInstance
@@ -29,8 +26,6 @@ import boto3
 import socket
 import time
 import watchtower
-from fluent import asynchandler as fluent_handler
-from fluent import asyncsender
 
 # Our imports
 from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler

--- a/images/airflow/2.10.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -12,7 +12,10 @@ import logging
 import os
 import re
 import sys
+import threading
 import traceback
+import weakref
+from queue import Queue
 
 # 3rd party imports
 from airflow.models.taskinstance import TaskInstance
@@ -26,14 +29,75 @@ import boto3
 import socket
 import time
 import watchtower
+from fluent import asynchandler as fluent_handler
+from fluent import asyncsender
 
 # Our imports
 from mwaa.logging.utils import parse_arn, throttle
 from mwaa.utils.statsd import get_statsd
 
+USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
+
 
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
+
+
+class ForkSafeFluentSender(asyncsender.FluentSender):
+    """
+    A FluentSender subclass that is safe to inherit across fork().
+
+    The base FluentSender uses threading.Lock and Queue (which also uses
+    threading.Lock internally). These locks are not fork-safe: if a thread
+    holds one at fork time, the child inherits it locked with no thread to
+    release it, causing a permanent deadlock on futex.
+
+    This subclass registers an os.register_at_fork() callback that
+    reinitializes these locks in the child process after fork. This follows
+    the same pattern Python's logging.Handler uses to make its RLock
+    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Use a weakref so this callback doesn't prevent the sender from being
+        # garbage collected. os.register_at_fork callbacks are never unregistered,
+        # so a strong reference would keep the sender alive forever.
+        weak_self = weakref.ref(self)
+        # Register a callback that Python will invoke in the child process
+        # immediately after fork(), before any user code runs. This gives us
+        # a chance to reset inherited thread-unsafe state.
+        os.register_at_fork(
+            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
+        )
+
+    @staticmethod
+    def _reinit_after_fork(weak_self):
+        self = weak_self()
+        if self is None:
+            return
+        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
+        #    have held this lock at fork time. The child inherits it locked,
+        #    but the owning thread doesn't exist in the child.
+        self.lock = threading.Lock()
+        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
+        #    internally (Queue.mutex). The _send_loop thread holds this during
+        #    get(). Same deadlock risk as self.lock.
+        self._queue = Queue(maxsize=self._queue_maxsize)
+        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
+        #    sender can never deliver anything. This makes _send() return False
+        #    immediately instead of accumulating data in a queue nothing drains.
+        self._closed = True
+        # 4. Close inherited socket: Prevents the child from sharing a TCP
+        #    connection with the parent, which would corrupt data on the wire.
+        self._close()
+
+
+class ForkSafeFluentHandler(fluent_handler.FluentHandler):
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+
+    def getSenderClass(self):
+        return ForkSafeFluentSender
 
 
 # fmt: off
@@ -98,13 +162,15 @@ class BaseLogHandler(logging.Handler):
         self.log_group_name, self.region_name = parse_arn(log_group_arn)
         self.handler = None
         self.logs_source = "Unknown"
+        self.NON_CRITICAL_LOGGING_ENABLED = USE_NON_CRITICAL_LOGGING.lower() == 'true'
+        self.log_stream = None
 
         # TODO Find a nice and unambiguous solution to the craziness of super() and MRO.
         logging.Handler.__init__(self)
 
         self.stats = get_statsd()
 
-    def create_watchtower_handler(
+    def create_cloudwatch_handler(
         self,
         stream_name: str,
         logs_source: str,
@@ -125,7 +191,47 @@ class BaseLogHandler(logging.Handler):
         """
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
-        if self.enabled:
+        self.logs_source = logs_source
+        self.log_stream = stream_name
+
+        if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            self.handler = ForkSafeFluentHandler(
+                'customer.logs',
+                host='localhost',
+                port=24224
+            )
+            if self.formatter:
+                # Wrap the existing formatter to add routing fields
+                original_formatter = self.formatter
+
+                log_group = self.log_group_name
+                log_stream = self.log_stream
+
+                class RoutingFormatter(logging.Formatter):
+                    def format(self, record) -> Dict[str, str]:  # type: ignore[override]
+                        # Get the original formatted message
+                        formatted_msg = original_formatter.format(record)
+                        # Return dict with both the original format and routing fields
+                        return {
+                            'log_group': log_group,
+                            'log_stream': log_stream,
+                            'message': formatted_msg
+                        }
+                self.handler.setFormatter(RoutingFormatter())
+            else:
+                log_group = self.log_group_name
+                log_stream = self.log_stream
+                # If no formatter exists, use a basic one with routing fields
+                class DefaultRoutingFormatter(logging.Formatter):
+                    def format(self, record) -> Dict[str, str]:  # type: ignore[override]
+                        return {
+                            'log_group': log_group,
+                            'log_stream': log_stream,
+                            'message': record.getMessage()
+                        }
+                self.handler.setFormatter(DefaultRoutingFormatter())
+
+        elif self.enabled:
             self.handler = watchtower.CloudWatchLogHandler(
                 log_group_name=self.log_group_name,
                 log_stream_name=stream_name,
@@ -136,7 +242,6 @@ class BaseLogHandler(logging.Handler):
             )
             if self.formatter:
                 self.handler.setFormatter(self.formatter)
-        self.logs_source = logs_source
 
     def close(self):
         """Close the log handler (by closing the underlying log handler)."""
@@ -265,7 +370,33 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
         # https://github.com/aws/amazon-mwaa-docker-images/issues/57
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
-        if self.enabled:
+        if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            self.handler = ForkSafeFluentHandler(
+                'customer.task.logs',
+                host='localhost',
+                port=24224,
+                queue_maxsize=50000,
+            )
+
+            original_formatter = self.formatter
+            log_group = self.log_group_name
+            stream_name = self._render_filename(ti, ti.try_number)
+
+            class TaskFormatter(logging.Formatter):
+                def format(self, record) -> Dict[str, str]:  # type: ignore[override]
+                    if original_formatter:
+                        formatted_msg = original_formatter.format(record)
+                    else:
+                        formatted_msg = record.getMessage()
+                    return {
+                        'message': formatted_msg,
+                        'log_group': log_group,
+                        'log_stream': stream_name
+                    }
+
+            self.handler.setFormatter(TaskFormatter())
+
+        elif self.enabled:
             # identical to open-source implementation, except create_log_group set to False
             self.handler = watchtower.CloudWatchLogHandler(
                 log_group_name=self.log_group_name,
@@ -274,7 +405,6 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
                 use_queues=True,
                 create_log_group=False,
             )
-
             if self.formatter:
                 self.handler.setFormatter(self.formatter)
         else:
@@ -326,7 +456,7 @@ class DagProcessorManagerLogHandler(BaseLogHandler):
         [1] https://airflow.apache.org/docs/apache-airflow/2.9.2/configurations-ref.html#config-logging-log-processor-filename-template
         """
         super().__init__(log_group_arn, kms_key_arn, enabled)
-        self.create_watchtower_handler(stream_name, "DAGProcessorManager")
+        self.create_cloudwatch_handler(stream_name, "DAGProcessorManager")
 
     def _print(self, msg: str):
         # The DAG processing loggers are not started in the same way that the Web
@@ -385,7 +515,7 @@ class DagProcessingLogHandler(BaseLogHandler):
         :param filename: The name of the DAG file being processed.
         """
         stream_name = self._render_filename(filename)
-        self.create_watchtower_handler(
+        self.create_cloudwatch_handler(
             stream_name,
             logs_source="DAGProcessing",
             # cannot use queues/batching with DAG processing, since the DAG processor
@@ -469,4 +599,4 @@ class SubprocessLogHandler(BaseLogHandler):
         # not guaranteed unique and may be reused so include an epoch for uniqueness and
         # easy sorting chronologically.
         _stream_name = "%s_%s_%s.log" % (stream_name_prefix, hostname, epoch)
-        self.create_watchtower_handler(_stream_name, logs_source)
+        self.create_cloudwatch_handler(_stream_name, logs_source)

--- a/images/airflow/2.10.1/python/mwaa/logging/fork_safe_handler.py
+++ b/images/airflow/2.10.1/python/mwaa/logging/fork_safe_handler.py
@@ -1,0 +1,72 @@
+"""Fork-safe FluentHandler and FluentSender for use with Celery prefork.
+
+This module is intentionally separate from cloudwatch_handlers.py so that
+mocking in tests survives module reloads (same pattern as fluent_handler.FluentHandler).
+"""
+
+import os
+import threading
+import weakref
+from queue import Queue
+
+from fluent import asynchandler as fluent_handler
+from fluent import asyncsender
+
+
+class ForkSafeFluentSender(asyncsender.FluentSender):
+    """
+    A FluentSender subclass that is safe to inherit across fork().
+
+    The base FluentSender uses threading.Lock and Queue (which also uses
+    threading.Lock internally). These locks are not fork-safe: if a thread
+    holds one at fork time, the child inherits it locked with no thread to
+    release it, causing a permanent deadlock on futex.
+
+    This subclass registers an os.register_at_fork() callback that
+    reinitializes these locks in the child process after fork. This follows
+    the same pattern Python's logging.Handler uses to make its RLock
+    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the ForkSafeFluentSender with fork-safe callbacks."""
+        super().__init__(*args, **kwargs)
+        # Use a weakref so this callback doesn't prevent the sender from being
+        # garbage collected. os.register_at_fork callbacks are never unregistered,
+        # so a strong reference would keep the sender alive forever.
+        weak_self = weakref.ref(self)
+        # Register a callback that Python will invoke in the child process
+        # immediately after fork(), before any user code runs. This gives us
+        # a chance to reset inherited thread-unsafe state.
+        os.register_at_fork(
+            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
+        )
+
+    @staticmethod
+    def _reinit_after_fork(weak_self):
+        self = weak_self()
+        if self is None:
+            return
+        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
+        #    have held this lock at fork time. The child inherits it locked,
+        #    but the owning thread doesn't exist in the child.
+        self.lock = threading.Lock()
+        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
+        #    internally (Queue.mutex). The _send_loop thread holds this during
+        #    get(). Same deadlock risk as self.lock.
+        self._queue = Queue(maxsize=self._queue_maxsize)
+        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
+        #    sender can never deliver anything. This makes _send() return False
+        #    immediately instead of accumulating data in a queue nothing drains.
+        self._closed = True
+        # 4. Close inherited socket: Prevents the child from sharing a TCP
+        #    connection with the parent, which would corrupt data on the wire.
+        self._close()
+
+
+class ForkSafeFluentHandler(fluent_handler.FluentHandler):
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+
+    def getSenderClass(self):
+        """Return the ForkSafeFluentSender class for fork-safe logging."""
+        return ForkSafeFluentSender

--- a/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
@@ -33,6 +33,7 @@ from fluent import asynchandler as fluent_handler
 from fluent import asyncsender
 
 # Our imports
+from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
 from mwaa.logging.utils import parse_arn, throttle
 from mwaa.utils.statsd import get_statsd
 
@@ -40,64 +41,6 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
-
-
-class ForkSafeFluentSender(asyncsender.FluentSender):
-    """
-    A FluentSender subclass that is safe to inherit across fork().
-
-    The base FluentSender uses threading.Lock and Queue (which also uses
-    threading.Lock internally). These locks are not fork-safe: if a thread
-    holds one at fork time, the child inherits it locked with no thread to
-    release it, causing a permanent deadlock on futex.
-
-    This subclass registers an os.register_at_fork() callback that
-    reinitializes these locks in the child process after fork. This follows
-    the same pattern Python's logging.Handler uses to make its RLock
-    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Use a weakref so this callback doesn't prevent the sender from being
-        # garbage collected. os.register_at_fork callbacks are never unregistered,
-        # so a strong reference would keep the sender alive forever.
-        weak_self = weakref.ref(self)
-        # Register a callback that Python will invoke in the child process
-        # immediately after fork(), before any user code runs. This gives us
-        # a chance to reset inherited thread-unsafe state.
-        os.register_at_fork(
-            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
-        )
-
-    @staticmethod
-    def _reinit_after_fork(weak_self):
-        self = weak_self()
-        if self is None:
-            return
-        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
-        #    have held this lock at fork time. The child inherits it locked,
-        #    but the owning thread doesn't exist in the child.
-        self.lock = threading.Lock()
-        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
-        #    internally (Queue.mutex). The _send_loop thread holds this during
-        #    get(). Same deadlock risk as self.lock.
-        self._queue = Queue(maxsize=self._queue_maxsize)
-        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
-        #    sender can never deliver anything. This makes _send() return False
-        #    immediately instead of accumulating data in a queue nothing drains.
-        self._closed = True
-        # 4. Close inherited socket: Prevents the child from sharing a TCP
-        #    connection with the parent, which would corrupt data on the wire.
-        self._close()
-
-
-class ForkSafeFluentHandler(fluent_handler.FluentHandler):
-    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
-
-    def getSenderClass(self):
-        return ForkSafeFluentSender
-
 
 # fmt: off
 # IMPORTANT NOTE: The time complexity of log inspection is O(M*N) where M is the number

--- a/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
@@ -12,10 +12,7 @@ import logging
 import os
 import re
 import sys
-import threading
 import traceback
-import weakref
-from queue import Queue
 
 # 3rd party imports
 from airflow.models.taskinstance import TaskInstance
@@ -29,8 +26,6 @@ import boto3
 import socket
 import time
 import watchtower
-from fluent import asynchandler as fluent_handler
-from fluent import asyncsender
 
 # Our imports
 from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler

--- a/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
@@ -12,7 +12,10 @@ import logging
 import os
 import re
 import sys
+import threading
 import traceback
+import weakref
+from queue import Queue
 
 # 3rd party imports
 from airflow.models.taskinstance import TaskInstance
@@ -27,6 +30,7 @@ import socket
 import time
 import watchtower
 from fluent import asynchandler as fluent_handler
+from fluent import asyncsender
 
 # Our imports
 from mwaa.logging.utils import parse_arn, throttle
@@ -36,6 +40,63 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
+
+
+class ForkSafeFluentSender(asyncsender.FluentSender):
+    """
+    A FluentSender subclass that is safe to inherit across fork().
+
+    The base FluentSender uses threading.Lock and Queue (which also uses
+    threading.Lock internally). These locks are not fork-safe: if a thread
+    holds one at fork time, the child inherits it locked with no thread to
+    release it, causing a permanent deadlock on futex.
+
+    This subclass registers an os.register_at_fork() callback that
+    reinitializes these locks in the child process after fork. This follows
+    the same pattern Python's logging.Handler uses to make its RLock
+    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Use a weakref so this callback doesn't prevent the sender from being
+        # garbage collected. os.register_at_fork callbacks are never unregistered,
+        # so a strong reference would keep the sender alive forever.
+        weak_self = weakref.ref(self)
+        # Register a callback that Python will invoke in the child process
+        # immediately after fork(), before any user code runs. This gives us
+        # a chance to reset inherited thread-unsafe state.
+        os.register_at_fork(
+            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
+        )
+
+    @staticmethod
+    def _reinit_after_fork(weak_self):
+        self = weak_self()
+        if self is None:
+            return
+        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
+        #    have held this lock at fork time. The child inherits it locked,
+        #    but the owning thread doesn't exist in the child.
+        self.lock = threading.Lock()
+        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
+        #    internally (Queue.mutex). The _send_loop thread holds this during
+        #    get(). Same deadlock risk as self.lock.
+        self._queue = Queue(maxsize=self._queue_maxsize)
+        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
+        #    sender can never deliver anything. This makes _send() return False
+        #    immediately instead of accumulating data in a queue nothing drains.
+        self._closed = True
+        # 4. Close inherited socket: Prevents the child from sharing a TCP
+        #    connection with the parent, which would corrupt data on the wire.
+        self._close()
+
+
+class ForkSafeFluentHandler(fluent_handler.FluentHandler):
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+
+    def getSenderClass(self):
+        return ForkSafeFluentSender
 
 
 # fmt: off
@@ -133,7 +194,7 @@ class BaseLogHandler(logging.Handler):
         self.log_stream = stream_name
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
-            self.handler = fluent_handler.FluentHandler(
+            self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
                 port=24224
@@ -309,7 +370,7 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
-            self.handler = fluent_handler.FluentHandler(
+            self.handler = ForkSafeFluentHandler(
                 'customer.task.logs',
                 host='localhost',
                 port=24224,

--- a/images/airflow/2.10.3/python/mwaa/logging/fork_safe_handler.py
+++ b/images/airflow/2.10.3/python/mwaa/logging/fork_safe_handler.py
@@ -1,0 +1,73 @@
+"""Fork-safe FluentHandler and FluentSender for use with Celery prefork.
+
+This module is intentionally separate from cloudwatch_handlers.py so that
+mocking in tests survives module reloads (same pattern as fluent_handler.FluentHandler).
+"""
+
+import os
+import threading
+import weakref
+from queue import Queue
+
+from fluent import asynchandler as fluent_handler
+from fluent import asyncsender
+
+
+class ForkSafeFluentSender(asyncsender.FluentSender):
+    """
+    A FluentSender subclass that is safe to inherit across fork().
+
+    The base FluentSender uses threading.Lock and Queue (which also uses
+    threading.Lock internally). These locks are not fork-safe: if a thread
+    holds one at fork time, the child inherits it locked with no thread to
+    release it, causing a permanent deadlock on futex.
+
+    This subclass registers an os.register_at_fork() callback that
+    reinitializes these locks in the child process after fork. This follows
+    the same pattern Python's logging.Handler uses to make its RLock
+    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the ForkSafeFluentSender with fork-safe callbacks."""
+        super().__init__(*args, **kwargs)
+        # Use a weakref so this callback doesn't prevent the sender from being
+        # garbage collected. os.register_at_fork callbacks are never unregistered,
+        # so a strong reference would keep the sender alive forever.
+        weak_self = weakref.ref(self)
+        # Register a callback that Python will invoke in the child process
+        # immediately after fork(), before any user code runs. This gives us
+        # a chance to reset inherited thread-unsafe state.
+        os.register_at_fork(
+            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
+        )
+
+    @staticmethod
+    def _reinit_after_fork(weak_self):
+        self = weak_self()
+        if self is None:
+            return
+        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
+        #    have held this lock at fork time. The child inherits it locked,
+        #    but the owning thread doesn't exist in the child.
+        self.lock = threading.Lock()
+        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
+        #    internally (Queue.mutex). The _send_loop thread holds this during
+        #    get(). Same deadlock risk as self.lock.
+        self._queue = Queue(maxsize=self._queue_maxsize)
+        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
+        #    sender can never deliver anything. This makes _send() return False
+        #    immediately instead of accumulating data in a queue nothing drains.
+        self._closed = True
+        # 4. Close inherited socket: Prevents the child from sharing a TCP
+        #    connection with the parent, which would corrupt data on the wire.
+        self._close()
+
+
+class ForkSafeFluentHandler(fluent_handler.FluentHandler):
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+
+    def getSenderClass(self):
+        """Return the ForkSafeFluentSender class for fork-safe logging."""
+        return ForkSafeFluentSender
+

--- a/images/airflow/2.11.0/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.11.0/python/mwaa/logging/cloudwatch_handlers.py
@@ -12,10 +12,7 @@ import logging
 import os
 import re
 import sys
-import threading
 import traceback
-import weakref
-from queue import Queue
 
 # 3rd party imports
 from airflow.models.taskinstance import TaskInstance
@@ -29,8 +26,6 @@ import boto3
 import socket
 import time
 import watchtower
-from fluent import asynchandler as fluent_handler
-from fluent import asyncsender
 
 # Our imports
 from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler

--- a/images/airflow/2.11.0/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.11.0/python/mwaa/logging/cloudwatch_handlers.py
@@ -33,6 +33,7 @@ from fluent import asynchandler as fluent_handler
 from fluent import asyncsender
 
 # Our imports
+from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
 from mwaa.logging.utils import parse_arn, throttle
 from mwaa.utils.statsd import get_statsd
 
@@ -40,63 +41,6 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
-
-
-class ForkSafeFluentSender(asyncsender.FluentSender):
-    """
-    A FluentSender subclass that is safe to inherit across fork().
-
-    The base FluentSender uses threading.Lock and Queue (which also uses
-    threading.Lock internally). These locks are not fork-safe: if a thread
-    holds one at fork time, the child inherits it locked with no thread to
-    release it, causing a permanent deadlock on futex.
-
-    This subclass registers an os.register_at_fork() callback that
-    reinitializes these locks in the child process after fork. This follows
-    the same pattern Python's logging.Handler uses to make its RLock
-    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Use a weakref so this callback doesn't prevent the sender from being
-        # garbage collected. os.register_at_fork callbacks are never unregistered,
-        # so a strong reference would keep the sender alive forever.
-        weak_self = weakref.ref(self)
-        # Register a callback that Python will invoke in the child process
-        # immediately after fork(), before any user code runs. This gives us
-        # a chance to reset inherited thread-unsafe state.
-        os.register_at_fork(
-            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
-        )
-
-    @staticmethod
-    def _reinit_after_fork(weak_self):
-        self = weak_self()
-        if self is None:
-            return
-        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
-        #    have held this lock at fork time. The child inherits it locked,
-        #    but the owning thread doesn't exist in the child.
-        self.lock = threading.Lock()
-        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
-        #    internally (Queue.mutex). The _send_loop thread holds this during
-        #    get(). Same deadlock risk as self.lock.
-        self._queue = Queue(maxsize=self._queue_maxsize)
-        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
-        #    sender can never deliver anything. This makes _send() return False
-        #    immediately instead of accumulating data in a queue nothing drains.
-        self._closed = True
-        # 4. Close inherited socket: Prevents the child from sharing a TCP
-        #    connection with the parent, which would corrupt data on the wire.
-        self._close()
-
-
-class ForkSafeFluentHandler(fluent_handler.FluentHandler):
-    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
-
-    def getSenderClass(self):
-        return ForkSafeFluentSender
 
 
 # fmt: off

--- a/images/airflow/2.11.0/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.11.0/python/mwaa/logging/cloudwatch_handlers.py
@@ -12,7 +12,10 @@ import logging
 import os
 import re
 import sys
+import threading
 import traceback
+import weakref
+from queue import Queue
 
 # 3rd party imports
 from airflow.models.taskinstance import TaskInstance
@@ -27,6 +30,7 @@ import socket
 import time
 import watchtower
 from fluent import asynchandler as fluent_handler
+from fluent import asyncsender
 
 # Our imports
 from mwaa.logging.utils import parse_arn, throttle
@@ -36,6 +40,63 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
+
+
+class ForkSafeFluentSender(asyncsender.FluentSender):
+    """
+    A FluentSender subclass that is safe to inherit across fork().
+
+    The base FluentSender uses threading.Lock and Queue (which also uses
+    threading.Lock internally). These locks are not fork-safe: if a thread
+    holds one at fork time, the child inherits it locked with no thread to
+    release it, causing a permanent deadlock on futex.
+
+    This subclass registers an os.register_at_fork() callback that
+    reinitializes these locks in the child process after fork. This follows
+    the same pattern Python's logging.Handler uses to make its RLock
+    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Use a weakref so this callback doesn't prevent the sender from being
+        # garbage collected. os.register_at_fork callbacks are never unregistered,
+        # so a strong reference would keep the sender alive forever.
+        weak_self = weakref.ref(self)
+        # Register a callback that Python will invoke in the child process
+        # immediately after fork(), before any user code runs. This gives us
+        # a chance to reset inherited thread-unsafe state.
+        os.register_at_fork(
+            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
+        )
+
+    @staticmethod
+    def _reinit_after_fork(weak_self):
+        self = weak_self()
+        if self is None:
+            return
+        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
+        #    have held this lock at fork time. The child inherits it locked,
+        #    but the owning thread doesn't exist in the child.
+        self.lock = threading.Lock()
+        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
+        #    internally (Queue.mutex). The _send_loop thread holds this during
+        #    get(). Same deadlock risk as self.lock.
+        self._queue = Queue(maxsize=self._queue_maxsize)
+        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
+        #    sender can never deliver anything. This makes _send() return False
+        #    immediately instead of accumulating data in a queue nothing drains.
+        self._closed = True
+        # 4. Close inherited socket: Prevents the child from sharing a TCP
+        #    connection with the parent, which would corrupt data on the wire.
+        self._close()
+
+
+class ForkSafeFluentHandler(fluent_handler.FluentHandler):
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+
+    def getSenderClass(self):
+        return ForkSafeFluentSender
 
 
 # fmt: off
@@ -133,7 +194,7 @@ class BaseLogHandler(logging.Handler):
         self.log_stream = stream_name
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
-            self.handler = fluent_handler.FluentHandler(
+            self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
                 port=24224
@@ -326,7 +387,7 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
-            self.handler = fluent_handler.FluentHandler(
+            self.handler = ForkSafeFluentHandler(
                 'customer.task.logs',
                 host='localhost',
                 port=24224,

--- a/images/airflow/2.11.0/python/mwaa/logging/fork_safe_handler.py
+++ b/images/airflow/2.11.0/python/mwaa/logging/fork_safe_handler.py
@@ -1,0 +1,72 @@
+"""Fork-safe FluentHandler and FluentSender for use with Celery prefork.
+
+This module is intentionally separate from cloudwatch_handlers.py so that
+mocking in tests survives module reloads (same pattern as fluent_handler.FluentHandler).
+"""
+
+import os
+import threading
+import weakref
+from queue import Queue
+
+from fluent import asynchandler as fluent_handler
+from fluent import asyncsender
+
+
+class ForkSafeFluentSender(asyncsender.FluentSender):
+    """
+    A FluentSender subclass that is safe to inherit across fork().
+
+    The base FluentSender uses threading.Lock and Queue (which also uses
+    threading.Lock internally). These locks are not fork-safe: if a thread
+    holds one at fork time, the child inherits it locked with no thread to
+    release it, causing a permanent deadlock on futex.
+
+    This subclass registers an os.register_at_fork() callback that
+    reinitializes these locks in the child process after fork. This follows
+    the same pattern Python's logging.Handler uses to make its RLock
+    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the ForkSafeFluentSender with fork-safe callbacks."""
+        super().__init__(*args, **kwargs)
+        # Use a weakref so this callback doesn't prevent the sender from being
+        # garbage collected. os.register_at_fork callbacks are never unregistered,
+        # so a strong reference would keep the sender alive forever.
+        weak_self = weakref.ref(self)
+        # Register a callback that Python will invoke in the child process
+        # immediately after fork(), before any user code runs. This gives us
+        # a chance to reset inherited thread-unsafe state.
+        os.register_at_fork(
+            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
+        )
+
+    @staticmethod
+    def _reinit_after_fork(weak_self):
+        self = weak_self()
+        if self is None:
+            return
+        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
+        #    have held this lock at fork time. The child inherits it locked,
+        #    but the owning thread doesn't exist in the child.
+        self.lock = threading.Lock()
+        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
+        #    internally (Queue.mutex). The _send_loop thread holds this during
+        #    get(). Same deadlock risk as self.lock.
+        self._queue = Queue(maxsize=self._queue_maxsize)
+        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
+        #    sender can never deliver anything. This makes _send() return False
+        #    immediately instead of accumulating data in a queue nothing drains.
+        self._closed = True
+        # 4. Close inherited socket: Prevents the child from sharing a TCP
+        #    connection with the parent, which would corrupt data on the wire.
+        self._close()
+
+
+class ForkSafeFluentHandler(fluent_handler.FluentHandler):
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+
+    def getSenderClass(self):
+        """Return the ForkSafeFluentSender class for fork-safe logging."""
+        return ForkSafeFluentSender

--- a/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
@@ -33,71 +33,14 @@ from fluent import asynchandler as fluent_handler
 from fluent import asyncsender
 
 # Our imports
+from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
 from mwaa.logging.utils import parse_arn, throttle
 from mwaa.utils.statsd import get_statsd
 
 USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 
-
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
-
-
-class ForkSafeFluentSender(asyncsender.FluentSender):
-    """
-    A FluentSender subclass that is safe to inherit across fork().
-
-    The base FluentSender uses threading.Lock and Queue (which also uses
-    threading.Lock internally). These locks are not fork-safe: if a thread
-    holds one at fork time, the child inherits it locked with no thread to
-    release it, causing a permanent deadlock on futex.
-
-    This subclass registers an os.register_at_fork() callback that
-    reinitializes these locks in the child process after fork. This follows
-    the same pattern Python's logging.Handler uses to make its RLock
-    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Use a weakref so this callback doesn't prevent the sender from being
-        # garbage collected. os.register_at_fork callbacks are never unregistered,
-        # so a strong reference would keep the sender alive forever.
-        weak_self = weakref.ref(self)
-        # Register a callback that Python will invoke in the child process
-        # immediately after fork(), before any user code runs. This gives us
-        # a chance to reset inherited thread-unsafe state.
-        os.register_at_fork(
-            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
-        )
-
-    @staticmethod
-    def _reinit_after_fork(weak_self):
-        self = weak_self()
-        if self is None:
-            return
-        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
-        #    have held this lock at fork time. The child inherits it locked,
-        #    but the owning thread doesn't exist in the child.
-        self.lock = threading.Lock()
-        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
-        #    internally (Queue.mutex). The _send_loop thread holds this during
-        #    get(). Same deadlock risk as self.lock.
-        self._queue = Queue(maxsize=self._queue_maxsize)
-        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
-        #    sender can never deliver anything. This makes _send() return False
-        #    immediately instead of accumulating data in a queue nothing drains.
-        self._closed = True
-        # 4. Close inherited socket: Prevents the child from sharing a TCP
-        #    connection with the parent, which would corrupt data on the wire.
-        self._close()
-
-
-class ForkSafeFluentHandler(fluent_handler.FluentHandler):
-    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
-
-    def getSenderClass(self):
-        return ForkSafeFluentSender
 
 
 # fmt: off

--- a/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
@@ -12,10 +12,7 @@ import logging
 import os
 import re
 import sys
-import threading
 import traceback
-import weakref
-from queue import Queue
 
 # 3rd party imports
 from airflow.models.taskinstance import TaskInstance
@@ -29,8 +26,6 @@ import boto3
 import socket
 import time
 import watchtower
-from fluent import asynchandler as fluent_handler
-from fluent import asyncsender
 
 # Our imports
 from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler

--- a/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
@@ -12,7 +12,10 @@ import logging
 import os
 import re
 import sys
+import threading
 import traceback
+import weakref
+from queue import Queue
 
 # 3rd party imports
 from airflow.models.taskinstance import TaskInstance
@@ -26,14 +29,75 @@ import boto3
 import socket
 import time
 import watchtower
+from fluent import asynchandler as fluent_handler
+from fluent import asyncsender
 
 # Our imports
 from mwaa.logging.utils import parse_arn, throttle
 from mwaa.utils.statsd import get_statsd
 
+USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
+
 
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
+
+
+class ForkSafeFluentSender(asyncsender.FluentSender):
+    """
+    A FluentSender subclass that is safe to inherit across fork().
+
+    The base FluentSender uses threading.Lock and Queue (which also uses
+    threading.Lock internally). These locks are not fork-safe: if a thread
+    holds one at fork time, the child inherits it locked with no thread to
+    release it, causing a permanent deadlock on futex.
+
+    This subclass registers an os.register_at_fork() callback that
+    reinitializes these locks in the child process after fork. This follows
+    the same pattern Python's logging.Handler uses to make its RLock
+    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Use a weakref so this callback doesn't prevent the sender from being
+        # garbage collected. os.register_at_fork callbacks are never unregistered,
+        # so a strong reference would keep the sender alive forever.
+        weak_self = weakref.ref(self)
+        # Register a callback that Python will invoke in the child process
+        # immediately after fork(), before any user code runs. This gives us
+        # a chance to reset inherited thread-unsafe state.
+        os.register_at_fork(
+            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
+        )
+
+    @staticmethod
+    def _reinit_after_fork(weak_self):
+        self = weak_self()
+        if self is None:
+            return
+        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
+        #    have held this lock at fork time. The child inherits it locked,
+        #    but the owning thread doesn't exist in the child.
+        self.lock = threading.Lock()
+        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
+        #    internally (Queue.mutex). The _send_loop thread holds this during
+        #    get(). Same deadlock risk as self.lock.
+        self._queue = Queue(maxsize=self._queue_maxsize)
+        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
+        #    sender can never deliver anything. This makes _send() return False
+        #    immediately instead of accumulating data in a queue nothing drains.
+        self._closed = True
+        # 4. Close inherited socket: Prevents the child from sharing a TCP
+        #    connection with the parent, which would corrupt data on the wire.
+        self._close()
+
+
+class ForkSafeFluentHandler(fluent_handler.FluentHandler):
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+
+    def getSenderClass(self):
+        return ForkSafeFluentSender
 
 
 # fmt: off
@@ -98,13 +162,15 @@ class BaseLogHandler(logging.Handler):
         self.log_group_name, self.region_name = parse_arn(log_group_arn)
         self.handler = None
         self.logs_source = "Unknown"
+        self.NON_CRITICAL_LOGGING_ENABLED = USE_NON_CRITICAL_LOGGING.lower() == 'true'
+        self.log_stream = None
 
         # TODO Find a nice and unambiguous solution to the craziness of super() and MRO.
         logging.Handler.__init__(self)
 
         self.stats = get_statsd()
 
-    def create_watchtower_handler(
+    def create_cloudwatch_handler(
         self,
         stream_name: str,
         logs_source: str,
@@ -125,7 +191,47 @@ class BaseLogHandler(logging.Handler):
         """
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
-        if self.enabled:
+        self.logs_source = logs_source
+        self.log_stream = stream_name
+
+        if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            self.handler = ForkSafeFluentHandler(
+                'customer.logs',
+                host='localhost',
+                port=24224
+            )
+            if self.formatter:
+                # Wrap the existing formatter to add routing fields
+                original_formatter = self.formatter
+
+                log_group = self.log_group_name
+                log_stream = self.log_stream
+
+                class RoutingFormatter(logging.Formatter):
+                    def format(self, record) -> Dict[str, str]:  # type: ignore[override]
+                        # Get the original formatted message
+                        formatted_msg = original_formatter.format(record)
+                        # Return dict with both the original format and routing fields
+                        return {
+                            'log_group': log_group,
+                            'log_stream': log_stream,
+                            'message': formatted_msg
+                        }
+                self.handler.setFormatter(RoutingFormatter())
+            else:
+                log_group = self.log_group_name
+                log_stream = self.log_stream
+                # If no formatter exists, use a basic one with routing fields
+                class DefaultRoutingFormatter(logging.Formatter):
+                    def format(self, record) -> Dict[str, str]:  # type: ignore[override]
+                        return {
+                            'log_group': log_group,
+                            'log_stream': log_stream,
+                            'message': record.getMessage()
+                        }
+                self.handler.setFormatter(DefaultRoutingFormatter())
+
+        elif self.enabled:
             self.handler = watchtower.CloudWatchLogHandler(
                 log_group_name=self.log_group_name,
                 log_stream_name=stream_name,
@@ -136,7 +242,6 @@ class BaseLogHandler(logging.Handler):
             )
             if self.formatter:
                 self.handler.setFormatter(self.formatter)
-        self.logs_source = logs_source
 
     def close(self):
         """Close the log handler (by closing the underlying log handler)."""
@@ -265,7 +370,33 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
         # https://github.com/aws/amazon-mwaa-docker-images/issues/57
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
-        if self.enabled:
+        if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            self.handler = ForkSafeFluentHandler(
+                'customer.task.logs',
+                host='localhost',
+                port=24224,
+                queue_maxsize=50000,
+            )
+
+            original_formatter = self.formatter
+            log_group = self.log_group_name
+            stream_name = self._render_filename(ti, ti.try_number)
+
+            class TaskFormatter(logging.Formatter):
+                def format(self, record) -> Dict[str, str]:  # type: ignore[override]
+                    if original_formatter:
+                        formatted_msg = original_formatter.format(record)
+                    else:
+                        formatted_msg = record.getMessage()
+                    return {
+                        'message': formatted_msg,
+                        'log_group': log_group,
+                        'log_stream': stream_name
+                    }
+
+            self.handler.setFormatter(TaskFormatter())
+
+        elif self.enabled:
             # identical to open-source implementation, except create_log_group set to False
             self.handler = watchtower.CloudWatchLogHandler(
                 log_group_name=self.log_group_name,
@@ -274,7 +405,6 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
                 use_queues=True,
                 create_log_group=False,
             )
-
             if self.formatter:
                 self.handler.setFormatter(self.formatter)
         else:
@@ -326,7 +456,7 @@ class DagProcessorManagerLogHandler(BaseLogHandler):
         [1] https://airflow.apache.org/docs/apache-airflow/2.9.2/configurations-ref.html#config-logging-log-processor-filename-template
         """
         super().__init__(log_group_arn, kms_key_arn, enabled)
-        self.create_watchtower_handler(stream_name, "DAGProcessorManager")
+        self.create_cloudwatch_handler(stream_name, "DAGProcessorManager")
 
     def _print(self, msg: str):
         # The DAG processing loggers are not started in the same way that the Web
@@ -385,7 +515,7 @@ class DagProcessingLogHandler(BaseLogHandler):
         :param filename: The name of the DAG file being processed.
         """
         stream_name = self._render_filename(filename)
-        self.create_watchtower_handler(
+        self.create_cloudwatch_handler(
             stream_name,
             logs_source="DAGProcessing",
             # cannot use queues/batching with DAG processing, since the DAG processor
@@ -469,4 +599,4 @@ class SubprocessLogHandler(BaseLogHandler):
         # not guaranteed unique and may be reused so include an epoch for uniqueness and
         # easy sorting chronologically.
         _stream_name = "%s_%s_%s.log" % (stream_name_prefix, hostname, epoch)
-        self.create_watchtower_handler(_stream_name, logs_source)
+        self.create_cloudwatch_handler(_stream_name, logs_source)

--- a/images/airflow/2.9.2/python/mwaa/logging/fork_safe_handler.py
+++ b/images/airflow/2.9.2/python/mwaa/logging/fork_safe_handler.py
@@ -1,0 +1,72 @@
+"""Fork-safe FluentHandler and FluentSender for use with Celery prefork.
+
+This module is intentionally separate from cloudwatch_handlers.py so that
+mocking in tests survives module reloads (same pattern as fluent_handler.FluentHandler).
+"""
+
+import os
+import threading
+import weakref
+from queue import Queue
+
+from fluent import asynchandler as fluent_handler
+from fluent import asyncsender
+
+
+class ForkSafeFluentSender(asyncsender.FluentSender):
+    """
+    A FluentSender subclass that is safe to inherit across fork().
+
+    The base FluentSender uses threading.Lock and Queue (which also uses
+    threading.Lock internally). These locks are not fork-safe: if a thread
+    holds one at fork time, the child inherits it locked with no thread to
+    release it, causing a permanent deadlock on futex.
+
+    This subclass registers an os.register_at_fork() callback that
+    reinitializes these locks in the child process after fork. This follows
+    the same pattern Python's logging.Handler uses to make its RLock
+    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the ForkSafeFluentSender with fork-safe callbacks."""
+        super().__init__(*args, **kwargs)
+        # Use a weakref so this callback doesn't prevent the sender from being
+        # garbage collected. os.register_at_fork callbacks are never unregistered,
+        # so a strong reference would keep the sender alive forever.
+        weak_self = weakref.ref(self)
+        # Register a callback that Python will invoke in the child process
+        # immediately after fork(), before any user code runs. This gives us
+        # a chance to reset inherited thread-unsafe state.
+        os.register_at_fork(
+            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
+        )
+
+    @staticmethod
+    def _reinit_after_fork(weak_self):
+        self = weak_self()
+        if self is None:
+            return
+        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
+        #    have held this lock at fork time. The child inherits it locked,
+        #    but the owning thread doesn't exist in the child.
+        self.lock = threading.Lock()
+        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
+        #    internally (Queue.mutex). The _send_loop thread holds this during
+        #    get(). Same deadlock risk as self.lock.
+        self._queue = Queue(maxsize=self._queue_maxsize)
+        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
+        #    sender can never deliver anything. This makes _send() return False
+        #    immediately instead of accumulating data in a queue nothing drains.
+        self._closed = True
+        # 4. Close inherited socket: Prevents the child from sharing a TCP
+        #    connection with the parent, which would corrupt data on the wire.
+        self._close()
+
+
+class ForkSafeFluentHandler(fluent_handler.FluentHandler):
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+
+    def getSenderClass(self):
+        """Return the ForkSafeFluentSender class for fork-safe logging."""
+        return ForkSafeFluentSender

--- a/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
@@ -22,10 +22,7 @@ import os
 import re
 import structlog
 import sys
-import threading
 import traceback
-import weakref
-from queue import Queue
 
 # 3rd party imports
 from airflow.models.taskinstance import TaskInstance
@@ -42,8 +39,6 @@ import boto3
 import socket
 import time
 import watchtower
-from fluent import asynchandler as fluent_handler
-from fluent import asyncsender
 
 # Our imports
 from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler

--- a/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
@@ -22,7 +22,10 @@ import os
 import re
 import structlog
 import sys
+import threading
 import traceback
+import weakref
+from queue import Queue
 
 # 3rd party imports
 from airflow.models.taskinstance import TaskInstance
@@ -40,6 +43,7 @@ import socket
 import time
 import watchtower
 from fluent import asynchandler as fluent_handler
+from fluent import asyncsender
 
 # Our imports
 from mwaa.logging.utils import parse_arn, throttle
@@ -49,6 +53,63 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
+
+
+class ForkSafeFluentSender(asyncsender.FluentSender):
+    """
+    A FluentSender subclass that is safe to inherit across fork().
+
+    The base FluentSender uses threading.Lock and Queue (which also uses
+    threading.Lock internally). These locks are not fork-safe: if a thread
+    holds one at fork time, the child inherits it locked with no thread to
+    release it, causing a permanent deadlock on futex.
+
+    This subclass registers an os.register_at_fork() callback that
+    reinitializes these locks in the child process after fork. This follows
+    the same pattern Python's logging.Handler uses to make its RLock
+    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Use a weakref so this callback doesn't prevent the sender from being
+        # garbage collected. os.register_at_fork callbacks are never unregistered,
+        # so a strong reference would keep the sender alive forever.
+        weak_self = weakref.ref(self)
+        # Register a callback that Python will invoke in the child process
+        # immediately after fork(), before any user code runs. This gives us
+        # a chance to reset inherited thread-unsafe state.
+        os.register_at_fork(
+            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
+        )
+
+    @staticmethod
+    def _reinit_after_fork(weak_self):
+        self = weak_self()
+        if self is None:
+            return
+        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
+        #    have held this lock at fork time. The child inherits it locked,
+        #    but the owning thread doesn't exist in the child.
+        self.lock = threading.Lock()
+        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
+        #    internally (Queue.mutex). The _send_loop thread holds this during
+        #    get(). Same deadlock risk as self.lock.
+        self._queue = Queue(maxsize=self._queue_maxsize)
+        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
+        #    sender can never deliver anything. This makes _send() return False
+        #    immediately instead of accumulating data in a queue nothing drains.
+        self._closed = True
+        # 4. Close inherited socket: Prevents the child from sharing a TCP
+        #    connection with the parent, which would corrupt data on the wire.
+        self._close()
+
+
+class ForkSafeFluentHandler(fluent_handler.FluentHandler):
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+
+    def getSenderClass(self):
+        return ForkSafeFluentSender
 
 
 # fmt: off
@@ -146,7 +207,7 @@ class BaseLogHandler(logging.Handler):
         self.log_stream = stream_name
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
-            self.handler = fluent_handler.FluentHandler(
+            self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
                 port=24224

--- a/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
@@ -46,6 +46,7 @@ from fluent import asynchandler as fluent_handler
 from fluent import asyncsender
 
 # Our imports
+from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
 from mwaa.logging.utils import parse_arn, throttle
 from mwaa.utils.statsd import get_statsd
 
@@ -53,63 +54,6 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
-
-
-class ForkSafeFluentSender(asyncsender.FluentSender):
-    """
-    A FluentSender subclass that is safe to inherit across fork().
-
-    The base FluentSender uses threading.Lock and Queue (which also uses
-    threading.Lock internally). These locks are not fork-safe: if a thread
-    holds one at fork time, the child inherits it locked with no thread to
-    release it, causing a permanent deadlock on futex.
-
-    This subclass registers an os.register_at_fork() callback that
-    reinitializes these locks in the child process after fork. This follows
-    the same pattern Python's logging.Handler uses to make its RLock
-    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Use a weakref so this callback doesn't prevent the sender from being
-        # garbage collected. os.register_at_fork callbacks are never unregistered,
-        # so a strong reference would keep the sender alive forever.
-        weak_self = weakref.ref(self)
-        # Register a callback that Python will invoke in the child process
-        # immediately after fork(), before any user code runs. This gives us
-        # a chance to reset inherited thread-unsafe state.
-        os.register_at_fork(
-            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
-        )
-
-    @staticmethod
-    def _reinit_after_fork(weak_self):
-        self = weak_self()
-        if self is None:
-            return
-        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
-        #    have held this lock at fork time. The child inherits it locked,
-        #    but the owning thread doesn't exist in the child.
-        self.lock = threading.Lock()
-        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
-        #    internally (Queue.mutex). The _send_loop thread holds this during
-        #    get(). Same deadlock risk as self.lock.
-        self._queue = Queue(maxsize=self._queue_maxsize)
-        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
-        #    sender can never deliver anything. This makes _send() return False
-        #    immediately instead of accumulating data in a queue nothing drains.
-        self._closed = True
-        # 4. Close inherited socket: Prevents the child from sharing a TCP
-        #    connection with the parent, which would corrupt data on the wire.
-        self._close()
-
-
-class ForkSafeFluentHandler(fluent_handler.FluentHandler):
-    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
-
-    def getSenderClass(self):
-        return ForkSafeFluentSender
 
 
 # fmt: off

--- a/images/airflow/3.0.6/python/mwaa/logging/fork_safe_handler.py
+++ b/images/airflow/3.0.6/python/mwaa/logging/fork_safe_handler.py
@@ -1,0 +1,72 @@
+"""Fork-safe FluentHandler and FluentSender for use with Celery prefork.
+
+This module is intentionally separate from cloudwatch_handlers.py so that
+mocking in tests survives module reloads (same pattern as fluent_handler.FluentHandler).
+"""
+
+import os
+import threading
+import weakref
+from queue import Queue
+
+from fluent import asynchandler as fluent_handler
+from fluent import asyncsender
+
+
+class ForkSafeFluentSender(asyncsender.FluentSender):
+    """
+    A FluentSender subclass that is safe to inherit across fork().
+
+    The base FluentSender uses threading.Lock and Queue (which also uses
+    threading.Lock internally). These locks are not fork-safe: if a thread
+    holds one at fork time, the child inherits it locked with no thread to
+    release it, causing a permanent deadlock on futex.
+
+    This subclass registers an os.register_at_fork() callback that
+    reinitializes these locks in the child process after fork. This follows
+    the same pattern Python's logging.Handler uses to make its RLock
+    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the ForkSafeFluentSender with fork-safe callbacks."""
+        super().__init__(*args, **kwargs)
+        # Use a weakref so this callback doesn't prevent the sender from being
+        # garbage collected. os.register_at_fork callbacks are never unregistered,
+        # so a strong reference would keep the sender alive forever.
+        weak_self = weakref.ref(self)
+        # Register a callback that Python will invoke in the child process
+        # immediately after fork(), before any user code runs. This gives us
+        # a chance to reset inherited thread-unsafe state.
+        os.register_at_fork(
+            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
+        )
+
+    @staticmethod
+    def _reinit_after_fork(weak_self):
+        self = weak_self()
+        if self is None:
+            return
+        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
+        #    have held this lock at fork time. The child inherits it locked,
+        #    but the owning thread doesn't exist in the child.
+        self.lock = threading.Lock()
+        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
+        #    internally (Queue.mutex). The _send_loop thread holds this during
+        #    get(). Same deadlock risk as self.lock.
+        self._queue = Queue(maxsize=self._queue_maxsize)
+        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
+        #    sender can never deliver anything. This makes _send() return False
+        #    immediately instead of accumulating data in a queue nothing drains.
+        self._closed = True
+        # 4. Close inherited socket: Prevents the child from sharing a TCP
+        #    connection with the parent, which would corrupt data on the wire.
+        self._close()
+
+
+class ForkSafeFluentHandler(fluent_handler.FluentHandler):
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+
+    def getSenderClass(self):
+        """Return the ForkSafeFluentSender class for fork-safe logging."""
+        return ForkSafeFluentSender

--- a/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -22,10 +22,7 @@ import os
 import re
 import structlog
 import sys
-import threading
 import traceback
-import weakref
-from queue import Queue
 
 # 3rd party imports
 from airflow.models.taskinstance import TaskInstance
@@ -42,8 +39,6 @@ import boto3
 import socket
 import time
 import watchtower
-from fluent import asynchandler as fluent_handler
-from fluent import asyncsender
 
 # Our imports
 from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler

--- a/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -22,7 +22,10 @@ import os
 import re
 import structlog
 import sys
+import threading
 import traceback
+import weakref
+from queue import Queue
 
 # 3rd party imports
 from airflow.models.taskinstance import TaskInstance
@@ -40,6 +43,7 @@ import socket
 import time
 import watchtower
 from fluent import asynchandler as fluent_handler
+from fluent import asyncsender
 
 # Our imports
 from mwaa.logging.utils import parse_arn, throttle
@@ -49,6 +53,63 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
+
+
+class ForkSafeFluentSender(asyncsender.FluentSender):
+    """
+    A FluentSender subclass that is safe to inherit across fork().
+
+    The base FluentSender uses threading.Lock and Queue (which also uses
+    threading.Lock internally). These locks are not fork-safe: if a thread
+    holds one at fork time, the child inherits it locked with no thread to
+    release it, causing a permanent deadlock on futex.
+
+    This subclass registers an os.register_at_fork() callback that
+    reinitializes these locks in the child process after fork. This follows
+    the same pattern Python's logging.Handler uses to make its RLock
+    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Use a weakref so this callback doesn't prevent the sender from being
+        # garbage collected. os.register_at_fork callbacks are never unregistered,
+        # so a strong reference would keep the sender alive forever.
+        weak_self = weakref.ref(self)
+        # Register a callback that Python will invoke in the child process
+        # immediately after fork(), before any user code runs. This gives us
+        # a chance to reset inherited thread-unsafe state.
+        os.register_at_fork(
+            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
+        )
+
+    @staticmethod
+    def _reinit_after_fork(weak_self):
+        self = weak_self()
+        if self is None:
+            return
+        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
+        #    have held this lock at fork time. The child inherits it locked,
+        #    but the owning thread doesn't exist in the child.
+        self.lock = threading.Lock()
+        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
+        #    internally (Queue.mutex). The _send_loop thread holds this during
+        #    get(). Same deadlock risk as self.lock.
+        self._queue = Queue(maxsize=self._queue_maxsize)
+        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
+        #    sender can never deliver anything. This makes _send() return False
+        #    immediately instead of accumulating data in a queue nothing drains.
+        self._closed = True
+        # 4. Close inherited socket: Prevents the child from sharing a TCP
+        #    connection with the parent, which would corrupt data on the wire.
+        self._close()
+
+
+class ForkSafeFluentHandler(fluent_handler.FluentHandler):
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+
+    def getSenderClass(self):
+        return ForkSafeFluentSender
 
 
 # fmt: off
@@ -146,7 +207,7 @@ class BaseLogHandler(logging.Handler):
         self.log_stream = stream_name
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
-            self.handler = fluent_handler.FluentHandler(
+            self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
                 port=24224

--- a/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -46,6 +46,7 @@ from fluent import asynchandler as fluent_handler
 from fluent import asyncsender
 
 # Our imports
+from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
 from mwaa.logging.utils import parse_arn, throttle
 from mwaa.utils.statsd import get_statsd
 
@@ -53,63 +54,6 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
-
-
-class ForkSafeFluentSender(asyncsender.FluentSender):
-    """
-    A FluentSender subclass that is safe to inherit across fork().
-
-    The base FluentSender uses threading.Lock and Queue (which also uses
-    threading.Lock internally). These locks are not fork-safe: if a thread
-    holds one at fork time, the child inherits it locked with no thread to
-    release it, causing a permanent deadlock on futex.
-
-    This subclass registers an os.register_at_fork() callback that
-    reinitializes these locks in the child process after fork. This follows
-    the same pattern Python's logging.Handler uses to make its RLock
-    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Use a weakref so this callback doesn't prevent the sender from being
-        # garbage collected. os.register_at_fork callbacks are never unregistered,
-        # so a strong reference would keep the sender alive forever.
-        weak_self = weakref.ref(self)
-        # Register a callback that Python will invoke in the child process
-        # immediately after fork(), before any user code runs. This gives us
-        # a chance to reset inherited thread-unsafe state.
-        os.register_at_fork(
-            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
-        )
-
-    @staticmethod
-    def _reinit_after_fork(weak_self):
-        self = weak_self()
-        if self is None:
-            return
-        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
-        #    have held this lock at fork time. The child inherits it locked,
-        #    but the owning thread doesn't exist in the child.
-        self.lock = threading.Lock()
-        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
-        #    internally (Queue.mutex). The _send_loop thread holds this during
-        #    get(). Same deadlock risk as self.lock.
-        self._queue = Queue(maxsize=self._queue_maxsize)
-        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
-        #    sender can never deliver anything. This makes _send() return False
-        #    immediately instead of accumulating data in a queue nothing drains.
-        self._closed = True
-        # 4. Close inherited socket: Prevents the child from sharing a TCP
-        #    connection with the parent, which would corrupt data on the wire.
-        self._close()
-
-
-class ForkSafeFluentHandler(fluent_handler.FluentHandler):
-    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
-
-    def getSenderClass(self):
-        return ForkSafeFluentSender
 
 
 # fmt: off

--- a/images/airflow/3.2.1/python/mwaa/logging/fork_safe_handler.py
+++ b/images/airflow/3.2.1/python/mwaa/logging/fork_safe_handler.py
@@ -1,0 +1,72 @@
+"""Fork-safe FluentHandler and FluentSender for use with Celery prefork.
+
+This module is intentionally separate from cloudwatch_handlers.py so that
+mocking in tests survives module reloads (same pattern as fluent_handler.FluentHandler).
+"""
+
+import os
+import threading
+import weakref
+from queue import Queue
+
+from fluent import asynchandler as fluent_handler
+from fluent import asyncsender
+
+
+class ForkSafeFluentSender(asyncsender.FluentSender):
+    """
+    A FluentSender subclass that is safe to inherit across fork().
+
+    The base FluentSender uses threading.Lock and Queue (which also uses
+    threading.Lock internally). These locks are not fork-safe: if a thread
+    holds one at fork time, the child inherits it locked with no thread to
+    release it, causing a permanent deadlock on futex.
+
+    This subclass registers an os.register_at_fork() callback that
+    reinitializes these locks in the child process after fork. This follows
+    the same pattern Python's logging.Handler uses to make its RLock
+    fork-safe (see CPython logging/__init__.py _register_at_fork_reinit_lock).
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the ForkSafeFluentSender with fork-safe callbacks."""
+        super().__init__(*args, **kwargs)
+        # Use a weakref so this callback doesn't prevent the sender from being
+        # garbage collected. os.register_at_fork callbacks are never unregistered,
+        # so a strong reference would keep the sender alive forever.
+        weak_self = weakref.ref(self)
+        # Register a callback that Python will invoke in the child process
+        # immediately after fork(), before any user code runs. This gives us
+        # a chance to reset inherited thread-unsafe state.
+        os.register_at_fork(
+            after_in_child=lambda: ForkSafeFluentSender._reinit_after_fork(weak_self)
+        )
+
+    @staticmethod
+    def _reinit_after_fork(weak_self):
+        self = weak_self()
+        if self is None:
+            return
+        # 1. Replace self.lock (threading.Lock): The log-emitting thread may
+        #    have held this lock at fork time. The child inherits it locked,
+        #    but the owning thread doesn't exist in the child.
+        self.lock = threading.Lock()
+        # 2. Replace self._queue (Queue): Python's Queue uses threading.Lock
+        #    internally (Queue.mutex). The _send_loop thread holds this during
+        #    get(). Same deadlock risk as self.lock.
+        self._queue = Queue(maxsize=self._queue_maxsize)
+        # 3. Mark closed: The _send_loop thread doesn't survive fork, so this
+        #    sender can never deliver anything. This makes _send() return False
+        #    immediately instead of accumulating data in a queue nothing drains.
+        self._closed = True
+        # 4. Close inherited socket: Prevents the child from sharing a TCP
+        #    connection with the parent, which would corrupt data on the wire.
+        self._close()
+
+
+class ForkSafeFluentHandler(fluent_handler.FluentHandler):
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+
+    def getSenderClass(self):
+        """Return the ForkSafeFluentSender class for fork-safe logging."""
+        return ForkSafeFluentSender

--- a/tests/images/airflow/2.10.1/python/mwaa/logging/test_cloudwatch_handler_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/logging/test_cloudwatch_handler_2_10_1.py
@@ -1,7 +1,9 @@
 import logging
 import pytest
 import os
-from unittest.mock import patch, Mock
+import importlib
+from unittest.mock import patch, Mock, MagicMock, ANY
+from airflow.models.taskinstance import TaskInstance
 from mwaa.config.setup_environment import (
     setup_environment_variables,
     _execute_startup_script,
@@ -9,13 +11,40 @@ from mwaa.config.setup_environment import (
     _is_protected_os_environ,
 )
 from mwaa.subprocess.subprocess import Subprocess
-from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+from mwaa.logging.cloudwatch_handlers import (
+    BaseLogHandler,
+    TaskLogHandler,
+    SubprocessLogHandler,
+    DagProcessorManagerLogHandler,
+    DagProcessingLogHandler
+)
 
 print(BaseLogHandler.__init__.__code__.co_varnames)
 
 @pytest.fixture
 def mock_handler():
     return Mock()
+
+@pytest.fixture
+def mock_boto3_client():
+    with patch('boto3.client') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_watchtower():
+    with patch('mwaa.logging.cloudwatch_handlers.watchtower.CloudWatchLogHandler') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_fluent():
+    with patch('mwaa.logging.fork_safe_handler.ForkSafeFluentHandler') as mock:
+        yield mock
+
+@pytest.fixture(autouse=True)
+def reload_module():
+    import importlib
+    import mwaa.logging.cloudwatch_handlers
+    importlib.reload(mwaa.logging.cloudwatch_handlers)
 
 
 @pytest.fixture
@@ -122,3 +151,133 @@ def test_emit_handles_exception(base_logger):
 
         # Verify that _report_logging_error was called with the correct message
         mock_report_error.assert_called_once_with("Failed to emit log record.")
+
+@pytest.mark.parametrize("use_non_critical_logging, expected_handler, unexpected_handler", [
+    ('false', 'watchtower', 'fluent'),
+    ('true', 'fluent', 'watchtower')
+])
+def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, use_non_critical_logging, expected_handler, unexpected_handler):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': use_non_critical_logging}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'test_source')
+
+        assert handler.handler is not None, "No handler was created"
+
+        if expected_handler == 'watchtower':
+            assert isinstance(handler.handler, mock_watchtower.return_value.__class__), "Created handler should be a Watchtower handler"
+            assert mock_watchtower.called, f"{expected_handler} handler should be created"
+            assert not mock_fluent.called, f"{unexpected_handler} handler should not be created"
+            mock_watchtower.assert_called_once_with(
+                log_group_name=handler.log_group_name,
+                log_stream_name='test_stream',
+                boto3_client=mock_boto3_client.return_value,
+                use_queues=True,
+                send_interval=10,
+                create_log_group=False
+            )
+        else:
+            assert isinstance(handler.handler, mock_fluent.return_value.__class__), "Created handler should be a Fluent handler"
+            assert mock_fluent.called, f"{expected_handler} handler should be created"
+            assert not mock_watchtower.called, f"{unexpected_handler} handler should not be created"
+            mock_fluent.assert_called_once_with(
+                'customer.logs',
+                host=ANY,
+                port=24224
+            )
+
+def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = TaskLogHandler('', 'arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+
+        ti = MagicMock(spec=TaskInstance)
+        ti.try_number = 1
+        ti.dag_id = 'test_dag'
+        ti.task_id = 'test_task'
+        ti.execution_date = '2023-01-01'
+
+        handler.set_context(ti)
+
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.task.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224,
+            'queue_maxsize': 50000
+        }
+
+def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = SubprocessLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_prefix',
+            'test_source',
+            True,
+            log_formatter=logging.Formatter('%(message)s')
+        )
+
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224
+        }
+
+def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = DagProcessorManagerLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_stream',
+            True
+        )
+
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224
+        }
+
+def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = DagProcessingLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_stream_template',
+            True
+        )
+
+        handler.set_context('test_dag.py')
+        
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224
+        }

--- a/tests/images/airflow/2.10.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -16,15 +16,17 @@ from unittest.mock import Mock
 
 import pytest
 
-from mwaa.logging.cloudwatch_handlers import (
-    ForkSafeFluentHandler,
-    ForkSafeFluentSender,
-)
+# Note: ForkSafeFluentHandler and ForkSafeFluentSender are imported inside
+# fixtures and test methods rather than at module level. This is because the
+# test suite uses an autouse fixture that reloads the cloudwatch_handlers module,
+# which creates new class objects. Top-level imports would hold references to
+# the original (pre-reload) classes, causing `is` and `isinstance` checks to fail.
 
 
 @pytest.fixture
 def sender():
     """Create a ForkSafeFluentSender and ensure cleanup (stops background thread)."""
+    from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
     s = ForkSafeFluentSender('test', host='localhost', port=24224)
     yield s
     s.close()
@@ -33,6 +35,7 @@ def sender():
 @pytest.fixture
 def handler():
     """Create a ForkSafeFluentHandler and ensure cleanup."""
+    from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
     h = ForkSafeFluentHandler('test', host='localhost', port=24224)
     yield h
     h.close()
@@ -53,6 +56,7 @@ class TestForkSafeFluentSender:
         sender.lock. In the child, _reinit_after_fork replaces it with a
         fresh unlocked Lock so subsequent code won't deadlock.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender.lock.acquire()
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -66,6 +70,7 @@ class TestForkSafeFluentSender:
         The _send_loop thread doesn't survive fork, so the sender can never
         deliver anything. _closed=True makes _send() return False immediately.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         assert sender._closed is True
@@ -77,6 +82,7 @@ class TestForkSafeFluentSender:
         If the _send_loop thread held Queue.mutex at fork time, the child
         inherits it locked. Replacing the Queue avoids this.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender._queue.put(b'test data', block=False)
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -89,6 +95,7 @@ class TestForkSafeFluentSender:
         Prevents the child from sharing a TCP connection with the parent,
         which would corrupt data on the wire (interleaved writes).
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender.socket = Mock()
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -102,6 +109,7 @@ class TestForkSafeFluentSender:
         on the inherited handler before set_context() replaces it, the
         message is silently dropped instead of accumulating in a dead queue.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         assert sender._send(b'test') is False
@@ -113,6 +121,7 @@ class TestForkSafeFluentSender:
         may fire after the sender is GC'd. Using weakref ensures this case
         is handled gracefully (no crash, no action).
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender = ForkSafeFluentSender('test', host='localhost', port=24224)
         ref = weakref.ref(sender)
         sender.close()
@@ -129,6 +138,7 @@ class TestForkSafeFluentSender:
         in its inherited locked state, this would deadlock. After reinit,
         the lock is fresh and unlocked, so close() completes normally.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         completed = []
@@ -153,10 +163,12 @@ class TestForkSafeFluentHandler:
         This is the extension point that makes the handler create our
         fork-safe sender instead of the default asyncsender.FluentSender.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         assert handler.getSenderClass() is ForkSafeFluentSender
 
     def test_sender_is_fork_safe_instance(self, handler):
         """Verify the lazily-created sender is a ForkSafeFluentSender."""
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         assert isinstance(handler.sender, ForkSafeFluentSender)
 
 
@@ -171,6 +183,7 @@ class TestForkSafetyIntegration:
         deterministically reproducible). This test verifies the basic machinery:
         os.register_at_fork fires, _reinit_after_fork runs, and close() completes.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
         handler = ForkSafeFluentHandler('test', host='localhost', port=24224)
         # Access sender to ensure it is fully initialized (thread + lock + queue)
         _ = handler.sender

--- a/tests/images/airflow/2.10.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -1,0 +1,203 @@
+"""Tests for ForkSafeFluentSender and ForkSafeFluentHandler.
+
+These tests verify that the fork-safety mechanism works correctly:
+- After os.register_at_fork fires _reinit_after_fork in a child process,
+  all thread-unsafe state (locks, queue, socket) is reset so the child
+  doesn't deadlock on inherited locked mutexes.
+"""
+
+import gc
+import os
+import signal
+import threading
+import time
+import weakref
+from unittest.mock import Mock
+
+import pytest
+
+from mwaa.logging.cloudwatch_handlers import (
+    ForkSafeFluentHandler,
+    ForkSafeFluentSender,
+)
+
+
+@pytest.fixture
+def sender():
+    """Create a ForkSafeFluentSender and ensure cleanup (stops background thread)."""
+    s = ForkSafeFluentSender('test', host='localhost', port=24224)
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def handler():
+    """Create a ForkSafeFluentHandler and ensure cleanup."""
+    h = ForkSafeFluentHandler('test', host='localhost', port=24224)
+    yield h
+    h.close()
+
+
+class TestForkSafeFluentSender:
+    """Tests for ForkSafeFluentSender fork-safety behavior.
+
+    Each test simulates what happens in a child process after fork by
+    calling _reinit_after_fork() directly, then verifying the sender
+    is in a safe, non-deadlocking state.
+    """
+
+    def test_reinit_after_fork_resets_lock(self, sender):
+        """Verify that a locked lock becomes acquirable after reinit.
+
+        Simulates the scenario where fork() happened while a thread held
+        sender.lock. In the child, _reinit_after_fork replaces it with a
+        fresh unlocked Lock so subsequent code won't deadlock.
+        """
+        sender.lock.acquire()
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender.lock.acquire(blocking=False), "Lock should be acquirable after reinit"
+        sender.lock.release()
+
+    def test_reinit_after_fork_marks_closed(self, sender):
+        """Verify sender is marked closed so _send() becomes a no-op.
+
+        The _send_loop thread doesn't survive fork, so the sender can never
+        deliver anything. _closed=True makes _send() return False immediately.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._closed is True
+
+    def test_reinit_after_fork_replaces_queue(self, sender):
+        """Verify the queue is replaced with a fresh empty one.
+
+        Python's Queue uses threading.Lock internally (Queue.mutex).
+        If the _send_loop thread held Queue.mutex at fork time, the child
+        inherits it locked. Replacing the Queue avoids this.
+        """
+        sender._queue.put(b'test data', block=False)
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._queue.empty(), "Queue should be empty after reinit"
+
+    def test_reinit_after_fork_closes_socket(self, sender):
+        """Verify the inherited TCP socket is closed.
+
+        Prevents the child from sharing a TCP connection with the parent,
+        which would corrupt data on the wire (interleaved writes).
+        """
+        sender.socket = Mock()
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender.socket is None
+
+    def test_send_returns_false_after_reinit(self, sender):
+        """Verify _send() is a no-op after reinit (returns False).
+
+        Confirms that if any code in the child accidentally calls emit()
+        on the inherited handler before set_context() replaces it, the
+        message is silently dropped instead of accumulating in a dead queue.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._send(b'test') is False
+
+    def test_reinit_with_dead_weakref(self):
+        """Verify reinit is a no-op when the sender has been garbage collected.
+
+        os.register_at_fork callbacks are never unregistered, so the callback
+        may fire after the sender is GC'd. Using weakref ensures this case
+        is handled gracefully (no crash, no action).
+        """
+        sender = ForkSafeFluentSender('test', host='localhost', port=24224)
+        ref = weakref.ref(sender)
+        sender.close()
+        del sender
+        gc.collect()
+
+        # Should not raise
+        ForkSafeFluentSender._reinit_after_fork(ref)
+
+    def test_close_after_reinit_does_not_deadlock(self, sender):
+        """Verify close() completes after reinit (no deadlock on lock).
+
+        asyncsender.close() does 'with self.lock:' - if the lock were still
+        in its inherited locked state, this would deadlock. After reinit,
+        the lock is fresh and unlocked, so close() completes normally.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        completed = []
+
+        def try_close():
+            sender.close()
+            completed.append(True)
+
+        t = threading.Thread(target=try_close)
+        t.start()
+        t.join(timeout=2)
+
+        assert completed, "close() deadlocked after fork reinit"
+
+
+class TestForkSafeFluentHandler:
+    """Tests for ForkSafeFluentHandler wiring."""
+
+    def test_uses_fork_safe_sender_class(self, handler):
+        """Verify getSenderClass() returns ForkSafeFluentSender.
+
+        This is the extension point that makes the handler create our
+        fork-safe sender instead of the default asyncsender.FluentSender.
+        """
+        assert handler.getSenderClass() is ForkSafeFluentSender
+
+    def test_sender_is_fork_safe_instance(self, handler):
+        """Verify the lazily-created sender is a ForkSafeFluentSender."""
+        assert isinstance(handler.sender, ForkSafeFluentSender)
+
+
+class TestForkSafetyIntegration:
+    """Integration test using actual fork()."""
+
+    def test_child_can_close_inherited_handler(self):
+        """Verify a forked child can close an inherited handler without deadlocking.
+
+        This is a smoke test. The real deadlock only occurs when a thread holds
+        the sender lock at the exact moment of fork (a race condition that is not
+        deterministically reproducible). This test verifies the basic machinery:
+        os.register_at_fork fires, _reinit_after_fork runs, and close() completes.
+        """
+        handler = ForkSafeFluentHandler('test', host='localhost', port=24224)
+        # Access sender to ensure it is fully initialized (thread + lock + queue)
+        _ = handler.sender
+
+        pid = os.fork()
+        if pid == 0:
+            # Child: close the inherited handler. Without the fix, this could
+            # deadlock if the sender lock was held at fork time.
+            try:
+                handler.close()
+                os._exit(0)
+            except Exception:
+                os._exit(1)
+        else:
+            # Parent: wait for child with timeout to detect deadlock
+            start = time.time()
+            while time.time() - start < 5:
+                result = os.waitpid(pid, os.WNOHANG)
+                if result[0] != 0:
+                    break
+                time.sleep(0.1)
+            else:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+                pytest.fail("Child process deadlocked on close() after fork")
+
+            assert os.WIFEXITED(result[1]) and os.WEXITSTATUS(result[1]) == 0, \
+                "Child process exited with error"
+
+        handler.close()

--- a/tests/images/airflow/2.10.3/python/mwaa/logging/test_cloudwatch_handler_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/logging/test_cloudwatch_handler_2_10_3.py
@@ -37,7 +37,7 @@ def mock_watchtower():
 
 @pytest.fixture
 def mock_fluent():
-    with patch('mwaa.logging.cloudwatch_handlers.fluent_handler.FluentHandler') as mock:
+    with patch('mwaa.logging.fork_safe_handler.ForkSafeFluentHandler') as mock:
         yield mock
 
 @pytest.fixture(autouse=True)

--- a/tests/images/airflow/2.10.3/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -16,15 +16,17 @@ from unittest.mock import Mock
 
 import pytest
 
-from mwaa.logging.cloudwatch_handlers import (
-    ForkSafeFluentHandler,
-    ForkSafeFluentSender,
-)
+# Note: ForkSafeFluentHandler and ForkSafeFluentSender are imported inside
+# fixtures and test methods rather than at module level. This is because the
+# test suite uses an autouse fixture that reloads the cloudwatch_handlers module,
+# which creates new class objects. Top-level imports would hold references to
+# the original (pre-reload) classes, causing `is` and `isinstance` checks to fail.
 
 
 @pytest.fixture
 def sender():
     """Create a ForkSafeFluentSender and ensure cleanup (stops background thread)."""
+    from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
     s = ForkSafeFluentSender('test', host='localhost', port=24224)
     yield s
     s.close()
@@ -33,6 +35,7 @@ def sender():
 @pytest.fixture
 def handler():
     """Create a ForkSafeFluentHandler and ensure cleanup."""
+    from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
     h = ForkSafeFluentHandler('test', host='localhost', port=24224)
     yield h
     h.close()
@@ -53,6 +56,7 @@ class TestForkSafeFluentSender:
         sender.lock. In the child, _reinit_after_fork replaces it with a
         fresh unlocked Lock so subsequent code won't deadlock.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender.lock.acquire()
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -66,6 +70,7 @@ class TestForkSafeFluentSender:
         The _send_loop thread doesn't survive fork, so the sender can never
         deliver anything. _closed=True makes _send() return False immediately.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         assert sender._closed is True
@@ -77,6 +82,7 @@ class TestForkSafeFluentSender:
         If the _send_loop thread held Queue.mutex at fork time, the child
         inherits it locked. Replacing the Queue avoids this.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender._queue.put(b'test data', block=False)
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -89,6 +95,7 @@ class TestForkSafeFluentSender:
         Prevents the child from sharing a TCP connection with the parent,
         which would corrupt data on the wire (interleaved writes).
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender.socket = Mock()
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -102,6 +109,7 @@ class TestForkSafeFluentSender:
         on the inherited handler before set_context() replaces it, the
         message is silently dropped instead of accumulating in a dead queue.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         assert sender._send(b'test') is False
@@ -113,6 +121,7 @@ class TestForkSafeFluentSender:
         may fire after the sender is GC'd. Using weakref ensures this case
         is handled gracefully (no crash, no action).
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender = ForkSafeFluentSender('test', host='localhost', port=24224)
         ref = weakref.ref(sender)
         sender.close()
@@ -129,6 +138,7 @@ class TestForkSafeFluentSender:
         in its inherited locked state, this would deadlock. After reinit,
         the lock is fresh and unlocked, so close() completes normally.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         completed = []
@@ -153,10 +163,12 @@ class TestForkSafeFluentHandler:
         This is the extension point that makes the handler create our
         fork-safe sender instead of the default asyncsender.FluentSender.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         assert handler.getSenderClass() is ForkSafeFluentSender
 
     def test_sender_is_fork_safe_instance(self, handler):
         """Verify the lazily-created sender is a ForkSafeFluentSender."""
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         assert isinstance(handler.sender, ForkSafeFluentSender)
 
 
@@ -171,6 +183,7 @@ class TestForkSafetyIntegration:
         deterministically reproducible). This test verifies the basic machinery:
         os.register_at_fork fires, _reinit_after_fork runs, and close() completes.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
         handler = ForkSafeFluentHandler('test', host='localhost', port=24224)
         # Access sender to ensure it is fully initialized (thread + lock + queue)
         _ = handler.sender
@@ -201,3 +214,4 @@ class TestForkSafetyIntegration:
                 "Child process exited with error"
 
         handler.close()
+

--- a/tests/images/airflow/2.10.3/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -1,0 +1,203 @@
+"""Tests for ForkSafeFluentSender and ForkSafeFluentHandler.
+
+These tests verify that the fork-safety mechanism works correctly:
+- After os.register_at_fork fires _reinit_after_fork in a child process,
+  all thread-unsafe state (locks, queue, socket) is reset so the child
+  doesn't deadlock on inherited locked mutexes.
+"""
+
+import gc
+import os
+import signal
+import threading
+import time
+import weakref
+from unittest.mock import Mock
+
+import pytest
+
+from mwaa.logging.cloudwatch_handlers import (
+    ForkSafeFluentHandler,
+    ForkSafeFluentSender,
+)
+
+
+@pytest.fixture
+def sender():
+    """Create a ForkSafeFluentSender and ensure cleanup (stops background thread)."""
+    s = ForkSafeFluentSender('test', host='localhost', port=24224)
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def handler():
+    """Create a ForkSafeFluentHandler and ensure cleanup."""
+    h = ForkSafeFluentHandler('test', host='localhost', port=24224)
+    yield h
+    h.close()
+
+
+class TestForkSafeFluentSender:
+    """Tests for ForkSafeFluentSender fork-safety behavior.
+
+    Each test simulates what happens in a child process after fork by
+    calling _reinit_after_fork() directly, then verifying the sender
+    is in a safe, non-deadlocking state.
+    """
+
+    def test_reinit_after_fork_resets_lock(self, sender):
+        """Verify that a locked lock becomes acquirable after reinit.
+
+        Simulates the scenario where fork() happened while a thread held
+        sender.lock. In the child, _reinit_after_fork replaces it with a
+        fresh unlocked Lock so subsequent code won't deadlock.
+        """
+        sender.lock.acquire()
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender.lock.acquire(blocking=False), "Lock should be acquirable after reinit"
+        sender.lock.release()
+
+    def test_reinit_after_fork_marks_closed(self, sender):
+        """Verify sender is marked closed so _send() becomes a no-op.
+
+        The _send_loop thread doesn't survive fork, so the sender can never
+        deliver anything. _closed=True makes _send() return False immediately.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._closed is True
+
+    def test_reinit_after_fork_replaces_queue(self, sender):
+        """Verify the queue is replaced with a fresh empty one.
+
+        Python's Queue uses threading.Lock internally (Queue.mutex).
+        If the _send_loop thread held Queue.mutex at fork time, the child
+        inherits it locked. Replacing the Queue avoids this.
+        """
+        sender._queue.put(b'test data', block=False)
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._queue.empty(), "Queue should be empty after reinit"
+
+    def test_reinit_after_fork_closes_socket(self, sender):
+        """Verify the inherited TCP socket is closed.
+
+        Prevents the child from sharing a TCP connection with the parent,
+        which would corrupt data on the wire (interleaved writes).
+        """
+        sender.socket = Mock()
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender.socket is None
+
+    def test_send_returns_false_after_reinit(self, sender):
+        """Verify _send() is a no-op after reinit (returns False).
+
+        Confirms that if any code in the child accidentally calls emit()
+        on the inherited handler before set_context() replaces it, the
+        message is silently dropped instead of accumulating in a dead queue.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._send(b'test') is False
+
+    def test_reinit_with_dead_weakref(self):
+        """Verify reinit is a no-op when the sender has been garbage collected.
+
+        os.register_at_fork callbacks are never unregistered, so the callback
+        may fire after the sender is GC'd. Using weakref ensures this case
+        is handled gracefully (no crash, no action).
+        """
+        sender = ForkSafeFluentSender('test', host='localhost', port=24224)
+        ref = weakref.ref(sender)
+        sender.close()
+        del sender
+        gc.collect()
+
+        # Should not raise
+        ForkSafeFluentSender._reinit_after_fork(ref)
+
+    def test_close_after_reinit_does_not_deadlock(self, sender):
+        """Verify close() completes after reinit (no deadlock on lock).
+
+        asyncsender.close() does 'with self.lock:' - if the lock were still
+        in its inherited locked state, this would deadlock. After reinit,
+        the lock is fresh and unlocked, so close() completes normally.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        completed = []
+
+        def try_close():
+            sender.close()
+            completed.append(True)
+
+        t = threading.Thread(target=try_close)
+        t.start()
+        t.join(timeout=2)
+
+        assert completed, "close() deadlocked after fork reinit"
+
+
+class TestForkSafeFluentHandler:
+    """Tests for ForkSafeFluentHandler wiring."""
+
+    def test_uses_fork_safe_sender_class(self, handler):
+        """Verify getSenderClass() returns ForkSafeFluentSender.
+
+        This is the extension point that makes the handler create our
+        fork-safe sender instead of the default asyncsender.FluentSender.
+        """
+        assert handler.getSenderClass() is ForkSafeFluentSender
+
+    def test_sender_is_fork_safe_instance(self, handler):
+        """Verify the lazily-created sender is a ForkSafeFluentSender."""
+        assert isinstance(handler.sender, ForkSafeFluentSender)
+
+
+class TestForkSafetyIntegration:
+    """Integration test using actual fork()."""
+
+    def test_child_can_close_inherited_handler(self):
+        """Verify a forked child can close an inherited handler without deadlocking.
+
+        This is a smoke test. The real deadlock only occurs when a thread holds
+        the sender lock at the exact moment of fork (a race condition that is not
+        deterministically reproducible). This test verifies the basic machinery:
+        os.register_at_fork fires, _reinit_after_fork runs, and close() completes.
+        """
+        handler = ForkSafeFluentHandler('test', host='localhost', port=24224)
+        # Access sender to ensure it is fully initialized (thread + lock + queue)
+        _ = handler.sender
+
+        pid = os.fork()
+        if pid == 0:
+            # Child: close the inherited handler. Without the fix, this could
+            # deadlock if the sender lock was held at fork time.
+            try:
+                handler.close()
+                os._exit(0)
+            except Exception:
+                os._exit(1)
+        else:
+            # Parent: wait for child with timeout to detect deadlock
+            start = time.time()
+            while time.time() - start < 5:
+                result = os.waitpid(pid, os.WNOHANG)
+                if result[0] != 0:
+                    break
+                time.sleep(0.1)
+            else:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+                pytest.fail("Child process deadlocked on close() after fork")
+
+            assert os.WIFEXITED(result[1]) and os.WEXITSTATUS(result[1]) == 0, \
+                "Child process exited with error"
+
+        handler.close()

--- a/tests/images/airflow/2.11.0/python/mwaa/logging/test_cloudwatch_handler_2_11_0.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/logging/test_cloudwatch_handler_2_11_0.py
@@ -38,7 +38,7 @@ def mock_watchtower():
 
 @pytest.fixture
 def mock_fluent():
-    with patch('mwaa.logging.cloudwatch_handlers.fluent_handler.FluentHandler') as mock:
+    with patch('mwaa.logging.fork_safe_handler.ForkSafeFluentHandler') as mock:
         yield mock
 
 @pytest.fixture(autouse=True)

--- a/tests/images/airflow/2.11.0/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -16,15 +16,17 @@ from unittest.mock import Mock
 
 import pytest
 
-from mwaa.logging.cloudwatch_handlers import (
-    ForkSafeFluentHandler,
-    ForkSafeFluentSender,
-)
+# Note: ForkSafeFluentHandler and ForkSafeFluentSender are imported inside
+# fixtures and test methods rather than at module level. This is because the
+# test suite uses an autouse fixture that reloads the cloudwatch_handlers module,
+# which creates new class objects. Top-level imports would hold references to
+# the original (pre-reload) classes, causing `is` and `isinstance` checks to fail.
 
 
 @pytest.fixture
 def sender():
     """Create a ForkSafeFluentSender and ensure cleanup (stops background thread)."""
+    from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
     s = ForkSafeFluentSender('test', host='localhost', port=24224)
     yield s
     s.close()
@@ -33,6 +35,7 @@ def sender():
 @pytest.fixture
 def handler():
     """Create a ForkSafeFluentHandler and ensure cleanup."""
+    from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
     h = ForkSafeFluentHandler('test', host='localhost', port=24224)
     yield h
     h.close()
@@ -53,6 +56,7 @@ class TestForkSafeFluentSender:
         sender.lock. In the child, _reinit_after_fork replaces it with a
         fresh unlocked Lock so subsequent code won't deadlock.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender.lock.acquire()
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -66,6 +70,7 @@ class TestForkSafeFluentSender:
         The _send_loop thread doesn't survive fork, so the sender can never
         deliver anything. _closed=True makes _send() return False immediately.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         assert sender._closed is True
@@ -77,6 +82,7 @@ class TestForkSafeFluentSender:
         If the _send_loop thread held Queue.mutex at fork time, the child
         inherits it locked. Replacing the Queue avoids this.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender._queue.put(b'test data', block=False)
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -89,6 +95,7 @@ class TestForkSafeFluentSender:
         Prevents the child from sharing a TCP connection with the parent,
         which would corrupt data on the wire (interleaved writes).
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender.socket = Mock()
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -102,6 +109,7 @@ class TestForkSafeFluentSender:
         on the inherited handler before set_context() replaces it, the
         message is silently dropped instead of accumulating in a dead queue.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         assert sender._send(b'test') is False
@@ -113,6 +121,7 @@ class TestForkSafeFluentSender:
         may fire after the sender is GC'd. Using weakref ensures this case
         is handled gracefully (no crash, no action).
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender = ForkSafeFluentSender('test', host='localhost', port=24224)
         ref = weakref.ref(sender)
         sender.close()
@@ -129,6 +138,7 @@ class TestForkSafeFluentSender:
         in its inherited locked state, this would deadlock. After reinit,
         the lock is fresh and unlocked, so close() completes normally.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         completed = []
@@ -153,10 +163,12 @@ class TestForkSafeFluentHandler:
         This is the extension point that makes the handler create our
         fork-safe sender instead of the default asyncsender.FluentSender.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         assert handler.getSenderClass() is ForkSafeFluentSender
 
     def test_sender_is_fork_safe_instance(self, handler):
         """Verify the lazily-created sender is a ForkSafeFluentSender."""
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         assert isinstance(handler.sender, ForkSafeFluentSender)
 
 
@@ -171,6 +183,7 @@ class TestForkSafetyIntegration:
         deterministically reproducible). This test verifies the basic machinery:
         os.register_at_fork fires, _reinit_after_fork runs, and close() completes.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
         handler = ForkSafeFluentHandler('test', host='localhost', port=24224)
         # Access sender to ensure it is fully initialized (thread + lock + queue)
         _ = handler.sender

--- a/tests/images/airflow/2.11.0/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -1,0 +1,203 @@
+"""Tests for ForkSafeFluentSender and ForkSafeFluentHandler.
+
+These tests verify that the fork-safety mechanism works correctly:
+- After os.register_at_fork fires _reinit_after_fork in a child process,
+  all thread-unsafe state (locks, queue, socket) is reset so the child
+  doesn't deadlock on inherited locked mutexes.
+"""
+
+import gc
+import os
+import signal
+import threading
+import time
+import weakref
+from unittest.mock import Mock
+
+import pytest
+
+from mwaa.logging.cloudwatch_handlers import (
+    ForkSafeFluentHandler,
+    ForkSafeFluentSender,
+)
+
+
+@pytest.fixture
+def sender():
+    """Create a ForkSafeFluentSender and ensure cleanup (stops background thread)."""
+    s = ForkSafeFluentSender('test', host='localhost', port=24224)
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def handler():
+    """Create a ForkSafeFluentHandler and ensure cleanup."""
+    h = ForkSafeFluentHandler('test', host='localhost', port=24224)
+    yield h
+    h.close()
+
+
+class TestForkSafeFluentSender:
+    """Tests for ForkSafeFluentSender fork-safety behavior.
+
+    Each test simulates what happens in a child process after fork by
+    calling _reinit_after_fork() directly, then verifying the sender
+    is in a safe, non-deadlocking state.
+    """
+
+    def test_reinit_after_fork_resets_lock(self, sender):
+        """Verify that a locked lock becomes acquirable after reinit.
+
+        Simulates the scenario where fork() happened while a thread held
+        sender.lock. In the child, _reinit_after_fork replaces it with a
+        fresh unlocked Lock so subsequent code won't deadlock.
+        """
+        sender.lock.acquire()
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender.lock.acquire(blocking=False), "Lock should be acquirable after reinit"
+        sender.lock.release()
+
+    def test_reinit_after_fork_marks_closed(self, sender):
+        """Verify sender is marked closed so _send() becomes a no-op.
+
+        The _send_loop thread doesn't survive fork, so the sender can never
+        deliver anything. _closed=True makes _send() return False immediately.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._closed is True
+
+    def test_reinit_after_fork_replaces_queue(self, sender):
+        """Verify the queue is replaced with a fresh empty one.
+
+        Python's Queue uses threading.Lock internally (Queue.mutex).
+        If the _send_loop thread held Queue.mutex at fork time, the child
+        inherits it locked. Replacing the Queue avoids this.
+        """
+        sender._queue.put(b'test data', block=False)
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._queue.empty(), "Queue should be empty after reinit"
+
+    def test_reinit_after_fork_closes_socket(self, sender):
+        """Verify the inherited TCP socket is closed.
+
+        Prevents the child from sharing a TCP connection with the parent,
+        which would corrupt data on the wire (interleaved writes).
+        """
+        sender.socket = Mock()
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender.socket is None
+
+    def test_send_returns_false_after_reinit(self, sender):
+        """Verify _send() is a no-op after reinit (returns False).
+
+        Confirms that if any code in the child accidentally calls emit()
+        on the inherited handler before set_context() replaces it, the
+        message is silently dropped instead of accumulating in a dead queue.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._send(b'test') is False
+
+    def test_reinit_with_dead_weakref(self):
+        """Verify reinit is a no-op when the sender has been garbage collected.
+
+        os.register_at_fork callbacks are never unregistered, so the callback
+        may fire after the sender is GC'd. Using weakref ensures this case
+        is handled gracefully (no crash, no action).
+        """
+        sender = ForkSafeFluentSender('test', host='localhost', port=24224)
+        ref = weakref.ref(sender)
+        sender.close()
+        del sender
+        gc.collect()
+
+        # Should not raise
+        ForkSafeFluentSender._reinit_after_fork(ref)
+
+    def test_close_after_reinit_does_not_deadlock(self, sender):
+        """Verify close() completes after reinit (no deadlock on lock).
+
+        asyncsender.close() does 'with self.lock:' - if the lock were still
+        in its inherited locked state, this would deadlock. After reinit,
+        the lock is fresh and unlocked, so close() completes normally.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        completed = []
+
+        def try_close():
+            sender.close()
+            completed.append(True)
+
+        t = threading.Thread(target=try_close)
+        t.start()
+        t.join(timeout=2)
+
+        assert completed, "close() deadlocked after fork reinit"
+
+
+class TestForkSafeFluentHandler:
+    """Tests for ForkSafeFluentHandler wiring."""
+
+    def test_uses_fork_safe_sender_class(self, handler):
+        """Verify getSenderClass() returns ForkSafeFluentSender.
+
+        This is the extension point that makes the handler create our
+        fork-safe sender instead of the default asyncsender.FluentSender.
+        """
+        assert handler.getSenderClass() is ForkSafeFluentSender
+
+    def test_sender_is_fork_safe_instance(self, handler):
+        """Verify the lazily-created sender is a ForkSafeFluentSender."""
+        assert isinstance(handler.sender, ForkSafeFluentSender)
+
+
+class TestForkSafetyIntegration:
+    """Integration test using actual fork()."""
+
+    def test_child_can_close_inherited_handler(self):
+        """Verify a forked child can close an inherited handler without deadlocking.
+
+        This is a smoke test. The real deadlock only occurs when a thread holds
+        the sender lock at the exact moment of fork (a race condition that is not
+        deterministically reproducible). This test verifies the basic machinery:
+        os.register_at_fork fires, _reinit_after_fork runs, and close() completes.
+        """
+        handler = ForkSafeFluentHandler('test', host='localhost', port=24224)
+        # Access sender to ensure it is fully initialized (thread + lock + queue)
+        _ = handler.sender
+
+        pid = os.fork()
+        if pid == 0:
+            # Child: close the inherited handler. Without the fix, this could
+            # deadlock if the sender lock was held at fork time.
+            try:
+                handler.close()
+                os._exit(0)
+            except Exception:
+                os._exit(1)
+        else:
+            # Parent: wait for child with timeout to detect deadlock
+            start = time.time()
+            while time.time() - start < 5:
+                result = os.waitpid(pid, os.WNOHANG)
+                if result[0] != 0:
+                    break
+                time.sleep(0.1)
+            else:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+                pytest.fail("Child process deadlocked on close() after fork")
+
+            assert os.WIFEXITED(result[1]) and os.WEXITSTATUS(result[1]) == 0, \
+                "Child process exited with error"
+
+        handler.close()

--- a/tests/images/airflow/2.9.2/python/mwaa/logging/test_cloudwatch_handler_2_9_2.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/logging/test_cloudwatch_handler_2_9_2.py
@@ -1,7 +1,9 @@
 import logging
 import pytest
 import os
-from unittest.mock import patch, Mock
+import importlib
+from unittest.mock import patch, Mock, MagicMock, ANY
+from airflow.models.taskinstance import TaskInstance
 from mwaa.config.setup_environment import (
     setup_environment_variables,
     _execute_startup_script,
@@ -9,13 +11,40 @@ from mwaa.config.setup_environment import (
     _is_protected_os_environ,
 )
 from mwaa.subprocess.subprocess import Subprocess
-from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+from mwaa.logging.cloudwatch_handlers import (
+    BaseLogHandler,
+    TaskLogHandler,
+    SubprocessLogHandler,
+    DagProcessorManagerLogHandler,
+    DagProcessingLogHandler
+)
 
 print(BaseLogHandler.__init__.__code__.co_varnames)
 
 @pytest.fixture
 def mock_handler():
     return Mock()
+
+@pytest.fixture
+def mock_boto3_client():
+    with patch('boto3.client') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_watchtower():
+    with patch('mwaa.logging.cloudwatch_handlers.watchtower.CloudWatchLogHandler') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_fluent():
+    with patch('mwaa.logging.fork_safe_handler.ForkSafeFluentHandler') as mock:
+        yield mock
+
+@pytest.fixture(autouse=True)
+def reload_module():
+    import importlib
+    import mwaa.logging.cloudwatch_handlers
+    importlib.reload(mwaa.logging.cloudwatch_handlers)
 
 
 @pytest.fixture
@@ -123,3 +152,133 @@ def test_emit_handles_exception(base_logger):
 
         # Verify that _report_logging_error was called with the correct message
         mock_report_error.assert_called_once_with("Failed to emit log record.")
+
+@pytest.mark.parametrize("use_non_critical_logging, expected_handler, unexpected_handler", [
+    ('false', 'watchtower', 'fluent'),
+    ('true', 'fluent', 'watchtower')
+])
+def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, use_non_critical_logging, expected_handler, unexpected_handler):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': use_non_critical_logging}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'test_source')
+
+        assert handler.handler is not None, "No handler was created"
+
+        if expected_handler == 'watchtower':
+            assert isinstance(handler.handler, mock_watchtower.return_value.__class__), "Created handler should be a Watchtower handler"
+            assert mock_watchtower.called, f"{expected_handler} handler should be created"
+            assert not mock_fluent.called, f"{unexpected_handler} handler should not be created"
+            mock_watchtower.assert_called_once_with(
+                log_group_name=handler.log_group_name,
+                log_stream_name='test_stream',
+                boto3_client=mock_boto3_client.return_value,
+                use_queues=True,
+                send_interval=10,
+                create_log_group=False
+            )
+        else:
+            assert isinstance(handler.handler, mock_fluent.return_value.__class__), "Created handler should be a Fluent handler"
+            assert mock_fluent.called, f"{expected_handler} handler should be created"
+            assert not mock_watchtower.called, f"{unexpected_handler} handler should not be created"
+            mock_fluent.assert_called_once_with(
+                'customer.logs',
+                host=ANY,
+                port=24224
+            )
+
+def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = TaskLogHandler('', 'arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+
+        ti = MagicMock(spec=TaskInstance)
+        ti.try_number = 1
+        ti.dag_id = 'test_dag'
+        ti.task_id = 'test_task'
+        ti.execution_date = '2023-01-01'
+
+        handler.set_context(ti)
+
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.task.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224,
+            'queue_maxsize': 50000
+        }
+
+def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = SubprocessLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_prefix',
+            'test_source',
+            True,
+            log_formatter=logging.Formatter('%(message)s')
+        )
+
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224
+        }
+
+def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = DagProcessorManagerLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_stream',
+            True
+        )
+
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224
+        }
+
+def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = DagProcessingLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_stream_template',
+            True
+        )
+
+        handler.set_context('test_dag.py')
+        
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224
+        }

--- a/tests/images/airflow/2.9.2/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -16,15 +16,17 @@ from unittest.mock import Mock
 
 import pytest
 
-from mwaa.logging.cloudwatch_handlers import (
-    ForkSafeFluentHandler,
-    ForkSafeFluentSender,
-)
+# Note: ForkSafeFluentHandler and ForkSafeFluentSender are imported inside
+# fixtures and test methods rather than at module level. This is because the
+# test suite uses an autouse fixture that reloads the cloudwatch_handlers module,
+# which creates new class objects. Top-level imports would hold references to
+# the original (pre-reload) classes, causing `is` and `isinstance` checks to fail.
 
 
 @pytest.fixture
 def sender():
     """Create a ForkSafeFluentSender and ensure cleanup (stops background thread)."""
+    from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
     s = ForkSafeFluentSender('test', host='localhost', port=24224)
     yield s
     s.close()
@@ -33,6 +35,7 @@ def sender():
 @pytest.fixture
 def handler():
     """Create a ForkSafeFluentHandler and ensure cleanup."""
+    from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
     h = ForkSafeFluentHandler('test', host='localhost', port=24224)
     yield h
     h.close()
@@ -53,6 +56,7 @@ class TestForkSafeFluentSender:
         sender.lock. In the child, _reinit_after_fork replaces it with a
         fresh unlocked Lock so subsequent code won't deadlock.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender.lock.acquire()
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -66,6 +70,7 @@ class TestForkSafeFluentSender:
         The _send_loop thread doesn't survive fork, so the sender can never
         deliver anything. _closed=True makes _send() return False immediately.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         assert sender._closed is True
@@ -77,6 +82,7 @@ class TestForkSafeFluentSender:
         If the _send_loop thread held Queue.mutex at fork time, the child
         inherits it locked. Replacing the Queue avoids this.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender._queue.put(b'test data', block=False)
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -89,6 +95,7 @@ class TestForkSafeFluentSender:
         Prevents the child from sharing a TCP connection with the parent,
         which would corrupt data on the wire (interleaved writes).
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender.socket = Mock()
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -102,6 +109,7 @@ class TestForkSafeFluentSender:
         on the inherited handler before set_context() replaces it, the
         message is silently dropped instead of accumulating in a dead queue.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         assert sender._send(b'test') is False
@@ -113,6 +121,7 @@ class TestForkSafeFluentSender:
         may fire after the sender is GC'd. Using weakref ensures this case
         is handled gracefully (no crash, no action).
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender = ForkSafeFluentSender('test', host='localhost', port=24224)
         ref = weakref.ref(sender)
         sender.close()
@@ -129,6 +138,7 @@ class TestForkSafeFluentSender:
         in its inherited locked state, this would deadlock. After reinit,
         the lock is fresh and unlocked, so close() completes normally.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         completed = []
@@ -153,10 +163,12 @@ class TestForkSafeFluentHandler:
         This is the extension point that makes the handler create our
         fork-safe sender instead of the default asyncsender.FluentSender.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         assert handler.getSenderClass() is ForkSafeFluentSender
 
     def test_sender_is_fork_safe_instance(self, handler):
         """Verify the lazily-created sender is a ForkSafeFluentSender."""
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         assert isinstance(handler.sender, ForkSafeFluentSender)
 
 
@@ -171,6 +183,7 @@ class TestForkSafetyIntegration:
         deterministically reproducible). This test verifies the basic machinery:
         os.register_at_fork fires, _reinit_after_fork runs, and close() completes.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
         handler = ForkSafeFluentHandler('test', host='localhost', port=24224)
         # Access sender to ensure it is fully initialized (thread + lock + queue)
         _ = handler.sender

--- a/tests/images/airflow/2.9.2/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -1,0 +1,203 @@
+"""Tests for ForkSafeFluentSender and ForkSafeFluentHandler.
+
+These tests verify that the fork-safety mechanism works correctly:
+- After os.register_at_fork fires _reinit_after_fork in a child process,
+  all thread-unsafe state (locks, queue, socket) is reset so the child
+  doesn't deadlock on inherited locked mutexes.
+"""
+
+import gc
+import os
+import signal
+import threading
+import time
+import weakref
+from unittest.mock import Mock
+
+import pytest
+
+from mwaa.logging.cloudwatch_handlers import (
+    ForkSafeFluentHandler,
+    ForkSafeFluentSender,
+)
+
+
+@pytest.fixture
+def sender():
+    """Create a ForkSafeFluentSender and ensure cleanup (stops background thread)."""
+    s = ForkSafeFluentSender('test', host='localhost', port=24224)
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def handler():
+    """Create a ForkSafeFluentHandler and ensure cleanup."""
+    h = ForkSafeFluentHandler('test', host='localhost', port=24224)
+    yield h
+    h.close()
+
+
+class TestForkSafeFluentSender:
+    """Tests for ForkSafeFluentSender fork-safety behavior.
+
+    Each test simulates what happens in a child process after fork by
+    calling _reinit_after_fork() directly, then verifying the sender
+    is in a safe, non-deadlocking state.
+    """
+
+    def test_reinit_after_fork_resets_lock(self, sender):
+        """Verify that a locked lock becomes acquirable after reinit.
+
+        Simulates the scenario where fork() happened while a thread held
+        sender.lock. In the child, _reinit_after_fork replaces it with a
+        fresh unlocked Lock so subsequent code won't deadlock.
+        """
+        sender.lock.acquire()
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender.lock.acquire(blocking=False), "Lock should be acquirable after reinit"
+        sender.lock.release()
+
+    def test_reinit_after_fork_marks_closed(self, sender):
+        """Verify sender is marked closed so _send() becomes a no-op.
+
+        The _send_loop thread doesn't survive fork, so the sender can never
+        deliver anything. _closed=True makes _send() return False immediately.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._closed is True
+
+    def test_reinit_after_fork_replaces_queue(self, sender):
+        """Verify the queue is replaced with a fresh empty one.
+
+        Python's Queue uses threading.Lock internally (Queue.mutex).
+        If the _send_loop thread held Queue.mutex at fork time, the child
+        inherits it locked. Replacing the Queue avoids this.
+        """
+        sender._queue.put(b'test data', block=False)
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._queue.empty(), "Queue should be empty after reinit"
+
+    def test_reinit_after_fork_closes_socket(self, sender):
+        """Verify the inherited TCP socket is closed.
+
+        Prevents the child from sharing a TCP connection with the parent,
+        which would corrupt data on the wire (interleaved writes).
+        """
+        sender.socket = Mock()
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender.socket is None
+
+    def test_send_returns_false_after_reinit(self, sender):
+        """Verify _send() is a no-op after reinit (returns False).
+
+        Confirms that if any code in the child accidentally calls emit()
+        on the inherited handler before set_context() replaces it, the
+        message is silently dropped instead of accumulating in a dead queue.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._send(b'test') is False
+
+    def test_reinit_with_dead_weakref(self):
+        """Verify reinit is a no-op when the sender has been garbage collected.
+
+        os.register_at_fork callbacks are never unregistered, so the callback
+        may fire after the sender is GC'd. Using weakref ensures this case
+        is handled gracefully (no crash, no action).
+        """
+        sender = ForkSafeFluentSender('test', host='localhost', port=24224)
+        ref = weakref.ref(sender)
+        sender.close()
+        del sender
+        gc.collect()
+
+        # Should not raise
+        ForkSafeFluentSender._reinit_after_fork(ref)
+
+    def test_close_after_reinit_does_not_deadlock(self, sender):
+        """Verify close() completes after reinit (no deadlock on lock).
+
+        asyncsender.close() does 'with self.lock:' - if the lock were still
+        in its inherited locked state, this would deadlock. After reinit,
+        the lock is fresh and unlocked, so close() completes normally.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        completed = []
+
+        def try_close():
+            sender.close()
+            completed.append(True)
+
+        t = threading.Thread(target=try_close)
+        t.start()
+        t.join(timeout=2)
+
+        assert completed, "close() deadlocked after fork reinit"
+
+
+class TestForkSafeFluentHandler:
+    """Tests for ForkSafeFluentHandler wiring."""
+
+    def test_uses_fork_safe_sender_class(self, handler):
+        """Verify getSenderClass() returns ForkSafeFluentSender.
+
+        This is the extension point that makes the handler create our
+        fork-safe sender instead of the default asyncsender.FluentSender.
+        """
+        assert handler.getSenderClass() is ForkSafeFluentSender
+
+    def test_sender_is_fork_safe_instance(self, handler):
+        """Verify the lazily-created sender is a ForkSafeFluentSender."""
+        assert isinstance(handler.sender, ForkSafeFluentSender)
+
+
+class TestForkSafetyIntegration:
+    """Integration test using actual fork()."""
+
+    def test_child_can_close_inherited_handler(self):
+        """Verify a forked child can close an inherited handler without deadlocking.
+
+        This is a smoke test. The real deadlock only occurs when a thread holds
+        the sender lock at the exact moment of fork (a race condition that is not
+        deterministically reproducible). This test verifies the basic machinery:
+        os.register_at_fork fires, _reinit_after_fork runs, and close() completes.
+        """
+        handler = ForkSafeFluentHandler('test', host='localhost', port=24224)
+        # Access sender to ensure it is fully initialized (thread + lock + queue)
+        _ = handler.sender
+
+        pid = os.fork()
+        if pid == 0:
+            # Child: close the inherited handler. Without the fix, this could
+            # deadlock if the sender lock was held at fork time.
+            try:
+                handler.close()
+                os._exit(0)
+            except Exception:
+                os._exit(1)
+        else:
+            # Parent: wait for child with timeout to detect deadlock
+            start = time.time()
+            while time.time() - start < 5:
+                result = os.waitpid(pid, os.WNOHANG)
+                if result[0] != 0:
+                    break
+                time.sleep(0.1)
+            else:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+                pytest.fail("Child process deadlocked on close() after fork")
+
+            assert os.WIFEXITED(result[1]) and os.WEXITSTATUS(result[1]) == 0, \
+                "Child process exited with error"
+
+        handler.close()

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -39,7 +39,7 @@ def mock_watchtower():
 
 @pytest.fixture
 def mock_fluent():
-    with patch('mwaa.logging.cloudwatch_handlers.fluent_handler.FluentHandler') as mock:
+    with patch('mwaa.logging.fork_safe_handler.ForkSafeFluentHandler') as mock:
         yield mock
 
 @pytest.fixture(autouse=True)

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -16,15 +16,17 @@ from unittest.mock import Mock
 
 import pytest
 
-from mwaa.logging.cloudwatch_handlers import (
-    ForkSafeFluentHandler,
-    ForkSafeFluentSender,
-)
+# Note: ForkSafeFluentHandler and ForkSafeFluentSender are imported inside
+# fixtures and test methods rather than at module level. This is because the
+# test suite uses an autouse fixture that reloads the cloudwatch_handlers module,
+# which creates new class objects. Top-level imports would hold references to
+# the original (pre-reload) classes, causing `is` and `isinstance` checks to fail.
 
 
 @pytest.fixture
 def sender():
     """Create a ForkSafeFluentSender and ensure cleanup (stops background thread)."""
+    from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
     s = ForkSafeFluentSender('test', host='localhost', port=24224)
     yield s
     s.close()
@@ -33,6 +35,7 @@ def sender():
 @pytest.fixture
 def handler():
     """Create a ForkSafeFluentHandler and ensure cleanup."""
+    from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
     h = ForkSafeFluentHandler('test', host='localhost', port=24224)
     yield h
     h.close()
@@ -53,6 +56,7 @@ class TestForkSafeFluentSender:
         sender.lock. In the child, _reinit_after_fork replaces it with a
         fresh unlocked Lock so subsequent code won't deadlock.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender.lock.acquire()
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -66,6 +70,7 @@ class TestForkSafeFluentSender:
         The _send_loop thread doesn't survive fork, so the sender can never
         deliver anything. _closed=True makes _send() return False immediately.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         assert sender._closed is True
@@ -77,6 +82,7 @@ class TestForkSafeFluentSender:
         If the _send_loop thread held Queue.mutex at fork time, the child
         inherits it locked. Replacing the Queue avoids this.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender._queue.put(b'test data', block=False)
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -89,6 +95,7 @@ class TestForkSafeFluentSender:
         Prevents the child from sharing a TCP connection with the parent,
         which would corrupt data on the wire (interleaved writes).
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender.socket = Mock()
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -102,6 +109,7 @@ class TestForkSafeFluentSender:
         on the inherited handler before set_context() replaces it, the
         message is silently dropped instead of accumulating in a dead queue.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         assert sender._send(b'test') is False
@@ -113,6 +121,7 @@ class TestForkSafeFluentSender:
         may fire after the sender is GC'd. Using weakref ensures this case
         is handled gracefully (no crash, no action).
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender = ForkSafeFluentSender('test', host='localhost', port=24224)
         ref = weakref.ref(sender)
         sender.close()
@@ -129,6 +138,7 @@ class TestForkSafeFluentSender:
         in its inherited locked state, this would deadlock. After reinit,
         the lock is fresh and unlocked, so close() completes normally.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         completed = []
@@ -153,10 +163,12 @@ class TestForkSafeFluentHandler:
         This is the extension point that makes the handler create our
         fork-safe sender instead of the default asyncsender.FluentSender.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         assert handler.getSenderClass() is ForkSafeFluentSender
 
     def test_sender_is_fork_safe_instance(self, handler):
         """Verify the lazily-created sender is a ForkSafeFluentSender."""
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         assert isinstance(handler.sender, ForkSafeFluentSender)
 
 
@@ -171,6 +183,7 @@ class TestForkSafetyIntegration:
         deterministically reproducible). This test verifies the basic machinery:
         os.register_at_fork fires, _reinit_after_fork runs, and close() completes.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
         handler = ForkSafeFluentHandler('test', host='localhost', port=24224)
         # Access sender to ensure it is fully initialized (thread + lock + queue)
         _ = handler.sender

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -1,0 +1,203 @@
+"""Tests for ForkSafeFluentSender and ForkSafeFluentHandler.
+
+These tests verify that the fork-safety mechanism works correctly:
+- After os.register_at_fork fires _reinit_after_fork in a child process,
+  all thread-unsafe state (locks, queue, socket) is reset so the child
+  doesn't deadlock on inherited locked mutexes.
+"""
+
+import gc
+import os
+import signal
+import threading
+import time
+import weakref
+from unittest.mock import Mock
+
+import pytest
+
+from mwaa.logging.cloudwatch_handlers import (
+    ForkSafeFluentHandler,
+    ForkSafeFluentSender,
+)
+
+
+@pytest.fixture
+def sender():
+    """Create a ForkSafeFluentSender and ensure cleanup (stops background thread)."""
+    s = ForkSafeFluentSender('test', host='localhost', port=24224)
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def handler():
+    """Create a ForkSafeFluentHandler and ensure cleanup."""
+    h = ForkSafeFluentHandler('test', host='localhost', port=24224)
+    yield h
+    h.close()
+
+
+class TestForkSafeFluentSender:
+    """Tests for ForkSafeFluentSender fork-safety behavior.
+
+    Each test simulates what happens in a child process after fork by
+    calling _reinit_after_fork() directly, then verifying the sender
+    is in a safe, non-deadlocking state.
+    """
+
+    def test_reinit_after_fork_resets_lock(self, sender):
+        """Verify that a locked lock becomes acquirable after reinit.
+
+        Simulates the scenario where fork() happened while a thread held
+        sender.lock. In the child, _reinit_after_fork replaces it with a
+        fresh unlocked Lock so subsequent code won't deadlock.
+        """
+        sender.lock.acquire()
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender.lock.acquire(blocking=False), "Lock should be acquirable after reinit"
+        sender.lock.release()
+
+    def test_reinit_after_fork_marks_closed(self, sender):
+        """Verify sender is marked closed so _send() becomes a no-op.
+
+        The _send_loop thread doesn't survive fork, so the sender can never
+        deliver anything. _closed=True makes _send() return False immediately.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._closed is True
+
+    def test_reinit_after_fork_replaces_queue(self, sender):
+        """Verify the queue is replaced with a fresh empty one.
+
+        Python's Queue uses threading.Lock internally (Queue.mutex).
+        If the _send_loop thread held Queue.mutex at fork time, the child
+        inherits it locked. Replacing the Queue avoids this.
+        """
+        sender._queue.put(b'test data', block=False)
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._queue.empty(), "Queue should be empty after reinit"
+
+    def test_reinit_after_fork_closes_socket(self, sender):
+        """Verify the inherited TCP socket is closed.
+
+        Prevents the child from sharing a TCP connection with the parent,
+        which would corrupt data on the wire (interleaved writes).
+        """
+        sender.socket = Mock()
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender.socket is None
+
+    def test_send_returns_false_after_reinit(self, sender):
+        """Verify _send() is a no-op after reinit (returns False).
+
+        Confirms that if any code in the child accidentally calls emit()
+        on the inherited handler before set_context() replaces it, the
+        message is silently dropped instead of accumulating in a dead queue.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._send(b'test') is False
+
+    def test_reinit_with_dead_weakref(self):
+        """Verify reinit is a no-op when the sender has been garbage collected.
+
+        os.register_at_fork callbacks are never unregistered, so the callback
+        may fire after the sender is GC'd. Using weakref ensures this case
+        is handled gracefully (no crash, no action).
+        """
+        sender = ForkSafeFluentSender('test', host='localhost', port=24224)
+        ref = weakref.ref(sender)
+        sender.close()
+        del sender
+        gc.collect()
+
+        # Should not raise
+        ForkSafeFluentSender._reinit_after_fork(ref)
+
+    def test_close_after_reinit_does_not_deadlock(self, sender):
+        """Verify close() completes after reinit (no deadlock on lock).
+
+        asyncsender.close() does 'with self.lock:' - if the lock were still
+        in its inherited locked state, this would deadlock. After reinit,
+        the lock is fresh and unlocked, so close() completes normally.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        completed = []
+
+        def try_close():
+            sender.close()
+            completed.append(True)
+
+        t = threading.Thread(target=try_close)
+        t.start()
+        t.join(timeout=2)
+
+        assert completed, "close() deadlocked after fork reinit"
+
+
+class TestForkSafeFluentHandler:
+    """Tests for ForkSafeFluentHandler wiring."""
+
+    def test_uses_fork_safe_sender_class(self, handler):
+        """Verify getSenderClass() returns ForkSafeFluentSender.
+
+        This is the extension point that makes the handler create our
+        fork-safe sender instead of the default asyncsender.FluentSender.
+        """
+        assert handler.getSenderClass() is ForkSafeFluentSender
+
+    def test_sender_is_fork_safe_instance(self, handler):
+        """Verify the lazily-created sender is a ForkSafeFluentSender."""
+        assert isinstance(handler.sender, ForkSafeFluentSender)
+
+
+class TestForkSafetyIntegration:
+    """Integration test using actual fork()."""
+
+    def test_child_can_close_inherited_handler(self):
+        """Verify a forked child can close an inherited handler without deadlocking.
+
+        This is a smoke test. The real deadlock only occurs when a thread holds
+        the sender lock at the exact moment of fork (a race condition that is not
+        deterministically reproducible). This test verifies the basic machinery:
+        os.register_at_fork fires, _reinit_after_fork runs, and close() completes.
+        """
+        handler = ForkSafeFluentHandler('test', host='localhost', port=24224)
+        # Access sender to ensure it is fully initialized (thread + lock + queue)
+        _ = handler.sender
+
+        pid = os.fork()
+        if pid == 0:
+            # Child: close the inherited handler. Without the fix, this could
+            # deadlock if the sender lock was held at fork time.
+            try:
+                handler.close()
+                os._exit(0)
+            except Exception:
+                os._exit(1)
+        else:
+            # Parent: wait for child with timeout to detect deadlock
+            start = time.time()
+            while time.time() - start < 5:
+                result = os.waitpid(pid, os.WNOHANG)
+                if result[0] != 0:
+                    break
+                time.sleep(0.1)
+            else:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+                pytest.fail("Child process deadlocked on close() after fork")
+
+            assert os.WIFEXITED(result[1]) and os.WEXITSTATUS(result[1]) == 0, \
+                "Child process exited with error"
+
+        handler.close()

--- a/tests/images/airflow/3.2.1/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/logging/test_cloudwatch_handler.py
@@ -39,7 +39,7 @@ def mock_watchtower():
 
 @pytest.fixture
 def mock_fluent():
-    with patch('mwaa.logging.cloudwatch_handlers.fluent_handler.FluentHandler') as mock:
+    with patch('mwaa.logging.fork_safe_handler.ForkSafeFluentHandler') as mock:
         yield mock
 
 @pytest.fixture(autouse=True)

--- a/tests/images/airflow/3.2.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -16,15 +16,17 @@ from unittest.mock import Mock
 
 import pytest
 
-from mwaa.logging.cloudwatch_handlers import (
-    ForkSafeFluentHandler,
-    ForkSafeFluentSender,
-)
+# Note: ForkSafeFluentHandler and ForkSafeFluentSender are imported inside
+# fixtures and test methods rather than at module level. This is because the
+# test suite uses an autouse fixture that reloads the cloudwatch_handlers module,
+# which creates new class objects. Top-level imports would hold references to
+# the original (pre-reload) classes, causing `is` and `isinstance` checks to fail.
 
 
 @pytest.fixture
 def sender():
     """Create a ForkSafeFluentSender and ensure cleanup (stops background thread)."""
+    from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
     s = ForkSafeFluentSender('test', host='localhost', port=24224)
     yield s
     s.close()
@@ -33,6 +35,7 @@ def sender():
 @pytest.fixture
 def handler():
     """Create a ForkSafeFluentHandler and ensure cleanup."""
+    from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
     h = ForkSafeFluentHandler('test', host='localhost', port=24224)
     yield h
     h.close()
@@ -53,6 +56,7 @@ class TestForkSafeFluentSender:
         sender.lock. In the child, _reinit_after_fork replaces it with a
         fresh unlocked Lock so subsequent code won't deadlock.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender.lock.acquire()
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -66,6 +70,7 @@ class TestForkSafeFluentSender:
         The _send_loop thread doesn't survive fork, so the sender can never
         deliver anything. _closed=True makes _send() return False immediately.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         assert sender._closed is True
@@ -77,6 +82,7 @@ class TestForkSafeFluentSender:
         If the _send_loop thread held Queue.mutex at fork time, the child
         inherits it locked. Replacing the Queue avoids this.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender._queue.put(b'test data', block=False)
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -89,6 +95,7 @@ class TestForkSafeFluentSender:
         Prevents the child from sharing a TCP connection with the parent,
         which would corrupt data on the wire (interleaved writes).
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender.socket = Mock()
 
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
@@ -102,6 +109,7 @@ class TestForkSafeFluentSender:
         on the inherited handler before set_context() replaces it, the
         message is silently dropped instead of accumulating in a dead queue.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         assert sender._send(b'test') is False
@@ -113,6 +121,7 @@ class TestForkSafeFluentSender:
         may fire after the sender is GC'd. Using weakref ensures this case
         is handled gracefully (no crash, no action).
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         sender = ForkSafeFluentSender('test', host='localhost', port=24224)
         ref = weakref.ref(sender)
         sender.close()
@@ -129,6 +138,7 @@ class TestForkSafeFluentSender:
         in its inherited locked state, this would deadlock. After reinit,
         the lock is fresh and unlocked, so close() completes normally.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
 
         completed = []
@@ -153,10 +163,12 @@ class TestForkSafeFluentHandler:
         This is the extension point that makes the handler create our
         fork-safe sender instead of the default asyncsender.FluentSender.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         assert handler.getSenderClass() is ForkSafeFluentSender
 
     def test_sender_is_fork_safe_instance(self, handler):
         """Verify the lazily-created sender is a ForkSafeFluentSender."""
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
         assert isinstance(handler.sender, ForkSafeFluentSender)
 
 
@@ -171,6 +183,7 @@ class TestForkSafetyIntegration:
         deterministically reproducible). This test verifies the basic machinery:
         os.register_at_fork fires, _reinit_after_fork runs, and close() completes.
         """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
         handler = ForkSafeFluentHandler('test', host='localhost', port=24224)
         # Access sender to ensure it is fully initialized (thread + lock + queue)
         _ = handler.sender

--- a/tests/images/airflow/3.2.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -1,0 +1,203 @@
+"""Tests for ForkSafeFluentSender and ForkSafeFluentHandler.
+
+These tests verify that the fork-safety mechanism works correctly:
+- After os.register_at_fork fires _reinit_after_fork in a child process,
+  all thread-unsafe state (locks, queue, socket) is reset so the child
+  doesn't deadlock on inherited locked mutexes.
+"""
+
+import gc
+import os
+import signal
+import threading
+import time
+import weakref
+from unittest.mock import Mock
+
+import pytest
+
+from mwaa.logging.cloudwatch_handlers import (
+    ForkSafeFluentHandler,
+    ForkSafeFluentSender,
+)
+
+
+@pytest.fixture
+def sender():
+    """Create a ForkSafeFluentSender and ensure cleanup (stops background thread)."""
+    s = ForkSafeFluentSender('test', host='localhost', port=24224)
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def handler():
+    """Create a ForkSafeFluentHandler and ensure cleanup."""
+    h = ForkSafeFluentHandler('test', host='localhost', port=24224)
+    yield h
+    h.close()
+
+
+class TestForkSafeFluentSender:
+    """Tests for ForkSafeFluentSender fork-safety behavior.
+
+    Each test simulates what happens in a child process after fork by
+    calling _reinit_after_fork() directly, then verifying the sender
+    is in a safe, non-deadlocking state.
+    """
+
+    def test_reinit_after_fork_resets_lock(self, sender):
+        """Verify that a locked lock becomes acquirable after reinit.
+
+        Simulates the scenario where fork() happened while a thread held
+        sender.lock. In the child, _reinit_after_fork replaces it with a
+        fresh unlocked Lock so subsequent code won't deadlock.
+        """
+        sender.lock.acquire()
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender.lock.acquire(blocking=False), "Lock should be acquirable after reinit"
+        sender.lock.release()
+
+    def test_reinit_after_fork_marks_closed(self, sender):
+        """Verify sender is marked closed so _send() becomes a no-op.
+
+        The _send_loop thread doesn't survive fork, so the sender can never
+        deliver anything. _closed=True makes _send() return False immediately.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._closed is True
+
+    def test_reinit_after_fork_replaces_queue(self, sender):
+        """Verify the queue is replaced with a fresh empty one.
+
+        Python's Queue uses threading.Lock internally (Queue.mutex).
+        If the _send_loop thread held Queue.mutex at fork time, the child
+        inherits it locked. Replacing the Queue avoids this.
+        """
+        sender._queue.put(b'test data', block=False)
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._queue.empty(), "Queue should be empty after reinit"
+
+    def test_reinit_after_fork_closes_socket(self, sender):
+        """Verify the inherited TCP socket is closed.
+
+        Prevents the child from sharing a TCP connection with the parent,
+        which would corrupt data on the wire (interleaved writes).
+        """
+        sender.socket = Mock()
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender.socket is None
+
+    def test_send_returns_false_after_reinit(self, sender):
+        """Verify _send() is a no-op after reinit (returns False).
+
+        Confirms that if any code in the child accidentally calls emit()
+        on the inherited handler before set_context() replaces it, the
+        message is silently dropped instead of accumulating in a dead queue.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._send(b'test') is False
+
+    def test_reinit_with_dead_weakref(self):
+        """Verify reinit is a no-op when the sender has been garbage collected.
+
+        os.register_at_fork callbacks are never unregistered, so the callback
+        may fire after the sender is GC'd. Using weakref ensures this case
+        is handled gracefully (no crash, no action).
+        """
+        sender = ForkSafeFluentSender('test', host='localhost', port=24224)
+        ref = weakref.ref(sender)
+        sender.close()
+        del sender
+        gc.collect()
+
+        # Should not raise
+        ForkSafeFluentSender._reinit_after_fork(ref)
+
+    def test_close_after_reinit_does_not_deadlock(self, sender):
+        """Verify close() completes after reinit (no deadlock on lock).
+
+        asyncsender.close() does 'with self.lock:' - if the lock were still
+        in its inherited locked state, this would deadlock. After reinit,
+        the lock is fresh and unlocked, so close() completes normally.
+        """
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        completed = []
+
+        def try_close():
+            sender.close()
+            completed.append(True)
+
+        t = threading.Thread(target=try_close)
+        t.start()
+        t.join(timeout=2)
+
+        assert completed, "close() deadlocked after fork reinit"
+
+
+class TestForkSafeFluentHandler:
+    """Tests for ForkSafeFluentHandler wiring."""
+
+    def test_uses_fork_safe_sender_class(self, handler):
+        """Verify getSenderClass() returns ForkSafeFluentSender.
+
+        This is the extension point that makes the handler create our
+        fork-safe sender instead of the default asyncsender.FluentSender.
+        """
+        assert handler.getSenderClass() is ForkSafeFluentSender
+
+    def test_sender_is_fork_safe_instance(self, handler):
+        """Verify the lazily-created sender is a ForkSafeFluentSender."""
+        assert isinstance(handler.sender, ForkSafeFluentSender)
+
+
+class TestForkSafetyIntegration:
+    """Integration test using actual fork()."""
+
+    def test_child_can_close_inherited_handler(self):
+        """Verify a forked child can close an inherited handler without deadlocking.
+
+        This is a smoke test. The real deadlock only occurs when a thread holds
+        the sender lock at the exact moment of fork (a race condition that is not
+        deterministically reproducible). This test verifies the basic machinery:
+        os.register_at_fork fires, _reinit_after_fork runs, and close() completes.
+        """
+        handler = ForkSafeFluentHandler('test', host='localhost', port=24224)
+        # Access sender to ensure it is fully initialized (thread + lock + queue)
+        _ = handler.sender
+
+        pid = os.fork()
+        if pid == 0:
+            # Child: close the inherited handler. Without the fix, this could
+            # deadlock if the sender lock was held at fork time.
+            try:
+                handler.close()
+                os._exit(0)
+            except Exception:
+                os._exit(1)
+        else:
+            # Parent: wait for child with timeout to detect deadlock
+            start = time.time()
+            while time.time() - start < 5:
+                result = os.waitpid(pid, os.WNOHANG)
+                if result[0] != 0:
+                    break
+                time.sleep(0.1)
+            else:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+                pytest.fail("Child process deadlocked on close() after fork")
+
+            assert os.WIFEXITED(result[1]) and os.WEXITSTATUS(result[1]) == 0, \
+                "Child process exited with error"
+
+        handler.close()


### PR DESCRIPTION
*Description of changes:*


Fix Non-Critical Logging deadlock issue in Airflow that's caused by the usage of non fork-safe locks that comes with FluentHandler. The issue is more observable when CloudWatch is disabled - and logs are unable to be sent to CloudWatch - this increases the likelihood that the process is holding onto a lock when logs are being re-emitted.

The interaction with celery creating children processes for running tasks and the Fluentbit Sender grabbing non-safe locks caused tasks to be stuck in RUNNING. This is because fork copies the lock state, but does not copy any other threads, causing the child process to not have any thread to unblock.

This PR also adds the functionality and unit tests of Non-Critical Logging to 2.9.2 and 2.10.1 as well, as it was previously missing.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
