### PR TITLE
Add oversized log chunking for task logs in Airflow 3.0.6

### DIFF
--- a/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
@@ -281,6 +281,7 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         task-sdk/src/airflow/sdk/log.py#L143
     """
     LOG_SOURCE = "task"
+    _MAX_EVENT_BYTES = 260_000 # ~254 KB, leaving headroom for CW overhead + JSON envelope
     # In Airflow currently there are some logs that "seeps" out of the traditional task log stream. Ideally we should
     # use log_filename_template config to generate a pattern for filtering only task log streams. But that config
     # value is not a regex pattern but instead a Jinja template. As a workaround for now we use a deny list instead.
@@ -316,6 +317,156 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
             use_queues=True,
             create_log_group=False,
         )
+
+    def _split_oversize_event(self, msg: dict) -> list[dict]:
+        """
+        Split an oversized structured log message into multiple CloudWatch-safe chunks.
+
+        Background:
+            In Airflow 2.x, oversized log messages were silently truncated by watchtower
+            with a "Log message size exceeds CWL max payload size, truncated" warning,
+            causing permanent data loss for customers. This method was introduced in
+            Airflow 3.x to preserve all log content by splitting the 'event' field across
+            multiple log events, each within CloudWatch's per-event size limit.
+
+        Behavior:
+            - If the serialized msg fits within _MAX_EVENT_BYTES, returns [msg] unchanged.
+            - Otherwise, splits msg['event'] into N chunks, each returned as a separate
+              dict with all metadata keys preserved.
+            - On any internal error, falls back to truncation rather than killing the task.
+
+        Critical constraint (ensure_ascii):
+            Watchtower's CloudWatchLogFormatter serializes dicts using json.dumps with
+            ensure_ascii=True (the Python default). This means non-ASCII characters are
+            escaped to \\uXXXX sequences (6 bytes each), e.g.:
+                '田' (3 bytes UTF-8) -> '\\u7530' (6 bytes in JSON)
+            All size measurements in this method MUST use ensure_ascii=True to match
+            watchtower's behavior. Using ensure_ascii=False would undercount the final
+            serialized size, causing chunks to exceed watchtower's max_message_size
+            (262,144 bytes) and trigger silent byte-level truncation with data loss.
+
+        Returns:
+            A list of one or more msg dicts, each safe for watchtower to emit without
+            truncation.
+        """
+        try:
+            return self._split_oversize_event_inner(msg)
+        except Exception as e:
+            # Logging must never kill a customer's task. If splitting fails,
+            # fall back to returning the original message truncated to fit.
+            print(f"[_split_oversize_event] ERROR during split, falling back: {e}")
+            self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.split_error", 1)
+            try:
+                # Attempt to truncate the event to fit within the limit
+                event_value = msg.get("event", "")
+                if isinstance(event_value, str) and len(event_value.encode("utf-8")) > self._MAX_EVENT_BYTES:
+                    metadata = {k: v for k, v in msg.items() if k != "event"}
+                    # Rough truncation — leave room for metadata + truncation marker
+                    truncated = event_value[:self._MAX_EVENT_BYTES // 4] + "\n... [TRUNCATED due to split error] ..."
+                    return [{**metadata, "event": truncated}]
+            except Exception:
+                pass
+            return [msg]
+
+    def _split_oversize_event_inner(self, msg: dict) -> list[dict]:
+        """
+        Inner implementation of oversize event splitting.
+
+        Design Decision — Character-level binary search:
+            We split the event string by Python characters (Unicode code points), using
+            binary search to find the maximum substring that fits within the byte budget
+            when JSON-serialized. This approach was chosen over two alternatives:
+
+            Alternative 1 — Byte-level splitting (O(N), rejected):
+                Serialize the event to JSON-escaped bytes, then split at byte boundaries.
+                Pros: O(N) time complexity, single pass.
+                Cons: Requires careful handling of multi-byte UTF-8 continuation bytes
+                AND variable-length JSON escape sequences (\\n=2 bytes, \\uXXXX=6 bytes,
+                surrogate pairs=12 bytes, \\\\=2 bytes) at split boundaries. Getting all
+                edge cases correct is fragile and hard to verify.
+
+            Alternative 2 — Fixed character budget (O(N), rejected):
+                Assume worst-case 6 bytes per character (\\uXXXX) and use a fixed
+                chars_per_chunk = max_bytes // 6.
+                Pros: O(N), simple, no binary search.
+                Cons: Extremely wasteful for ASCII-heavy content. A 260KB budget would
+                only allow ~43K chars per chunk even if the content is pure ASCII (1 byte
+                per char in JSON). Real logs are typically 80%+ ASCII, so this would
+                produce 3-4x more chunks than necessary, increasing CloudWatch API calls
+                and costs.
+
+            Chosen approach — Character-level binary search (O(N * log(N/K))):
+                For each chunk, binary search over character count to find the largest
+                substring whose JSON-serialized size fits the budget. Each probe calls
+                json.dumps on a candidate substring to measure its exact escaped size.
+                Pros: Correct by construction (no escape-boundary bugs), produces
+                optimally-filled chunks regardless of character mix.
+                Cons: O(N * log(N/K)) where K = number of chunks. In practice with
+                N ~ 500KB and K ~ 2-3, this means ~18 binary search probes per chunk,
+                each serializing ~200KB. Total work is ~3-4x a single json.dumps call.
+                Acceptable for a code path that only triggers on oversized messages
+                (>260KB), which is rare in normal operation.
+
+        Critical: ensure_ascii=True for size measurement:
+            Watchtower's CloudWatchLogFormatter uses json.dumps with ensure_ascii=True
+            (Python's default). This escapes non-ASCII to \\uXXXX (6 bytes each).
+            We MUST measure sizes the same way. Using ensure_ascii=False would measure
+            '田' as 3 bytes but watchtower would serialize it as 6 bytes (\\u7530),
+            causing the final output to exceed watchtower's 262,144-byte limit and
+            triggering silent truncation.
+        """
+        # Measure total size using ensure_ascii=True to match watchtower's serialization
+        serialized = json.dumps(msg, default=str)
+        serialized_size = len(serialized.encode("utf-8"))
+
+        if serialized_size <= self._MAX_EVENT_BYTES:
+            return [msg]
+
+        event_value = msg.get("event", "")
+        if not isinstance(event_value, str):
+            event_value = str(event_value)
+
+        # Compute the byte budget available for the event content in each chunk.
+        # The "envelope" is the JSON overhead from metadata keys + empty event value.
+        metadata = {k: v for k, v in msg.items() if k != "event"}
+        envelope = json.dumps({**metadata, "event": ""}, default=str).encode("utf-8")
+        max_event_json_bytes = self._MAX_EVENT_BYTES - len(envelope)
+
+        chunks = []
+        pos = 0
+        total_chars = len(event_value)
+
+        while pos < total_chars:
+            # Binary search for the largest substring starting at pos that fits
+            # within max_event_json_bytes when JSON-serialized with ensure_ascii=True.
+            lo = 1
+            hi = min(total_chars - pos, max_event_json_bytes)
+            best = lo  # Guarantee at least 1 char progress to avoid infinite loop
+
+            while lo <= hi:
+                mid = (lo + hi) // 2
+                candidate = event_value[pos:pos + mid]
+                # json.dumps(candidate) wraps in quotes: '"..content.."'
+                # [1:-1] strips the quotes to get just the escaped content
+                escaped_size = len(json.dumps(candidate)[1:-1].encode("utf-8"))
+                if escaped_size <= max_event_json_bytes:
+                    best = mid
+                    lo = mid + 1
+                else:
+                    hi = mid - 1
+
+            chunk_str = event_value[pos:pos + best]
+            chunks.append({**metadata, "event": chunk_str})
+            pos += best
+
+        num_chunks = len(chunks) if chunks else 0
+        print(f"[_split_oversize_event] split oversized log event: "
+              f"original_size={serialized_size}, chunks={num_chunks}, "
+              f"max_per_chunk={self._MAX_EVENT_BYTES}")
+        self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.oversize_split", 1)
+
+        return chunks if chunks else [msg]
+
 
     @cached_property
     def processors(self) -> tuple[structlog.typing.Processor, ...]:
@@ -355,19 +506,21 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
             if ts := msg.pop("timestamp", None):
                 with contextlib.suppress(Exception):
                     created = datetime.fromisoformat(ts)
-            record = logRecordFactory(
-                name, level, pathname="", lineno=0, msg=msg, args=(), exc_info=None, func=None, sinfo=None
-            )
-            if created is not None:
-                ct = created.timestamp()
-                record.created = ct
-                record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
-            try:
-                _handler.handle(record)
-            except Exception as e:
-                self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.emit_error", 1)
-                # TODO maybe consider removing this if we plan to make logging non-critical
-                raise e
+
+            for chunks_msg in self._split_oversize_event(msg):
+                record = logRecordFactory(
+                    name, level, pathname="", lineno=0, msg=chunks_msg, args=(), exc_info=None, func=None, sinfo=None
+                )
+                if created is not None:
+                    ct = created.timestamp()
+                    record.created = ct
+                    record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
+                try:
+                    _handler.handle(record)
+                except Exception as e:
+                    self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.emit_error", 1)
+                    # TODO maybe consider removing this if we plan to make logging non-critical
+                    raise e
             return event
 
         return (proc,)

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import pytest
 import os
@@ -744,3 +745,376 @@ def test_discover_triggerer_streams_follows_pagination(mock_boto3_client):
         assert stream_page2 in streams
         assert len(streams) == 2
         assert logger.hook.conn.describe_log_streams.call_count == 2
+
+
+# =============================================================================
+# Tests for _split_oversize_event
+# =============================================================================
+
+class TestSplitOversizeEvent:
+    """Comprehensive tests for CloudWatchRemoteTaskLogger._split_oversize_event."""
+
+    @pytest.fixture
+    def logger(self):
+        """Create a CloudWatchRemoteTaskLogger instance for testing."""
+        return CloudWatchRemoteTaskLogger(
+            log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+            kms_key_arn=None,
+            enabled=True,
+            log_level='INFO'
+        )
+
+    # --- Basic behavior: no split needed ---
+
+    def test_small_message_returns_single_item_list(self, logger):
+        """A message under the size limit should be returned as-is in a single-item list."""
+        msg = {"event": "short log line", "level": "info", "timestamp": "2024-01-01T00:00:00"}
+        result = logger._split_oversize_event(msg)
+        assert result == [msg]
+        assert len(result) == 1
+
+    def test_empty_event_returns_single_item(self, logger):
+        """A message with an empty event field should not be split."""
+        msg = {"event": "", "level": "info", "timestamp": "2024-01-01T00:00:00"}
+        result = logger._split_oversize_event(msg)
+        assert result == [msg]
+
+    def test_message_exactly_at_limit_returns_single_item(self, logger):
+        """A message exactly at _MAX_EVENT_BYTES should not be split."""
+        metadata = {"level": "info", "timestamp": "2024-01-01T00:00:00"}
+        # Calculate how much space we have for the event
+        envelope = json.dumps({**metadata, "event": ""}, default=str).encode("utf-8")
+        available = logger._MAX_EVENT_BYTES - len(envelope)
+        # Create an event that, when JSON-serialized, fills exactly to the limit
+        # Use 'a' chars which don't get escaped in JSON
+        event_str = "a" * (available - 2)  # -2 for the quotes around the string in JSON
+        msg = {**metadata, "event": event_str}
+        serialized_size = len(json.dumps(msg, default=str).encode("utf-8"))
+        # Ensure we're at or under the limit
+        assert serialized_size <= logger._MAX_EVENT_BYTES
+        result = logger._split_oversize_event(msg)
+        assert len(result) == 1
+        assert result[0]["event"] == event_str
+
+    # --- Splitting behavior ---
+
+    def test_oversize_message_is_split_into_multiple_chunks(self, logger):
+        """A message exceeding _MAX_EVENT_BYTES should be split into multiple chunks."""
+        # Create a message well over the limit
+        large_event = "x" * (logger._MAX_EVENT_BYTES * 2)
+        msg = {"event": large_event, "level": "info", "timestamp": "2024-01-01T00:00:00"}
+        result = logger._split_oversize_event(msg)
+        assert len(result) > 1
+
+    def test_split_chunks_concatenate_to_original_event(self, logger):
+        """Concatenating all chunk events should reproduce the original event string."""
+        large_event = "Hello world! " * 30000  # ~390KB, well over 260KB limit
+        msg = {"event": large_event, "level": "info", "timestamp": "2024-01-01T00:00:00"}
+        result = logger._split_oversize_event(msg)
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_event
+
+    def test_each_chunk_is_within_size_limit(self, logger):
+        """Each chunk, when JSON-serialized, must be within _MAX_EVENT_BYTES."""
+        large_event = "a" * (logger._MAX_EVENT_BYTES * 3)
+        msg = {"event": large_event, "level": "info", "timestamp": "2024-01-01T00:00:00"}
+        result = logger._split_oversize_event(msg)
+        for i, chunk in enumerate(result):
+            chunk_size = len(json.dumps(chunk, default=str).encode("utf-8"))
+            assert chunk_size <= logger._MAX_EVENT_BYTES, (
+                f"Chunk {i} is {chunk_size} bytes, exceeds limit of {logger._MAX_EVENT_BYTES}"
+            )
+
+    def test_metadata_preserved_in_all_chunks(self, logger):
+        """All metadata keys (everything except 'event') must be present in every chunk."""
+        metadata = {
+            "level": "error",
+            "timestamp": "2024-01-01T12:00:00",
+            "logger_name": "airflow.task",
+            "task_id": "my_task",
+        }
+        large_event = "log line " * 50000
+        msg = {**metadata, "event": large_event}
+        result = logger._split_oversize_event(msg)
+        assert len(result) > 1
+        for chunk in result:
+            for key, value in metadata.items():
+                assert chunk[key] == value, f"Metadata key '{key}' missing or wrong in chunk"
+
+    # --- JSON escape handling ---
+
+    def test_newlines_in_event_are_handled_correctly(self, logger):
+        """Events with newline characters (which become \\n in JSON) should split correctly."""
+        # Newlines become 2-char sequences in JSON, so this tests escape-aware splitting
+        large_event = "line\n" * 80000  # lots of newlines
+        msg = {"event": large_event, "level": "info"}
+        result = logger._split_oversize_event(msg)
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_event
+        for chunk in result:
+            chunk_size = len(json.dumps(chunk, default=str).encode("utf-8"))
+            assert chunk_size <= logger._MAX_EVENT_BYTES
+
+    def test_tabs_in_event_are_handled_correctly(self, logger):
+        """Events with tab characters (which become \\t in JSON) should split correctly."""
+        large_event = "col1\tcol2\tcol3\n" * 30000
+        msg = {"event": large_event, "level": "info"}
+        result = logger._split_oversize_event(msg)
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_event
+
+    def test_backslashes_in_event_are_handled_correctly(self, logger):
+        """Events with backslashes (which become \\\\ in JSON) should split correctly."""
+        large_event = "path\\to\\file\n" * 30000
+        msg = {"event": large_event, "level": "info"}
+        result = logger._split_oversize_event(msg)
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_event
+        for chunk in result:
+            chunk_size = len(json.dumps(chunk, default=str).encode("utf-8"))
+            assert chunk_size <= logger._MAX_EVENT_BYTES
+
+    def test_quotes_in_event_are_handled_correctly(self, logger):
+        """Events with double quotes (which become \\" in JSON) should split correctly."""
+        large_event = 'key="value" ' * 30000
+        msg = {"event": large_event, "level": "info"}
+        result = logger._split_oversize_event(msg)
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_event
+
+    def test_mixed_escape_sequences(self, logger):
+        """Events with a mix of escape-worthy characters should split correctly."""
+        # Mix of \n, \t, \\, " — all become 2-char sequences in JSON
+        line = 'ERROR\t"file\\path"\nstack trace line\r\n'
+        large_event = line * 15000
+        msg = {"event": large_event, "level": "error"}
+        result = logger._split_oversize_event(msg)
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_event
+        for chunk in result:
+            chunk_size = len(json.dumps(chunk, default=str).encode("utf-8"))
+            assert chunk_size <= logger._MAX_EVENT_BYTES
+
+    # --- Multi-byte UTF-8 / Unicode handling ---
+    # With ensure_ascii=False, non-ASCII characters stay as raw UTF-8 bytes
+    # and the existing multi-byte walk-back logic handles them correctly.
+
+    def test_ascii_only_large_event_splits_correctly(self, logger):
+        """Pure ASCII events should always split and reassemble."""
+        large_event = "ABCDEFGHIJ" * 30000
+        msg = {"event": large_event, "level": "info"}
+        result = logger._split_oversize_event(msg)
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_event
+
+    def test_multibyte_utf8_characters_not_split_mid_char(self, logger):
+        """Multi-byte UTF-8 characters must not be split in the middle."""
+        # Japanese characters are 3 bytes each in UTF-8
+        large_event = "日本語テスト" * 20000
+        msg = {"event": large_event, "level": "info"}
+        result = logger._split_oversize_event(msg)
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_event
+        for chunk in result:
+            chunk_size = len(json.dumps(chunk, ensure_ascii=False, default=str).encode("utf-8"))
+            assert chunk_size <= logger._MAX_EVENT_BYTES
+
+    def test_emoji_characters_not_split(self, logger):
+        """4-byte emoji characters must not be split in the middle."""
+        large_event = "🚀🎉🔥" * 25000
+        msg = {"event": large_event, "level": "info"}
+        result = logger._split_oversize_event(msg)
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_event
+
+    def test_mixed_ascii_and_multibyte(self, logger):
+        """Mix of ASCII and multi-byte characters should split correctly."""
+        large_event = "Hello 世界! " * 30000
+        msg = {"event": large_event, "level": "info"}
+        result = logger._split_oversize_event(msg)
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_event
+
+    # --- Edge cases ---
+
+    def test_event_field_missing_returns_single_item(self, logger):
+        """If 'event' key is missing, the message should still be handled."""
+        # Create a large message without 'event' key — but it's under the limit
+        msg = {"level": "info", "data": "x" * 100}
+        result = logger._split_oversize_event(msg)
+        # Without 'event', it should just return as-is if under limit
+        assert len(result) == 1
+
+    def test_non_string_event_is_converted(self, logger):
+        """If event is not a string (e.g., dict or int), it should be str()-converted."""
+        large_dict_str = str({"key": "v" * logger._MAX_EVENT_BYTES})
+        msg = {"event": large_dict_str, "level": "info"}
+        result = logger._split_oversize_event(msg)
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_dict_str
+
+    def test_event_with_only_escape_characters(self, logger):
+        """An event consisting entirely of characters that get escaped in JSON."""
+        # Each \n becomes \\n in JSON (2 bytes), so effective size doubles
+        large_event = "\n" * (logger._MAX_EVENT_BYTES)
+        msg = {"event": large_event, "level": "info"}
+        result = logger._split_oversize_event(msg)
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_event
+        for chunk in result:
+            chunk_size = len(json.dumps(chunk, default=str).encode("utf-8"))
+            assert chunk_size <= logger._MAX_EVENT_BYTES
+
+    def test_single_character_over_limit(self, logger):
+        """Message just barely over the limit should split into exactly 2 chunks."""
+        metadata = {"level": "info"}
+        envelope = json.dumps({**metadata, "event": ""}, default=str).encode("utf-8")
+        available = logger._MAX_EVENT_BYTES - len(envelope)
+        # Create event that exceeds the limit. The envelope includes "event": "" which
+        # accounts for the key and empty quotes. Each 'a' adds 1 byte to the JSON.
+        # We need the total serialized msg to exceed _MAX_EVENT_BYTES.
+        # available = max - envelope_size, so event of length (available + 1) will exceed.
+        event_str = "a" * (available + 1)
+        msg = {**metadata, "event": event_str}
+        serialized_size = len(json.dumps(msg, default=str).encode("utf-8"))
+        assert serialized_size > logger._MAX_EVENT_BYTES, "Test setup: msg must exceed limit"
+        result = logger._split_oversize_event(msg)
+        assert len(result) == 2
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == event_str
+
+    def test_very_large_metadata_reduces_chunk_capacity(self, logger):
+        """Large metadata should reduce the available space for event chunks."""
+        # Large metadata means less room for event per chunk
+        large_metadata = {
+            "level": "info",
+            "logger_name": "a" * 1000,
+            "extra_field": "b" * 1000,
+        }
+        large_event = "x" * (logger._MAX_EVENT_BYTES * 2)
+        msg = {**large_metadata, "event": large_event}
+        result = logger._split_oversize_event(msg)
+        # Should produce more chunks than without large metadata
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_event
+        for chunk in result:
+            chunk_size = len(json.dumps(chunk, default=str).encode("utf-8"))
+            assert chunk_size <= logger._MAX_EVENT_BYTES
+
+    def test_returns_original_msg_if_empty_chunks(self, logger):
+        """If splitting somehow produces no chunks, should return [msg] as fallback."""
+        # This tests the `return chunks if chunks else [msg]` fallback
+        msg = {"event": "small", "level": "info"}
+        result = logger._split_oversize_event(msg)
+        assert result == [msg]
+
+    # --- Realistic scenarios ---
+
+    def test_realistic_stack_trace(self, logger):
+        """A realistic large Python stack trace should split and reassemble correctly."""
+        frame = (
+            '  File "/usr/local/lib/python3.12/site-packages/airflow/models/taskinstance.py", '
+            'line 1234, in _run_raw_task\n'
+            '    result = execute_callable(context=context)\n'
+        )
+        # Make it large enough to require splitting
+        large_event = "Traceback (most recent call last):\n" + frame * 2000 + "RuntimeError: something broke\n"
+        msg = {"event": large_event, "level": "error", "timestamp": "2024-06-15T10:30:00"}
+        result = logger._split_oversize_event(msg)
+        assert len(result) > 1
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_event
+
+    def test_realistic_json_log_payload(self, logger):
+        """A large JSON-structured log event should split and reassemble correctly."""
+        import json as json_mod
+        records = [{"id": i, "status": "processed", "data": "x" * 200} for i in range(1000)]
+        large_event = json_mod.dumps(records)
+        msg = {"event": large_event, "level": "info", "timestamp": "2024-06-15T10:30:00"}
+        result = logger._split_oversize_event(msg)
+        reconstructed = "".join(chunk["event"] for chunk in result)
+        assert reconstructed == large_event
+        # Verify the reconstructed JSON is still valid
+        parsed = json_mod.loads(reconstructed)
+        assert len(parsed) == 1000
+
+    # --- Resilience / fallback behavior ---
+
+    def test_split_error_does_not_raise(self, logger):
+        """If the inner split logic throws, the outer method should not propagate the exception."""
+        from unittest.mock import patch
+
+        msg = {"event": "test", "level": "info"}
+        with patch.object(logger, '_split_oversize_event_inner', side_effect=RuntimeError("simulated failure")):
+            # Should not raise — falls back gracefully
+            result = logger._split_oversize_event(msg)
+            assert len(result) == 1
+            assert "event" in result[0]
+
+    def test_split_error_returns_truncated_for_large_event(self, logger):
+        """On split failure with a large event, should return a truncated version."""
+        from unittest.mock import patch
+
+        large_event = "x" * (logger._MAX_EVENT_BYTES * 2)
+        msg = {"event": large_event, "level": "error"}
+        with patch.object(logger, '_split_oversize_event_inner', side_effect=ValueError("bad split")):
+            result = logger._split_oversize_event(msg)
+            assert len(result) == 1
+            assert "TRUNCATED" in result[0]["event"]
+            assert result[0]["level"] == "error"
+
+    def test_split_error_increments_metric(self, logger):
+        """On split failure, a metric should be emitted."""
+        from unittest.mock import patch, Mock
+
+        logger.stats = Mock()
+        msg = {"event": "test", "level": "info"}
+        with patch.object(logger, '_split_oversize_event_inner', side_effect=RuntimeError("fail")):
+            logger._split_oversize_event(msg)
+            logger.stats.incr.assert_called_once_with("mwaa.logging.task.split_error", 1)
+
+    # --- Watchtower compatibility ---
+
+    def test_chunks_fit_watchtower_limit_with_non_ascii(self, logger):
+        """Chunks must not exceed watchtower's max_message_size (262144 bytes) when
+        serialized with ensure_ascii=True (watchtower's default behavior).
+
+        This is a regression test for a bug where the split logic measured chunk sizes
+        using ensure_ascii=False (non-ASCII as raw UTF-8, e.g. 田=3 bytes) but watchtower
+        serializes with ensure_ascii=True (田 becomes \\u7530 = 6 bytes), causing chunks
+        to exceed watchtower's limit and get silently truncated.
+        """
+        WATCHTOWER_MAX_MESSAGE_SIZE = 262144
+        WATCHTOWER_EXTRA_PAYLOAD = 26
+        watchtower_effective_limit = WATCHTOWER_MAX_MESSAGE_SIZE - WATCHTOWER_EXTRA_PAYLOAD
+
+        # Build a message with heavy non-ASCII content (CJK, accented, emojis)
+        pattern = (
+            'ERROR: Failed for customer: \u7530\u4e2d\u592a\u90ce (order_id=98765)\n'
+            'WARNING: Donn\u00e9es invalides pour Jos\u00e9 Garc\u00eda \u2014 r\u00e9essayer\n'
+            'DEBUG: /data/uploads/\u5ba2\u6237\u6570\u636e_2024\u5e746\u6708.csv\n'
+            'INFO: \u2705 batch_1 ok, \u274c batch_2 fail, \U0001f504 batch_3 retry\n'
+        )
+        # Make it ~512KB raw to force splitting
+        event = pattern * (512000 // len(pattern.encode('utf-8')))
+        msg = {"logger": "airflow.task", "level": "info", "event": event}
+
+        result = logger._split_oversize_event(msg)
+
+        # Must produce multiple chunks
+        assert len(result) > 1, "Expected message to be split into multiple chunks"
+
+        # Each chunk, when serialized the way watchtower does it (ensure_ascii=True),
+        # must fit within watchtower's effective limit
+        for i, chunk in enumerate(result):
+            # Watchtower uses json.dumps with default serializer (ensure_ascii=True)
+            watchtower_serialized = json.dumps(chunk, default=str)
+            watchtower_size = len(watchtower_serialized.encode("utf-8"))
+            assert watchtower_size <= watchtower_effective_limit, (
+                f"Chunk {i} exceeds watchtower limit: {watchtower_size} > {watchtower_effective_limit}. "
+                f"This means watchtower will silently truncate the chunk, causing data loss."
+            )
+
+        # Verify no data loss: concatenated events must equal original
+        reassembled = "".join(chunk["event"] for chunk in result)
+        assert reassembled == event, "Data loss detected: reassembled chunks don't match original event"


### PR DESCRIPTION
*Issue # (if available):*
https://app.asana.com/1/8442528107068/project/1213077669682433/task/1214436608875623

## Description

Add support for splitting oversized task log messages (>260KB) into
multiple CloudWatch log events, preserving all content. Previously,
oversized logs were silently truncated by watchtower with data loss.

Implementation uses character-level binary search to find optimal chunk
boundaries that respect CloudWatch's per-event size limit (262KB).
Size measurement uses ensure_ascii=True to match watchtower's
CloudWatchLogFormatter serialization, ensuring non-ASCII characters
(CJK, accented text, emojis) are correctly accounted for at 6 bytes
each (\uXXXX escaping).

Design decisions documented inline:
- Character-level binary search chosen (Chosen, optimal fill, O(N·log(N/K)))
- Byte-level splitting rejected (fragile escape-boundary handling)
- Fixed char budget rejected (wasteful for ASCII-heavy content)

Observability:
- Worker log line on each split with original size and chunk count
- StatsD metric: mwaa.logging.task.oversize_split

Testing:
- Unit tests including test verifying chunks fit within
  watchtower's limit with heavy non-ASCII content
- Integration tested on MWAA 3.0.6 environment with mixed content
  oversized logs (512KB-1.2MB), confirmed complete data preservation
  across chunk boundaries with no truncation warnings

## Files Changed

```
images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
```

*List any breaking changes for*
* *The Environment runtime*: N/A
* *The local development experience*: N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

## Tests
Please refer all the DAGs and their respective logs here - [Test Evidence](https://drive.corp.amazon.com/personal/hbhalani/MWAA/Ops/Oversized_Cloudwatch_Logs_AF_3)