### PR TITLE
Fix 3.2.1 to 2.11.0 downgrade FAB table missing default sequence

### DIFF
--- a/images/airflow/3.2.1/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.2.1/python/mwaa/database/migrate_with_downgrade.py
@@ -230,7 +230,7 @@ def _check_downgrade_db():
             )
         airflow_db_command.downgrade(args)
 
-        if Version(target_version) == Version("3.0.6"):
+        if Version(target_version) in (Version("3.0.6"), Version("2.11.0")):
             logging.info(
                 "Target version uses an older FAB provider, downgrading FAB provider database..."
             )


### PR DESCRIPTION
*Issue #, if available:*
Symptom: After downgrade from 3.2.1 to 2.11.0, existing DAGs appear in console and work fine, but adding a new DAG will lead to DAG does not exist error banner in console, and having below error messages in dag processing log:
```
{override.py:1933} ERROR - Creation of Permission View Error: (psycopg2.errors.NotNullViolation) null value in column "id" of relation "ab_permission_view" violates not-null constraint

DETAIL:  Failing row contains (null, 2, null).

[SQL: INSERT INTO ab_permission_view (permission_id, view_menu_id) VALUES (%(permission_id)s, %(view_menu_id)s) RETURNING ab_permission_view.id]

[parameters: {'permission_id': 2, 'view_menu_id': None}]
``` 

*Description of changes:*
+ The fix is to (1) run `airflow fab-db downgrade` command; (2) manually add missing default sequence to fab table id fields. 

*Testing:*
+ Created an 3.2.1 environment with updated image, then performed a downgrade to 2.11.0, confirmed that newly added DAGs are able to show and execute in console, and no error logs in dag processing log. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
