### PR TITLE
Enabling queue_circular for Fluent Handlers which makes logging non-critical.

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -136,7 +136,9 @@ class BaseLogHandler(logging.Handler):
             self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
-                port=24224
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
             )
             if self.formatter:
                 # Wrap the existing formatter to add routing fields
@@ -314,6 +316,7 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
+                queue_circular=True,
             )
 
             original_formatter = self.formatter

--- a/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
@@ -135,7 +135,9 @@ class BaseLogHandler(logging.Handler):
             self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
-                port=24224
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
             )
             if self.formatter:
                 # Wrap the existing formatter to add routing fields
@@ -313,6 +315,7 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
+                queue_circular=True,
             )
 
             original_formatter = self.formatter

--- a/images/airflow/2.11.0/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.11.0/python/mwaa/logging/cloudwatch_handlers.py
@@ -136,7 +136,9 @@ class BaseLogHandler(logging.Handler):
             self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
-                port=24224
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
             )
             if self.formatter:
                 # Wrap the existing formatter to add routing fields
@@ -331,6 +333,7 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
+                queue_circular=True,
             )
 
             original_formatter = self.formatter

--- a/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
@@ -136,7 +136,9 @@ class BaseLogHandler(logging.Handler):
             self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
-                port=24224
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
             )
             if self.formatter:
                 # Wrap the existing formatter to add routing fields
@@ -314,6 +316,7 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
+                queue_circular=True,
             )
 
             original_formatter = self.formatter

--- a/tests/images/airflow/2.10.1/python/mwaa/logging/test_cloudwatch_handler_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/logging/test_cloudwatch_handler_2_10_1.py
@@ -187,7 +187,9 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
             mock_fluent.assert_called_once_with(
                 'customer.logs',
                 host=ANY,
-                port=24224
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
             )
 
 def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -212,7 +214,8 @@ def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
             'port': 24224,
-            'queue_maxsize': 50000
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -235,7 +238,9 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -256,7 +261,9 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -279,5 +286,7 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }

--- a/tests/images/airflow/2.10.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -214,3 +214,16 @@ class TestForkSafetyIntegration:
                 "Child process exited with error"
 
         handler.close()
+
+
+class TestQueueCircularConfiguration:
+    """Test that queue_circular parameter is correctly wired through the handler."""
+
+    def test_handler_passes_queue_circular_to_sender(self):
+        """Verify queue_circular=True is propagated to the underlying sender."""
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
+        h = ForkSafeFluentHandler('test', host='localhost', port=24224,
+                                  queue_maxsize=50000, queue_circular=True)
+        assert h.sender.queue_circular is True
+        assert h.sender.queue_maxsize == 50000
+        h.close()

--- a/tests/images/airflow/2.10.3/python/mwaa/logging/test_cloudwatch_handler_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/logging/test_cloudwatch_handler_2_10_3.py
@@ -193,7 +193,9 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
             mock_fluent.assert_called_once_with(
                 'customer.logs',
                 host=ANY,
-                port=24224
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
             )
 
 def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -218,7 +220,8 @@ def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
             'port': 24224,
-            'queue_maxsize': 50000
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -241,7 +244,9 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -262,7 +267,9 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -285,5 +292,7 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }

--- a/tests/images/airflow/2.10.3/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -215,3 +215,16 @@ class TestForkSafetyIntegration:
 
         handler.close()
 
+
+
+class TestQueueCircularConfiguration:
+    """Test that queue_circular parameter is correctly wired through the handler."""
+
+    def test_handler_passes_queue_circular_to_sender(self):
+        """Verify queue_circular=True is propagated to the underlying sender."""
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
+        h = ForkSafeFluentHandler('test', host='localhost', port=24224,
+                                  queue_maxsize=50000, queue_circular=True)
+        assert h.sender.queue_circular is True
+        assert h.sender.queue_maxsize == 50000
+        h.close()

--- a/tests/images/airflow/2.11.0/python/mwaa/logging/test_cloudwatch_handler_2_11_0.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/logging/test_cloudwatch_handler_2_11_0.py
@@ -194,7 +194,9 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
             mock_fluent.assert_called_once_with(
                 'customer.logs',
                 host=ANY,
-                port=24224
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
             )
 
 def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -219,7 +221,8 @@ def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
             'port': 24224,
-            'queue_maxsize': 50000
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -242,7 +245,9 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -263,7 +268,9 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -286,7 +293,9 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_task_log_handler_io_override_exception_is_caught(mocker):

--- a/tests/images/airflow/2.11.0/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -214,3 +214,16 @@ class TestForkSafetyIntegration:
                 "Child process exited with error"
 
         handler.close()
+
+
+class TestQueueCircularConfiguration:
+    """Test that queue_circular parameter is correctly wired through the handler."""
+
+    def test_handler_passes_queue_circular_to_sender(self):
+        """Verify queue_circular=True is propagated to the underlying sender."""
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
+        h = ForkSafeFluentHandler('test', host='localhost', port=24224,
+                                  queue_maxsize=50000, queue_circular=True)
+        assert h.sender.queue_circular is True
+        assert h.sender.queue_maxsize == 50000
+        h.close()

--- a/tests/images/airflow/2.9.2/python/mwaa/logging/test_cloudwatch_handler_2_9_2.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/logging/test_cloudwatch_handler_2_9_2.py
@@ -188,7 +188,9 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
             mock_fluent.assert_called_once_with(
                 'customer.logs',
                 host=ANY,
-                port=24224
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
             )
 
 def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -213,7 +215,8 @@ def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
             'port': 24224,
-            'queue_maxsize': 50000
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -236,7 +239,9 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -257,7 +262,9 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -280,5 +287,7 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }

--- a/tests/images/airflow/2.9.2/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -214,3 +214,16 @@ class TestForkSafetyIntegration:
                 "Child process exited with error"
 
         handler.close()
+
+
+class TestQueueCircularConfiguration:
+    """Test that queue_circular parameter is correctly wired through the handler."""
+
+    def test_handler_passes_queue_circular_to_sender(self):
+        """Verify queue_circular=True is propagated to the underlying sender."""
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
+        h = ForkSafeFluentHandler('test', host='localhost', port=24224,
+                                  queue_maxsize=50000, queue_circular=True)
+        assert h.sender.queue_circular is True
+        assert h.sender.queue_maxsize == 50000
+        h.close()


### PR DESCRIPTION
*Description of changes:*
This pull request will enable queue_circular for the Fluent Handlers to ensure that logging will not block the processes. In the event that the queue is full (at 50,000) for any reasons, the oldest message in the queue will be dropped rather than blocking the queue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
