### PR TITLE
Fix WorkerTaskMonitor.get_cleanup_task_count() - return len() not List itself

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/celery/task_monitor.py
+++ b/images/airflow/2.10.1/python/mwaa/celery/task_monitor.py
@@ -526,7 +526,7 @@ class WorkerTaskMonitor:
 
         :return: Number of current tasks marked for cleanup.
         """
-        return _get_celery_tasks(self.cleanup_celery_state)
+        return len(_get_celery_tasks(self.cleanup_celery_state))
 
 
     def _get_next_unprocessed_signal(self) -> tuple[str | None, SignalData | None]:

--- a/images/airflow/2.10.3/python/mwaa/celery/task_monitor.py
+++ b/images/airflow/2.10.3/python/mwaa/celery/task_monitor.py
@@ -526,7 +526,7 @@ class WorkerTaskMonitor:
 
         :return: Number of current tasks marked for cleanup.
         """
-        return _get_celery_tasks(self.cleanup_celery_state)
+        return len(_get_celery_tasks(self.cleanup_celery_state))
 
 
     def _get_next_unprocessed_signal(self) -> tuple[str | None, SignalData | None]:

--- a/images/airflow/2.11.0/python/mwaa/celery/task_monitor.py
+++ b/images/airflow/2.11.0/python/mwaa/celery/task_monitor.py
@@ -526,7 +526,7 @@ class WorkerTaskMonitor:
 
         :return: Number of current tasks marked for cleanup.
         """
-        return _get_celery_tasks(self.cleanup_celery_state)
+        return len(_get_celery_tasks(self.cleanup_celery_state))
 
 
     def _get_next_unprocessed_signal(self) -> tuple[str | None, SignalData | None]:

--- a/images/airflow/2.9.2/python/mwaa/celery/task_monitor.py
+++ b/images/airflow/2.9.2/python/mwaa/celery/task_monitor.py
@@ -526,7 +526,7 @@ class WorkerTaskMonitor:
 
         :return: Number of current tasks marked for cleanup.
         """
-        return _get_celery_tasks(self.cleanup_celery_state)
+        return len(_get_celery_tasks(self.cleanup_celery_state))
 
 
     def _get_next_unprocessed_signal(self) -> (str, SignalData):

--- a/tests/images/airflow/2.10.1/python/mwaa/celery/test_task_monitor_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/celery/test_task_monitor_2_10_1.py
@@ -183,3 +183,16 @@ def test_get_airflow_process_id_mapping():
         assert 1236 not in result.values()
         assert 1237 not in result.values()
         assert 1238 not in result.values()
+
+
+def test_get_cleanup_task_count_returns_length(task_monitor):
+    """Test get_cleanup_task_count returns the number of tasks marked for cleanup."""
+    tasks = [{"task_id": "task1"}, {"task_id": "task2"}]
+    with patch('mwaa.celery.task_monitor._get_celery_tasks', return_value=tasks):
+        assert task_monitor.get_cleanup_task_count() == 2
+
+
+def test_get_cleanup_task_count_empty(task_monitor):
+    """Test get_cleanup_task_count returns 0 when no cleanup tasks exist."""
+    with patch('mwaa.celery.task_monitor._get_celery_tasks', return_value=[]):
+        assert task_monitor.get_cleanup_task_count() == 0

--- a/tests/images/airflow/2.10.3/python/mwaa/celery/test_task_monitor_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/celery/test_task_monitor_2_10_3.py
@@ -184,3 +184,16 @@ def test_get_airflow_process_id_mapping():
         assert 1236 not in result.values()
         assert 1237 not in result.values()
         assert 1238 not in result.values()
+
+
+def test_get_cleanup_task_count_returns_length(task_monitor):
+    """Test get_cleanup_task_count returns the number of tasks marked for cleanup."""
+    tasks = [{"task_id": "task1"}, {"task_id": "task2"}]
+    with patch('mwaa.celery.task_monitor._get_celery_tasks', return_value=tasks):
+        assert task_monitor.get_cleanup_task_count() == 2
+
+
+def test_get_cleanup_task_count_empty(task_monitor):
+    """Test get_cleanup_task_count returns 0 when no cleanup tasks exist."""
+    with patch('mwaa.celery.task_monitor._get_celery_tasks', return_value=[]):
+        assert task_monitor.get_cleanup_task_count() == 0

--- a/tests/images/airflow/2.11.0/python/mwaa/celery/test_task_monitor_2_11_0.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/celery/test_task_monitor_2_11_0.py
@@ -184,3 +184,16 @@ def test_get_airflow_process_id_mapping():
         assert 1236 not in result.values()
         assert 1237 not in result.values()
         assert 1238 not in result.values()
+
+
+def test_get_cleanup_task_count_returns_length(task_monitor):
+    """Test get_cleanup_task_count returns the number of tasks marked for cleanup."""
+    tasks = [{"task_id": "task1"}, {"task_id": "task2"}]
+    with patch('mwaa.celery.task_monitor._get_celery_tasks', return_value=tasks):
+        assert task_monitor.get_cleanup_task_count() == 2
+
+
+def test_get_cleanup_task_count_empty(task_monitor):
+    """Test get_cleanup_task_count returns 0 when no cleanup tasks exist."""
+    with patch('mwaa.celery.task_monitor._get_celery_tasks', return_value=[]):
+        assert task_monitor.get_cleanup_task_count() == 0

--- a/tests/images/airflow/2.9.2/python/mwaa/celery/test_task_monitor_2_9_2.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/celery/test_task_monitor_2_9_2.py
@@ -184,3 +184,16 @@ def test_get_airflow_process_id_mapping():
         assert 1236 not in result.values()
         assert 1237 not in result.values()
         assert 1238 not in result.values()
+
+
+def test_get_cleanup_task_count_returns_length(task_monitor):
+    """Test get_cleanup_task_count returns the number of tasks marked for cleanup."""
+    tasks = [{"task_id": "task1"}, {"task_id": "task2"}]
+    with patch('mwaa.celery.task_monitor._get_celery_tasks', return_value=tasks):
+        assert task_monitor.get_cleanup_task_count() == 2
+
+
+def test_get_cleanup_task_count_empty(task_monitor):
+    """Test get_cleanup_task_count returns 0 when no cleanup tasks exist."""
+    with patch('mwaa.celery.task_monitor._get_celery_tasks', return_value=[]):
+        assert task_monitor.get_cleanup_task_count() == 0

--- a/tests/images/airflow/3.0.6/python/mwaa/celery/test_task_monitor.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/celery/test_task_monitor.py
@@ -181,3 +181,16 @@ def test_get_airflow_process_id_mapping():
         assert 1236 not in result.values()
         assert 1237 not in result.values()
         assert 1238 not in result.values()
+
+
+def test_get_cleanup_task_count_returns_length(task_monitor):
+    """Test get_cleanup_task_count returns the number of tasks marked for cleanup."""
+    tasks = [{"task_id": "task1"}, {"task_id": "task2"}]
+    with patch('mwaa.celery.task_monitor._get_celery_tasks', return_value=tasks):
+        assert task_monitor.get_cleanup_task_count() == 2
+
+
+def test_get_cleanup_task_count_empty(task_monitor):
+    """Test get_cleanup_task_count returns 0 when no cleanup tasks exist."""
+    with patch('mwaa.celery.task_monitor._get_celery_tasks', return_value=[]):
+        assert task_monitor.get_cleanup_task_count() == 0

--- a/tests/images/airflow/3.2.1/python/mwaa/celery/test_task_monitor.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/celery/test_task_monitor.py
@@ -181,3 +181,16 @@ def test_get_airflow_process_id_mapping():
         assert 1236 not in result.values()
         assert 1237 not in result.values()
         assert 1238 not in result.values()
+
+
+def test_get_cleanup_task_count_returns_length(task_monitor):
+    """Test get_cleanup_task_count returns the number of tasks marked for cleanup."""
+    tasks = [{"task_id": "task1"}, {"task_id": "task2"}]
+    with patch('mwaa.celery.task_monitor._get_celery_tasks', return_value=tasks):
+        assert task_monitor.get_cleanup_task_count() == 2
+
+
+def test_get_cleanup_task_count_empty(task_monitor):
+    """Test get_cleanup_task_count returns 0 when no cleanup tasks exist."""
+    with patch('mwaa.celery.task_monitor._get_celery_tasks', return_value=[]):
+        assert task_monitor.get_cleanup_task_count() == 0


### PR DESCRIPTION
*Issue #, if available:*
Internal Asana task: https://app.asana.com/1/8442528107068/project/1213106236209173/task/1214459779716791

*Description of changes:*

In logs we can often see: `2026-05-01T01:14:42Z E! [inputs.statsd] Parsing value to int64, unable to parse metric: airflow.mwaa.task_monitor.cleanup_task_count:[]|c`

That metric is populated with:
`Stats.incr("mwaa.task_monitor.cleanup_task_count", self.task_monitor.get_cleanup_task_count())`

And that in turn returns array not an integer:
https://github.com/aws/amazon-mwaa-docker-images/blob/main/images/airflow/2.9.2/python/mwaa/celery/task_monitor.py#L523

Fix: `WorkerTaskMonitor.get_cleanup_task_count()` - return len() not List itself.
