### PR TITLE
Enabling queue_circular for Fluent Handlers in 3.0.6 and 3.2.1

### DIFF
--- a/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
@@ -149,7 +149,9 @@ class BaseLogHandler(logging.Handler):
             self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
-                port=24224
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
             )
             if self.formatter:
                 # Wrap the existing formatter to add routing fields

--- a/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -149,7 +149,9 @@ class BaseLogHandler(logging.Handler):
             self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
-                port=24224
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
             )
             if self.formatter:
                 # Wrap the existing formatter to add routing fields

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -189,7 +189,9 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
             mock_fluent.assert_called_once_with(
                 'customer.logs',
                 host=ANY,
-                port=24224
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
             )
 
 def test_cloudwatch_remote_task_logger_initialization(mock_boto3_client):
@@ -414,7 +416,9 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -435,7 +439,9 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -458,7 +464,9 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 

--- a/tests/images/airflow/3.2.1/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/logging/test_cloudwatch_handler.py
@@ -187,7 +187,9 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
             mock_fluent.assert_called_once_with(
                 'customer.logs',
                 host=ANY,
-                port=24224
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
             )
 
 def test_cloudwatch_remote_task_logger_initialization(mock_boto3_client):
@@ -493,7 +495,9 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -513,7 +517,9 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -535,7 +541,9 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
         assert mock_fluent.call_args.args[0] == 'customer.logs'
         assert mock_fluent.call_args.kwargs == {
             'host': ANY,
-            'port': 24224
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
         }
 
 def test_cloudwatch_remote_task_logger_always_uses_watchtower_not_fluent(mock_boto3_client, mock_fluent, mock_watchtower):


### PR DESCRIPTION
*Description of changes:*
This pull request will enable queue_circular for the Fluent Handlers in 3.0.6 and 3.2.1 to ensure that logging will not block the processes. In the event that the queue is full (at 50,000) for any reasons, the oldest message in the queue will be dropped rather than blocking the queue. This is the continuation of the last PR: https://github.com/aws/amazon-mwaa-docker-images/pull/505

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
