### PR TITLE
Remove pool size enforcement for 3.2.1

### DIFF
--- a/images/airflow/3.2.1/python/mwaa/entrypoint.py
+++ b/images/airflow/3.2.1/python/mwaa/entrypoint.py
@@ -70,7 +70,6 @@ from mwaa.config.sqs import (
 )
 from mwaa.utils.cmd import run_command
 from mwaa.utils.dblock import with_db_lock
-from mwaa.utils.statsd import get_statsd
 from mwaa.utils.user_requirements import install_user_requirements
 
 # Usually, we pass the `__name__` variable instead as that defaults to the
@@ -173,33 +172,6 @@ async def airflow_dag_reserialize():
     await run_command("python3 -m mwaa.database.reserialize")
 
 
-async def increase_pool_size_if_insufficient(environ: dict[str, str]):
-    """
-    Increase the default pool size if it is too small.
-
-    Increases the default_pool size to 10000 if it is less than or equal 5000
-    as it improves performance in environments.
-
-    :param environ: A dictionary containing the environment variables.
-    """
-    problematic_pool_size = 5000
-
-    try:
-        command_output = []
-
-        # Get the current default_pool size
-        await run_command("airflow pools get default_pool | grep default_pool | awk '{print $3}'",
-                        env=environ, stdout_logging_method=lambda output : command_output.append(output))
-
-        # Increasing the pool size if it is the default size
-        if len(command_output) == 1 and int(command_output[0]) <= problematic_pool_size:
-            logger.info("Setting default_pool size to 10000.")
-            await run_command("airflow pools set default_pool 10000 default", env=environ)
-            stats = get_statsd()
-            stats.incr("mwaa.pool.increased_default_pool_size", 1)
-    except Exception as error:
-        logger.error(f"Error checking if pool issue is present: {error}")
-
 @with_db_lock(5678)
 async def create_airflow_user(environ: dict[str, str]):
     """
@@ -292,7 +264,6 @@ async def main() -> None:
     if command == "migrate-db":
         await airflow_db_migrate(environ)
         print("Finished running db validations")
-        await increase_pool_size_if_insufficient(environ)
         return
 
     await install_user_requirements(command, environ)

--- a/tests/images/airflow/3.2.1/python/mwaa/test_entrypoint.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/test_entrypoint.py
@@ -12,7 +12,6 @@ from mwaa.entrypoint import (
     airflow_db_migrate,
     create_airflow_user,
     create_queue,
-    increase_pool_size_if_insufficient,
     main
 )
 
@@ -210,7 +209,6 @@ async def test_main_migrate_db(mock_environ, mock_db_utils):
             patch.object(sys, 'argv', test_args), \
             patch('mwaa.entrypoint.setup_environment_variables') as mock_setup_env, \
             patch('mwaa.entrypoint.airflow_db_migrate') as mock_db_migrate, \
-            patch('mwaa.entrypoint.increase_pool_size_if_insufficient') as mock_pool:
         mock_setup_env.return_value = mock_environ
 
         await main()
@@ -334,49 +332,3 @@ def test_fix_shared_log_volume_permissions_dag_processor_dir_failure(mock_enviro
          patch('os.makedirs', side_effect=OSError('Read-only file system')):
         # Should not raise — just logs a warning
         entrypoint._fix_shared_log_volume_permissions()
-
-
-
-@pytest.mark.asyncio
-async def test_increase_pool_size_when_small(mock_db_utils):
-    """Test increase_pool_size_if_insufficient increases pool when size <= 5000"""
-    environ = {"PYTHONPATH": os.environ.get("PYTHONPATH", "")}
-    call_count = 0
-
-    async def mock_run_command(cmd, env=None, stdout_logging_method=None):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1 and stdout_logging_method:
-            # Simulate pool size output of 5000
-            stdout_logging_method("5000")
-        return 0
-
-    with patch('mwaa.entrypoint.run_command', side_effect=mock_run_command) as mock_cmd, \
-         patch('mwaa.entrypoint.get_statsd') as mock_get_statsd:
-        mock_stats = MagicMock()
-        mock_get_statsd.return_value = mock_stats
-
-        await increase_pool_size_if_insufficient(environ)
-
-        assert mock_cmd.call_count == 2
-        # Second call should set pool to 10000
-        assert "airflow pools set default_pool 10000 default" in mock_cmd.call_args_list[1][0][0]
-        mock_stats.incr.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_increase_pool_size_when_large(mock_db_utils):
-    """Test increase_pool_size_if_insufficient does nothing when size > 5000"""
-    environ = {"PYTHONPATH": os.environ.get("PYTHONPATH", "")}
-
-    async def mock_run_command(cmd, env=None, stdout_logging_method=None):
-        if stdout_logging_method:
-            # Simulate pool size output of 10000
-            stdout_logging_method("10000")
-        return 0
-
-    with patch('mwaa.entrypoint.run_command', side_effect=mock_run_command) as mock_cmd:
-        await increase_pool_size_if_insufficient(environ)
-
-        # Should only call once (the get command), not the set command
-        assert mock_cmd.call_count == 1

--- a/tests/images/airflow/3.2.1/python/mwaa/test_entrypoint.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/test_entrypoint.py
@@ -208,14 +208,13 @@ async def test_main_migrate_db(mock_environ, mock_db_utils):
     with patch.dict(os.environ, mock_environ), \
             patch.object(sys, 'argv', test_args), \
             patch('mwaa.entrypoint.setup_environment_variables') as mock_setup_env, \
-            patch('mwaa.entrypoint.airflow_db_migrate') as mock_db_migrate, \
+            patch('mwaa.entrypoint.airflow_db_migrate') as mock_db_migrate:
         mock_setup_env.return_value = mock_environ
 
         await main()
 
         mock_setup_env.assert_called_once()
         mock_db_migrate.assert_called_once()
-        mock_pool.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Default pool size enforcement has been removed for the other versions but not for 3.2.1. Removing this now as it looks like it could be causing issues with downgrades. 

Similar change: https://github.com/aws/amazon-mwaa-docker-images/pull/397

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
