### PR TITLE
fix(security): add localhost/ prefix to local image refs to prevent Docker Hub fallback

### DIFF
--- a/images/airflow/2.10.1/Dockerfile.derivatives.j2
+++ b/images/airflow/2.10.1/Dockerfile.derivatives.j2
@@ -1,4 +1,4 @@
-FROM amazon-mwaa-docker-images/airflow:2.10.1-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.10.1-base
 
 {% if bootstrapping_scripts_dev %}
 

--- a/images/airflow/2.10.1/Dockerfiles/Dockerfile
+++ b/images/airflow/2.10.1/Dockerfiles/Dockerfile
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.10.1-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.10.1-base
 
 USER airflow
 

--- a/images/airflow/2.10.1/Dockerfiles/Dockerfile-dev
+++ b/images/airflow/2.10.1/Dockerfiles/Dockerfile-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.10.1-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.10.1-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/2.10.1/Dockerfiles/Dockerfile-explorer
+++ b/images/airflow/2.10.1/Dockerfiles/Dockerfile-explorer
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.10.1-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.10.1-base
 
 USER airflow
 

--- a/images/airflow/2.10.1/Dockerfiles/Dockerfile-explorer-dev
+++ b/images/airflow/2.10.1/Dockerfiles/Dockerfile-explorer-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.10.1-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.10.1-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/2.10.1/Dockerfiles/Dockerfile-explorer-privileged
+++ b/images/airflow/2.10.1/Dockerfiles/Dockerfile-explorer-privileged
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.10.1-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.10.1-base
 
 USER root
 

--- a/images/airflow/2.10.1/Dockerfiles/Dockerfile-explorer-privileged-dev
+++ b/images/airflow/2.10.1/Dockerfiles/Dockerfile-explorer-privileged-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.10.1-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.10.1-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/2.10.1/build.ps1
+++ b/images/airflow/2.10.1/build.ps1
@@ -102,7 +102,7 @@ if ($GenerateBom -eq "True") {
 # ---------------------------------------------------------------------------
 # Build base image
 # ---------------------------------------------------------------------------
-& $ContainerRuntime build -f .\Dockerfiles\Dockerfile.base -t amazon-mwaa-docker-images/airflow:2.10.1-base .\
+& $ContainerRuntime build -f .\Dockerfiles\Dockerfile.base -t localhost/amazon-mwaa-docker-images/airflow:2.10.1-base .\
 if ($LASTEXITCODE -ne 0) { throw "Failed to build base image." }
 
 # ---------------------------------------------------------------------------

--- a/images/airflow/2.10.1/build.sh
+++ b/images/airflow/2.10.1/build.sh
@@ -23,7 +23,7 @@ if [[ "$GENERATE_BILL_OF_MATERIALS" == "True" ]]; then
 fi
 
 # Build the base image.
-${CONTAINER_RUNTIME} build -f ./Dockerfiles/Dockerfile.base -t amazon-mwaa-docker-images/airflow:2.10.1-base ./
+${CONTAINER_RUNTIME} build -f ./Dockerfiles/Dockerfile.base -t localhost/amazon-mwaa-docker-images/airflow:2.10.1-base ./
 
 # Build the derivatives.
 for dev in "True" "False"; do

--- a/images/airflow/2.10.3/Dockerfile.derivatives.j2
+++ b/images/airflow/2.10.3/Dockerfile.derivatives.j2
@@ -1,4 +1,4 @@
-FROM amazon-mwaa-docker-images/airflow:2.10.3-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.10.3-base
 
 {% if bootstrapping_scripts_dev %}
 

--- a/images/airflow/2.10.3/Dockerfiles/Dockerfile
+++ b/images/airflow/2.10.3/Dockerfiles/Dockerfile
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.10.3-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.10.3-base
 
 USER airflow
 

--- a/images/airflow/2.10.3/Dockerfiles/Dockerfile-dev
+++ b/images/airflow/2.10.3/Dockerfiles/Dockerfile-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.10.3-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.10.3-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/2.10.3/Dockerfiles/Dockerfile-explorer
+++ b/images/airflow/2.10.3/Dockerfiles/Dockerfile-explorer
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.10.3-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.10.3-base
 
 USER airflow
 

--- a/images/airflow/2.10.3/Dockerfiles/Dockerfile-explorer-dev
+++ b/images/airflow/2.10.3/Dockerfiles/Dockerfile-explorer-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.10.3-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.10.3-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/2.10.3/Dockerfiles/Dockerfile-explorer-privileged
+++ b/images/airflow/2.10.3/Dockerfiles/Dockerfile-explorer-privileged
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.10.3-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.10.3-base
 
 USER root
 

--- a/images/airflow/2.10.3/Dockerfiles/Dockerfile-explorer-privileged-dev
+++ b/images/airflow/2.10.3/Dockerfiles/Dockerfile-explorer-privileged-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.10.3-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.10.3-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/2.10.3/build.ps1
+++ b/images/airflow/2.10.3/build.ps1
@@ -102,7 +102,7 @@ if ($GenerateBom -eq "True") {
 # ---------------------------------------------------------------------------
 # Build base image
 # ---------------------------------------------------------------------------
-& $ContainerRuntime build -f .\Dockerfiles\Dockerfile.base -t amazon-mwaa-docker-images/airflow:2.10.3-base .\
+& $ContainerRuntime build -f .\Dockerfiles\Dockerfile.base -t localhost/amazon-mwaa-docker-images/airflow:2.10.3-base .\
 if ($LASTEXITCODE -ne 0) { throw "Failed to build base image." }
 
 # ---------------------------------------------------------------------------

--- a/images/airflow/2.10.3/build.sh
+++ b/images/airflow/2.10.3/build.sh
@@ -23,7 +23,7 @@ if [[ "$GENERATE_BILL_OF_MATERIALS" == "True" ]]; then
 fi
 
 # Build the base image.
-${CONTAINER_RUNTIME} build -f ./Dockerfiles/Dockerfile.base -t amazon-mwaa-docker-images/airflow:2.10.3-base ./
+${CONTAINER_RUNTIME} build -f ./Dockerfiles/Dockerfile.base -t localhost/amazon-mwaa-docker-images/airflow:2.10.3-base ./
 
 # Build the derivatives.
 for dev in "True" "False"; do

--- a/images/airflow/2.11.0/Dockerfile.derivatives.j2
+++ b/images/airflow/2.11.0/Dockerfile.derivatives.j2
@@ -1,4 +1,4 @@
-FROM amazon-mwaa-docker-images/airflow:2.11.0-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.11.0-base
 
 {% if bootstrapping_scripts_dev %}
 

--- a/images/airflow/2.11.0/Dockerfiles/Dockerfile
+++ b/images/airflow/2.11.0/Dockerfiles/Dockerfile
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.11.0-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.11.0-base
 
 USER airflow
 

--- a/images/airflow/2.11.0/Dockerfiles/Dockerfile-dev
+++ b/images/airflow/2.11.0/Dockerfiles/Dockerfile-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.11.0-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.11.0-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/2.11.0/Dockerfiles/Dockerfile-explorer
+++ b/images/airflow/2.11.0/Dockerfiles/Dockerfile-explorer
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.11.0-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.11.0-base
 
 USER airflow
 

--- a/images/airflow/2.11.0/Dockerfiles/Dockerfile-explorer-dev
+++ b/images/airflow/2.11.0/Dockerfiles/Dockerfile-explorer-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.11.0-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.11.0-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/2.11.0/Dockerfiles/Dockerfile-explorer-privileged
+++ b/images/airflow/2.11.0/Dockerfiles/Dockerfile-explorer-privileged
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.11.0-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.11.0-base
 
 USER root
 

--- a/images/airflow/2.11.0/Dockerfiles/Dockerfile-explorer-privileged-dev
+++ b/images/airflow/2.11.0/Dockerfiles/Dockerfile-explorer-privileged-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.11.0-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.11.0-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/2.11.0/build.ps1
+++ b/images/airflow/2.11.0/build.ps1
@@ -102,7 +102,7 @@ if ($GenerateBom -eq "True") {
 # ---------------------------------------------------------------------------
 # Build base image
 # ---------------------------------------------------------------------------
-& $ContainerRuntime build -f .\Dockerfiles\Dockerfile.base -t amazon-mwaa-docker-images/airflow:2.11.0-base .\
+& $ContainerRuntime build -f .\Dockerfiles\Dockerfile.base -t localhost/amazon-mwaa-docker-images/airflow:2.11.0-base .\
 if ($LASTEXITCODE -ne 0) { throw "Failed to build base image." }
 
 # ---------------------------------------------------------------------------

--- a/images/airflow/2.11.0/build.sh
+++ b/images/airflow/2.11.0/build.sh
@@ -23,7 +23,7 @@ if [[ "$GENERATE_BILL_OF_MATERIALS" == "True" ]]; then
 fi
 
 # Build the base image.
-${CONTAINER_RUNTIME} build -f ./Dockerfiles/Dockerfile.base -t amazon-mwaa-docker-images/airflow:2.11.0-base ./
+${CONTAINER_RUNTIME} build -f ./Dockerfiles/Dockerfile.base -t localhost/amazon-mwaa-docker-images/airflow:2.11.0-base ./
 
 # Build the derivatives.
 for dev in "True" "False"; do

--- a/images/airflow/2.9.2/Dockerfile.derivatives.j2
+++ b/images/airflow/2.9.2/Dockerfile.derivatives.j2
@@ -1,4 +1,4 @@
-FROM amazon-mwaa-docker-images/airflow:2.9.2-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.9.2-base
 
 {% if bootstrapping_scripts_dev %}
 

--- a/images/airflow/2.9.2/Dockerfiles/Dockerfile
+++ b/images/airflow/2.9.2/Dockerfiles/Dockerfile
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.9.2-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.9.2-base
 
 USER airflow
 

--- a/images/airflow/2.9.2/Dockerfiles/Dockerfile-dev
+++ b/images/airflow/2.9.2/Dockerfiles/Dockerfile-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.9.2-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.9.2-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer
+++ b/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.9.2-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.9.2-base
 
 USER airflow
 

--- a/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer-dev
+++ b/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.9.2-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.9.2-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer-privileged
+++ b/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer-privileged
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.9.2-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.9.2-base
 
 USER root
 

--- a/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer-privileged-dev
+++ b/images/airflow/2.9.2/Dockerfiles/Dockerfile-explorer-privileged-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:2.9.2-base
+FROM localhost/amazon-mwaa-docker-images/airflow:2.9.2-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/2.9.2/build.ps1
+++ b/images/airflow/2.9.2/build.ps1
@@ -102,7 +102,7 @@ if ($GenerateBom -eq "True") {
 # ---------------------------------------------------------------------------
 # Build base image
 # ---------------------------------------------------------------------------
-& $ContainerRuntime build -f .\Dockerfiles\Dockerfile.base -t amazon-mwaa-docker-images/airflow:2.9.2-base .\
+& $ContainerRuntime build -f .\Dockerfiles\Dockerfile.base -t localhost/amazon-mwaa-docker-images/airflow:2.9.2-base .\
 if ($LASTEXITCODE -ne 0) { throw "Failed to build base image." }
 
 # ---------------------------------------------------------------------------

--- a/images/airflow/2.9.2/build.sh
+++ b/images/airflow/2.9.2/build.sh
@@ -23,7 +23,7 @@ if [[ "$GENERATE_BILL_OF_MATERIALS" == "True" ]]; then
 fi
 
 # Build the base image.
-${CONTAINER_RUNTIME} build -f ./Dockerfiles/Dockerfile.base -t amazon-mwaa-docker-images/airflow:2.9.2-base ./
+${CONTAINER_RUNTIME} build -f ./Dockerfiles/Dockerfile.base -t localhost/amazon-mwaa-docker-images/airflow:2.9.2-base ./
 
 # Build the derivatives.
 for dev in "True" "False"; do

--- a/images/airflow/3.0.6/Dockerfile.derivatives.j2
+++ b/images/airflow/3.0.6/Dockerfile.derivatives.j2
@@ -1,4 +1,4 @@
-FROM amazon-mwaa-docker-images/airflow:3.0.6-base
+FROM localhost/amazon-mwaa-docker-images/airflow:3.0.6-base
 
 {% if bootstrapping_scripts_dev %}
 

--- a/images/airflow/3.0.6/Dockerfiles/Dockerfile
+++ b/images/airflow/3.0.6/Dockerfiles/Dockerfile
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:3.0.6-base
+FROM localhost/amazon-mwaa-docker-images/airflow:3.0.6-base
 
 USER airflow
 

--- a/images/airflow/3.0.6/Dockerfiles/Dockerfile-dev
+++ b/images/airflow/3.0.6/Dockerfiles/Dockerfile-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:3.0.6-base
+FROM localhost/amazon-mwaa-docker-images/airflow:3.0.6-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/3.0.6/Dockerfiles/Dockerfile-explorer
+++ b/images/airflow/3.0.6/Dockerfiles/Dockerfile-explorer
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:3.0.6-base
+FROM localhost/amazon-mwaa-docker-images/airflow:3.0.6-base
 
 USER airflow
 

--- a/images/airflow/3.0.6/Dockerfiles/Dockerfile-explorer-dev
+++ b/images/airflow/3.0.6/Dockerfiles/Dockerfile-explorer-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:3.0.6-base
+FROM localhost/amazon-mwaa-docker-images/airflow:3.0.6-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/3.0.6/Dockerfiles/Dockerfile-explorer-privileged
+++ b/images/airflow/3.0.6/Dockerfiles/Dockerfile-explorer-privileged
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:3.0.6-base
+FROM localhost/amazon-mwaa-docker-images/airflow:3.0.6-base
 
 USER root
 

--- a/images/airflow/3.0.6/Dockerfiles/Dockerfile-explorer-privileged-dev
+++ b/images/airflow/3.0.6/Dockerfiles/Dockerfile-explorer-privileged-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:3.0.6-base
+FROM localhost/amazon-mwaa-docker-images/airflow:3.0.6-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/3.0.6/build.ps1
+++ b/images/airflow/3.0.6/build.ps1
@@ -102,7 +102,7 @@ if ($GenerateBom -eq "True") {
 # ---------------------------------------------------------------------------
 # Build base image
 # ---------------------------------------------------------------------------
-& $ContainerRuntime build -f .\Dockerfiles\Dockerfile.base -t amazon-mwaa-docker-images/airflow:3.0.6-base .\
+& $ContainerRuntime build -f .\Dockerfiles\Dockerfile.base -t localhost/amazon-mwaa-docker-images/airflow:3.0.6-base .\
 if ($LASTEXITCODE -ne 0) { throw "Failed to build base image." }
 
 # ---------------------------------------------------------------------------

--- a/images/airflow/3.0.6/build.sh
+++ b/images/airflow/3.0.6/build.sh
@@ -23,7 +23,7 @@ if [[ "$GENERATE_BILL_OF_MATERIALS" == "True" ]]; then
 fi
 
 # Build the base image.
-${CONTAINER_RUNTIME} build -f ./Dockerfiles/Dockerfile.base -t amazon-mwaa-docker-images/airflow:3.0.6-base ./
+${CONTAINER_RUNTIME} build -f ./Dockerfiles/Dockerfile.base -t localhost/amazon-mwaa-docker-images/airflow:3.0.6-base ./
 
 
 # Build the derivatives.

--- a/images/airflow/3.2.1/Dockerfile.derivatives.j2
+++ b/images/airflow/3.2.1/Dockerfile.derivatives.j2
@@ -1,4 +1,4 @@
-FROM amazon-mwaa-docker-images/airflow:3.2.1-base
+FROM localhost/amazon-mwaa-docker-images/airflow:3.2.1-base
 
 {% if bootstrapping_scripts_dev %}
 

--- a/images/airflow/3.2.1/Dockerfiles/Dockerfile
+++ b/images/airflow/3.2.1/Dockerfiles/Dockerfile
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:3.2.1-base
+FROM localhost/amazon-mwaa-docker-images/airflow:3.2.1-base
 
 USER airflow
 

--- a/images/airflow/3.2.1/Dockerfiles/Dockerfile-dev
+++ b/images/airflow/3.2.1/Dockerfiles/Dockerfile-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:3.2.1-base
+FROM localhost/amazon-mwaa-docker-images/airflow:3.2.1-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer
+++ b/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:3.2.1-base
+FROM localhost/amazon-mwaa-docker-images/airflow:3.2.1-base
 
 USER airflow
 

--- a/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer-dev
+++ b/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:3.2.1-base
+FROM localhost/amazon-mwaa-docker-images/airflow:3.2.1-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer-privileged
+++ b/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer-privileged
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:3.2.1-base
+FROM localhost/amazon-mwaa-docker-images/airflow:3.2.1-base
 
 USER root
 

--- a/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer-privileged-dev
+++ b/images/airflow/3.2.1/Dockerfiles/Dockerfile-explorer-privileged-dev
@@ -4,7 +4,7 @@
 # instead.
 #
 
-FROM amazon-mwaa-docker-images/airflow:3.2.1-base
+FROM localhost/amazon-mwaa-docker-images/airflow:3.2.1-base
 
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # BEGINNING marker for dev bootstrapping steps.

--- a/images/airflow/3.2.1/build.ps1
+++ b/images/airflow/3.2.1/build.ps1
@@ -102,7 +102,7 @@ if ($GenerateBom -eq "True") {
 # ---------------------------------------------------------------------------
 # Build base image
 # ---------------------------------------------------------------------------
-& $ContainerRuntime build -f .\Dockerfiles\Dockerfile.base -t amazon-mwaa-docker-images/airflow:3.2.1-base .\
+& $ContainerRuntime build -f .\Dockerfiles\Dockerfile.base -t localhost/amazon-mwaa-docker-images/airflow:3.2.1-base .\
 if ($LASTEXITCODE -ne 0) { throw "Failed to build base image." }
 
 # ---------------------------------------------------------------------------

--- a/images/airflow/3.2.1/build.sh
+++ b/images/airflow/3.2.1/build.sh
@@ -23,7 +23,7 @@ if [[ "$GENERATE_BILL_OF_MATERIALS" == "True" ]]; then
 fi
 
 # Build the base image.
-${CONTAINER_RUNTIME} build -f ./Dockerfiles/Dockerfile.base -t amazon-mwaa-docker-images/airflow:3.2.1-base ./
+${CONTAINER_RUNTIME} build -f ./Dockerfiles/Dockerfile.base -t localhost/amazon-mwaa-docker-images/airflow:3.2.1-base ./
 
 
 # Build the derivatives.


### PR DESCRIPTION
## Summary

The `FROM` statements in derivative Dockerfiles reference the locally-built base image as `amazon-mwaa-docker-images/airflow:<version>-base`. Without a registry prefix, Docker could resolve this to `docker.io/amazon-mwaa-docker-images/airflow:<version>-base` if the local image is missing, creating a supply chain risk.

Adding the `localhost/` prefix ensures Docker only looks in the local image store and fails explicitly rather than pulling from an untrusted remote registry.

## Changes

Updated across all Airflow versions (2.9.2, 2.10.1, 2.10.3, 2.11.0, 3.0.6, 3.2.1):
- Jinja2 template (`Dockerfile.derivatives.j2`)
- All generated Dockerfiles (6 per version)
- Build scripts (`build.sh`, `build.ps1`)

54 files changed, all single-line substitutions.

## Testing

- Verified `localhost/` prefix is the standard Docker convention for local-only image resolution
- No functional change to build behavior when the local image exists (which it always does in our build pipeline)
- The base image is always built immediately before the derivative images in both `build.sh` and `build.ps1`, so the local tag is guaranteed to exist at `FROM` resolution time

## Motivation

Addresses ACAT security finding. Without `localhost/`, if the local build step were skipped or failed silently, Docker would attempt to pull from Docker Hub — potentially fetching an attacker-controlled image with the same name.