### PR TITLE
Add fluent-logger to 2.9.2 and 2.10.1 bootstrap and test requirements

### DIFF
--- a/images/airflow/2.10.1/bootstrap/02-airflow/001-install-required-pip-packages.sh
+++ b/images/airflow/2.10.1/bootstrap/02-airflow/001-install-required-pip-packages.sh
@@ -15,6 +15,7 @@ REQUIRED_PACKAGES=(
     psycopg2
     pycurl
     watchtower
+    fluent-logger
     virtualenv
 )
 

--- a/images/airflow/2.9.2/bootstrap/02-airflow/001-install-required-pip-packages.sh
+++ b/images/airflow/2.9.2/bootstrap/02-airflow/001-install-required-pip-packages.sh
@@ -15,6 +15,7 @@ REQUIRED_PACKAGES=(
     psycopg2
     pycurl
     watchtower
+    fluent-logger
     virtualenv
 )
 

--- a/tests/images/airflow/2.10.1/requirements.txt
+++ b/tests/images/airflow/2.10.1/requirements.txt
@@ -14,6 +14,7 @@ apache-airflow-providers-amazon[aiobotocore]
 celery[sqs]
 pycurl
 watchtower
+fluent-logger
 # Additional packages for development
 # NOTE: Like above, we don't specify the version here.
 boto3-stubs[logs]

--- a/tests/images/airflow/2.9.2/requirements.txt
+++ b/tests/images/airflow/2.9.2/requirements.txt
@@ -14,6 +14,7 @@ apache-airflow-providers-amazon[aiobotocore]
 celery[sqs]
 pycurl
 watchtower
+fluent-logger
 # Additional packages for development
 # NOTE: Like above, we don't specify the version here.
 boto3-stubs[logs]


### PR DESCRIPTION
*Description of changes:*

Adding `fluent-logger` to 2.9.2 and 2.10.1, the changes made in #495 requires this installed, otherwise the container crashes at startup

`fluent-logger` is part of the requirements of the other images

Log : `ModuleNotFoundError: No module named 'fluent'`

