### PR TITLE
Obtain db_lock only on actual queue create attempt

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.1/python/mwaa/entrypoint.py
@@ -200,7 +200,6 @@ async def create_airflow_user(environ: dict[str, str]):
     )
 
 
-@with_db_lock(1357)
 def create_queue() -> None:
     """
     Create the SQS required by Celery.
@@ -211,6 +210,12 @@ def create_queue() -> None:
     """
     if not should_create_queue():
         return
+    else:
+        _create_queue_with_db_lock_mutex()
+
+
+@with_db_lock(1357)
+def _create_queue_with_db_lock_mutex():
     queue_name = get_sqs_queue_name()
     endpoint = os.environ.get("MWAA__SQS__CUSTOM_ENDPOINT")
     sqs = boto3.client("sqs", endpoint_url=endpoint)  # type: ignore

--- a/images/airflow/2.10.3/python/mwaa/entrypoint.py
+++ b/images/airflow/2.10.3/python/mwaa/entrypoint.py
@@ -199,7 +199,6 @@ async def create_airflow_user(environ: dict[str, str]):
     )
 
 
-@with_db_lock(1357)
 def create_queue() -> None:
     """
     Create the SQS required by Celery.
@@ -210,6 +209,12 @@ def create_queue() -> None:
     """
     if not should_create_queue():
         return
+    else:
+        _create_queue_with_db_lock_mutex()
+
+
+@with_db_lock(1357)
+def _create_queue_with_db_lock_mutex():
     queue_name = get_sqs_queue_name()
     endpoint = os.environ.get("MWAA__SQS__CUSTOM_ENDPOINT")
     sqs = boto3.client("sqs", endpoint_url=endpoint)  # type: ignore

--- a/images/airflow/2.11.0/python/mwaa/entrypoint.py
+++ b/images/airflow/2.11.0/python/mwaa/entrypoint.py
@@ -199,7 +199,6 @@ async def create_airflow_user(environ: dict[str, str]):
     )
 
 
-@with_db_lock(1357)
 def create_queue() -> None:
     """
     Create the SQS required by Celery.
@@ -210,6 +209,12 @@ def create_queue() -> None:
     """
     if not should_create_queue():
         return
+    else:
+        _create_queue_with_db_lock_mutex()
+
+
+@with_db_lock(1357)
+def _create_queue_with_db_lock_mutex():
     queue_name = get_sqs_queue_name()
     endpoint = os.environ.get("MWAA__SQS__CUSTOM_ENDPOINT")
     sqs = boto3.client("sqs", endpoint_url=endpoint)  # type: ignore

--- a/images/airflow/2.9.2/python/mwaa/entrypoint.py
+++ b/images/airflow/2.9.2/python/mwaa/entrypoint.py
@@ -202,7 +202,6 @@ async def create_airflow_user(environ: dict[str, str]):
     )
 
 
-@with_db_lock(1357)
 def create_queue() -> None:
     """
     Create the SQS required by Celery.
@@ -213,6 +212,12 @@ def create_queue() -> None:
     """
     if not should_create_queue():
         return
+    else:
+        _create_queue_with_db_lock_mutex()
+
+
+@with_db_lock(1357)
+def _create_queue_with_db_lock_mutex():
     queue_name = get_sqs_queue_name()
     endpoint = os.environ.get("MWAA__SQS__CUSTOM_ENDPOINT")
     sqs = boto3.client("sqs", endpoint_url=endpoint)  # type: ignore

--- a/images/airflow/3.0.6/python/mwaa/entrypoint.py
+++ b/images/airflow/3.0.6/python/mwaa/entrypoint.py
@@ -198,7 +198,6 @@ async def create_airflow_user(environ: dict[str, str]):
     )
 
 
-@with_db_lock(1357)
 def create_queue() -> None:
     """
     Create the SQS required by Celery.
@@ -209,6 +208,12 @@ def create_queue() -> None:
     """
     if not should_create_queue():
         return
+    else:
+        _create_queue_with_db_lock_mutex()
+
+
+@with_db_lock(1357)
+def _create_queue_with_db_lock_mutex():
     queue_name = get_sqs_queue_name()
     endpoint = os.environ.get("MWAA__SQS__CUSTOM_ENDPOINT")
     sqs = boto3.client("sqs", endpoint_url=endpoint)  # type: ignore

--- a/images/airflow/3.2.1/python/mwaa/entrypoint.py
+++ b/images/airflow/3.2.1/python/mwaa/entrypoint.py
@@ -227,7 +227,6 @@ async def create_airflow_user(environ: dict[str, str]):
     )
 
 
-@with_db_lock(1357)
 def create_queue() -> None:
     """
     Create the SQS required by Celery.
@@ -238,6 +237,12 @@ def create_queue() -> None:
     """
     if not should_create_queue():
         return
+    else:
+        _create_queue_with_db_lock_mutex()
+
+
+@with_db_lock(1357)
+def _create_queue_with_db_lock_mutex():
     queue_name = get_sqs_queue_name()
     endpoint = os.environ.get("MWAA__SQS__CUSTOM_ENDPOINT")
     sqs = boto3.client("sqs", endpoint_url=endpoint)  # type: ignore


### PR DESCRIPTION
*Issue #, if available:* Internal MWAA tracking task: https://tiny.amazon.com/xfznhomy/create_queue_issue

*Description of changes:*

A failure to start up a worker has been observed in MWAA integ test, with failure happening during an attempt to obtain DB lock before executing create_queue() method.

```
psycopg2.OperationalError: SSL connection has been closed unexpectedly
create_queue()
File "/usr/local/airflow/.local/lib/python3.11/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py", line 923, in on_connect
File "/python/mwaa/entrypoint.py", line 268, in main
```

In MWAA the queue is created beforehand, and should_create_queue() which checks for `MWAA__SQS__CREATE_QUEUE` env var always returns false, meaning the DB lock is not necessary.

To prevent transient DB connectivity issues from letting the worker to start, moving the lock to "unconditional" create_queue attempt method portion.

### Testing
Ran locally with `/amazon-mwaa-docker-images/images/airflow/3.2.1/run.sh` and executed `hello_world_dag`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
