### PR TITLE
Fix test assertion to use ensure_ascii=True for chunk size validation for 3.0.6

### DIFF
--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -904,8 +904,8 @@ class TestSplitOversizeEvent:
             assert chunk_size <= logger._MAX_EVENT_BYTES
 
     # --- Multi-byte UTF-8 / Unicode handling ---
-    # With ensure_ascii=False, non-ASCII characters stay as raw UTF-8 bytes
-    # and the existing multi-byte walk-back logic handles them correctly.
+    # Size assertions use ensure_ascii=True (json.dumps default) to match
+    # both the implementation and watchtower's serialization behavior.
 
     def test_ascii_only_large_event_splits_correctly(self, logger):
         """Pure ASCII events should always split and reassemble."""
@@ -924,7 +924,7 @@ class TestSplitOversizeEvent:
         reconstructed = "".join(chunk["event"] for chunk in result)
         assert reconstructed == large_event
         for chunk in result:
-            chunk_size = len(json.dumps(chunk, ensure_ascii=False, default=str).encode("utf-8"))
+            chunk_size = len(json.dumps(chunk, default=str).encode("utf-8"))
             assert chunk_size <= logger._MAX_EVENT_BYTES
 
     def test_emoji_characters_not_split(self, logger):


### PR DESCRIPTION
Issue # (if available): https://app.asana.com/1/8442528107068/project/1213077669682433/task/1214436608875623

*Description of changes:*

Changed test_multibyte_utf8_characters_not_split_mid_char to use
json.dumps(chunk, default=str) instead of json.dumps(chunk, ensure_ascii=False)
for chunk size validation. The previous assertion was weaker — ensure_ascii=False
measures non-ASCII as fewer bytes (e.g. 日=3 bytes) than watchtower actually
produces (日=\u65e5=6 bytes), so the test would pass even if chunks exceeded
the real limit.


*List any breaking changes for*
* *The Environment runtime*:
* *The local development experience*:


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.