### PR TITLE
feat: add database connection retry mechanism for maintenance workflows

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.10.1/python/mwaa/database/migrate_with_downgrade.py
@@ -10,15 +10,16 @@ connect to the meta database, thus all configurations need to be set.
 from argparse import Namespace
 from packaging.version import Version
 from sqlalchemy import create_engine, text
+import logging
 import logging.config
 import os
 import sys
 
 from mwaa.config.database import get_db_connection_string
+from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 from mwaa.utils.dblock import with_db_lock
-from airflow.cli.commands import db_command as airflow_db_command
-
 from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+from airflow.cli.commands import db_command as airflow_db_command
 
 DB_IAM_USERNAME = "airflow_user"
 DB_ADMIN_USERNAME = "adminuser"
@@ -43,33 +44,37 @@ def _verify_environ():
 
 def _ensure_rds_iam_user():
     try:
-        # Set db_connection_url using RDS IAM credentials
-        try:
-            # On default, try to connect to engine using admin user to create/update airflow_user
+        def _connect_static():
             logger.info("Creating db_connection_url using static credentials")
-            db_connection_url = get_db_connection_string()
-            db_engine = create_engine(
-                db_connection_url,
-                connect_args={"connect_timeout": 3}
+            engine = create_engine(
+                get_db_connection_string(),
+                **MAINTENANCE_ENGINE_KWARGS,
             )
-            with db_engine.connect() as conn:
+            with engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
             logger.info("Engine created using static credentials")
-            
-        except Exception as e:
-            logger.warning(f"Exception type: {type(e).__name__}, message: {e}")
-            # If adminuser connection fails due to RDS IAM set up, then use RDS IAM for connection
+            return engine
+
+        @with_db_retry
+        def _connect_iam():
             logger.info("Creating db_connection_url using RDS IAM credentials")
             token = RDSIAMCredentialProvider.get_token()
             db_connection_url = RDSIAMCredentialProvider.create_db_connection_url(token)
             logger.info("Creating engine using RDS IAM and validating connection")
-            db_engine = create_engine(
+            engine = create_engine(
                 db_connection_url,
-                connect_args={"connect_timeout": 3}
+                **MAINTENANCE_ENGINE_KWARGS,
             )
-            with db_engine.connect() as conn:
+            with engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
             logger.info("Engine created using RDS IAM and connection validated")
+            return engine
+
+        try:
+            db_engine = _connect_static()
+        except Exception as e:
+            logger.warning(f"Static credentials failed: {type(e).__name__}: {e}")
+            db_engine = _connect_iam()
 
         with db_engine.connect() as conn:
             with conn.begin():
@@ -86,7 +91,6 @@ def _ensure_rds_iam_user():
                 ).scalar()
 
                 if current_role == DB_ADMIN_USERNAME:
-                    # Always ensure permissions are up to date
                     logger.info(f"Current role is {DB_ADMIN_USERNAME}, setting up permissions for airflow_user")
                     conn.execute(text(f"GRANT rds_iam TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'))
@@ -98,7 +102,6 @@ def _ensure_rds_iam_user():
                     conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f"GRANT {DB_ADMIN_USERNAME} TO {DB_IAM_USERNAME}"))
-
                 elif current_role == "airflow_user":
                     logger.info("Current role is airflow_user")
     except Exception as e:

--- a/images/airflow/2.10.1/python/mwaa/utils/db_retry.py
+++ b/images/airflow/2.10.1/python/mwaa/utils/db_retry.py
@@ -1,0 +1,35 @@
+"""Database connection retry utilities for MWAA maintenance workflows."""
+
+import logging
+import os
+
+from sqlalchemy.exc import InterfaceError, OperationalError
+from sqlalchemy.pool import NullPool
+from tenacity import (
+    after_log,
+    before_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
+
+_RETRY_ATTEMPTS = int(os.environ.get("MWAA_DB_RETRY_ATTEMPTS", "7"))
+_RETRY_MIN_WAIT = int(os.environ.get("MWAA_DB_RETRY_MIN_WAIT", "2"))
+_RETRY_MAX_WAIT = int(os.environ.get("MWAA_DB_RETRY_MAX_WAIT", "60"))
+
+MAINTENANCE_ENGINE_KWARGS = {
+    "poolclass": NullPool,
+    "connect_args": {"connect_timeout": 3},
+}
+
+with_db_retry = retry(
+    stop=stop_after_attempt(_RETRY_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=_RETRY_MIN_WAIT, max=_RETRY_MAX_WAIT),
+    retry=retry_if_exception_type((OperationalError, InterfaceError)),
+    before=before_log(logger, logging.INFO),
+    after=after_log(logger, logging.INFO),
+    reraise=True,
+)

--- a/images/airflow/2.10.1/python/mwaa/utils/dblock.py
+++ b/images/airflow/2.10.1/python/mwaa/utils/dblock.py
@@ -13,15 +13,23 @@ from typing import Any, Awaitable, Callable, TypeVar, Union, cast
 
 # 3rd party imports
 from sqlalchemy import create_engine, text
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Connection
 
 # Our imports
 from mwaa.config.database import get_db_connection_string
+from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 
 logger = logging.getLogger(__name__)
 
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+@with_db_retry
+def _connect_with_retry() -> Connection:
+    """Establish a DB connection with retry on transient RDS Proxy failures."""
+    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    return engine.connect()
 
 
 def _obtain_db_lock(conn: Any, lock_id: int, timeout_ms: int, friendly_name: str):
@@ -95,23 +103,27 @@ def with_db_lock(
     ) -> Union[Callable[..., Any], Callable[..., Awaitable[Any]]]:
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
             func_name: str = func.__name__
-            db_engine: Engine = create_engine(get_db_connection_string())
-            with db_engine.connect() as conn:  # type: ignore
+            conn = _connect_with_retry()
+            try:
+                _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
+                return await func(*args, **kwargs)
+            finally:
                 try:
-                    _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
-                    return await func(*args, **kwargs)
-                finally:
                     _release_db_lock(conn, lock_id, func_name)
+                finally:
+                    conn.close()
 
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
             func_name: str = func.__name__
-            db_engine: Engine = create_engine(get_db_connection_string())
-            with db_engine.connect() as conn:  # type: ignore
+            conn = _connect_with_retry()
+            try:
+                _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
+                return func(*args, **kwargs)
+            finally:
                 try:
-                    _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
-                    return func(*args, **kwargs)
-                finally:
                     _release_db_lock(conn, lock_id, func_name)
+                finally:
+                    conn.close()
 
         if asyncio.iscoroutinefunction(func):
             return cast(Callable[..., Awaitable[Any]], async_wrapper)

--- a/images/airflow/2.10.3/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.10.3/python/mwaa/database/migrate_with_downgrade.py
@@ -10,15 +10,16 @@ connect to the meta database, thus all configurations need to be set.
 from argparse import Namespace
 from packaging.version import Version
 from sqlalchemy import create_engine, text
+import logging
 import logging.config
 import os
 import sys
 
 from mwaa.config.database import get_db_connection_string
+from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 from mwaa.utils.dblock import with_db_lock
-from airflow.cli.commands import db_command as airflow_db_command
-
 from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+from airflow.cli.commands import db_command as airflow_db_command
 
 DB_IAM_USERNAME = "airflow_user"
 DB_ADMIN_USERNAME = "adminuser"
@@ -43,33 +44,37 @@ def _verify_environ():
 
 def _ensure_rds_iam_user():
     try:
-        # Set db_connection_url using RDS IAM credentials
-        try:
-            # On default, try to connect to engine using admin user to create/update airflow_user
+        def _connect_static():
             logger.info("Creating db_connection_url using static credentials")
-            db_connection_url = get_db_connection_string()
-            db_engine = create_engine(
-                db_connection_url,
-                connect_args={"connect_timeout": 3}
+            engine = create_engine(
+                get_db_connection_string(),
+                **MAINTENANCE_ENGINE_KWARGS,
             )
-            with db_engine.connect() as conn:
+            with engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
             logger.info("Engine created using static credentials")
-            
-        except Exception as e:
-            logger.warning(f"Exception type: {type(e).__name__}, message: {e}")
-            # If adminuser connection fails due to RDS IAM set up, then use RDS IAM for connection
+            return engine
+
+        @with_db_retry
+        def _connect_iam():
             logger.info("Creating db_connection_url using RDS IAM credentials")
             token = RDSIAMCredentialProvider.get_token()
             db_connection_url = RDSIAMCredentialProvider.create_db_connection_url(token)
             logger.info("Creating engine using RDS IAM and validating connection")
-            db_engine = create_engine(
+            engine = create_engine(
                 db_connection_url,
-                connect_args={"connect_timeout": 3}
+                **MAINTENANCE_ENGINE_KWARGS,
             )
-            with db_engine.connect() as conn:
+            with engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
             logger.info("Engine created using RDS IAM and connection validated")
+            return engine
+
+        try:
+            db_engine = _connect_static()
+        except Exception as e:
+            logger.warning(f"Static credentials failed: {type(e).__name__}: {e}")
+            db_engine = _connect_iam()
 
         with db_engine.connect() as conn:
             with conn.begin():
@@ -86,7 +91,6 @@ def _ensure_rds_iam_user():
                 ).scalar()
 
                 if current_role == DB_ADMIN_USERNAME:
-                    # Always ensure permissions are up to date
                     logger.info(f"Current role is {DB_ADMIN_USERNAME}, setting up permissions for airflow_user")
                     conn.execute(text(f"GRANT rds_iam TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'))
@@ -98,7 +102,6 @@ def _ensure_rds_iam_user():
                     conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f"GRANT {DB_ADMIN_USERNAME} TO {DB_IAM_USERNAME}"))
-
                 elif current_role == "airflow_user":
                     logger.info("Current role is airflow_user")
     except Exception as e:

--- a/images/airflow/2.10.3/python/mwaa/utils/db_retry.py
+++ b/images/airflow/2.10.3/python/mwaa/utils/db_retry.py
@@ -1,0 +1,35 @@
+"""Database connection retry utilities for MWAA maintenance workflows."""
+
+import logging
+import os
+
+from sqlalchemy.exc import InterfaceError, OperationalError
+from sqlalchemy.pool import NullPool
+from tenacity import (
+    after_log,
+    before_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
+
+_RETRY_ATTEMPTS = int(os.environ.get("MWAA_DB_RETRY_ATTEMPTS", "7"))
+_RETRY_MIN_WAIT = int(os.environ.get("MWAA_DB_RETRY_MIN_WAIT", "2"))
+_RETRY_MAX_WAIT = int(os.environ.get("MWAA_DB_RETRY_MAX_WAIT", "60"))
+
+MAINTENANCE_ENGINE_KWARGS = {
+    "poolclass": NullPool,
+    "connect_args": {"connect_timeout": 3},
+}
+
+with_db_retry = retry(
+    stop=stop_after_attempt(_RETRY_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=_RETRY_MIN_WAIT, max=_RETRY_MAX_WAIT),
+    retry=retry_if_exception_type((OperationalError, InterfaceError)),
+    before=before_log(logger, logging.INFO),
+    after=after_log(logger, logging.INFO),
+    reraise=True,
+)

--- a/images/airflow/2.10.3/python/mwaa/utils/dblock.py
+++ b/images/airflow/2.10.3/python/mwaa/utils/dblock.py
@@ -13,15 +13,23 @@ from typing import Any, Awaitable, Callable, TypeVar, Union, cast
 
 # 3rd party imports
 from sqlalchemy import create_engine, text
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Connection
 
 # Our imports
 from mwaa.config.database import get_db_connection_string
+from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 
 logger = logging.getLogger(__name__)
 
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+@with_db_retry
+def _connect_with_retry() -> Connection:
+    """Establish a DB connection with retry on transient RDS Proxy failures."""
+    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    return engine.connect()
 
 
 def _obtain_db_lock(conn: Any, lock_id: int, timeout_ms: int, friendly_name: str):
@@ -95,23 +103,27 @@ def with_db_lock(
     ) -> Union[Callable[..., Any], Callable[..., Awaitable[Any]]]:
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
             func_name: str = func.__name__
-            db_engine: Engine = create_engine(get_db_connection_string())
-            with db_engine.connect() as conn:  # type: ignore
+            conn = _connect_with_retry()
+            try:
+                _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
+                return await func(*args, **kwargs)
+            finally:
                 try:
-                    _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
-                    return await func(*args, **kwargs)
-                finally:
                     _release_db_lock(conn, lock_id, func_name)
+                finally:
+                    conn.close()
 
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
             func_name: str = func.__name__
-            db_engine: Engine = create_engine(get_db_connection_string())
-            with db_engine.connect() as conn:  # type: ignore
+            conn = _connect_with_retry()
+            try:
+                _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
+                return func(*args, **kwargs)
+            finally:
                 try:
-                    _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
-                    return func(*args, **kwargs)
-                finally:
                     _release_db_lock(conn, lock_id, func_name)
+                finally:
+                    conn.close()
 
         if asyncio.iscoroutinefunction(func):
             return cast(Callable[..., Awaitable[Any]], async_wrapper)

--- a/images/airflow/2.11.0/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.11.0/python/mwaa/database/migrate_with_downgrade.py
@@ -10,15 +10,16 @@ connect to the meta database, thus all configurations need to be set.
 from argparse import Namespace
 from packaging.version import Version
 from sqlalchemy import create_engine, text
+import logging
 import logging.config
 import os
 import sys
 
 from mwaa.config.database import get_db_connection_string
+from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 from mwaa.utils.dblock import with_db_lock
-from airflow.cli.commands import db_command as airflow_db_command
-
 from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+from airflow.cli.commands import db_command as airflow_db_command
 
 DB_IAM_USERNAME = "airflow_user"
 DB_ADMIN_USERNAME = "adminuser"
@@ -43,33 +44,37 @@ def _verify_environ():
 
 def _ensure_rds_iam_user():
     try:
-        # Set db_connection_url using RDS IAM credentials
-        try:
-            # On default, try to connect to engine using admin user to create/update airflow_user
+        def _connect_static():
             logger.info("Creating db_connection_url using static credentials")
-            db_connection_url = get_db_connection_string()
-            db_engine = create_engine(
-                db_connection_url,
-                connect_args={"connect_timeout": 3}
+            engine = create_engine(
+                get_db_connection_string(),
+                **MAINTENANCE_ENGINE_KWARGS,
             )
-            with db_engine.connect() as conn:
+            with engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
             logger.info("Engine created using static credentials")
-            
-        except Exception as e:
-            logger.warning(f"Exception type: {type(e).__name__}, message: {e}")
-            # If adminuser connection fails due to RDS IAM set up, then use RDS IAM for connection
+            return engine
+
+        @with_db_retry
+        def _connect_iam():
             logger.info("Creating db_connection_url using RDS IAM credentials")
             token = RDSIAMCredentialProvider.get_token()
             db_connection_url = RDSIAMCredentialProvider.create_db_connection_url(token)
             logger.info("Creating engine using RDS IAM and validating connection")
-            db_engine = create_engine(
+            engine = create_engine(
                 db_connection_url,
-                connect_args={"connect_timeout": 3}
+                **MAINTENANCE_ENGINE_KWARGS,
             )
-            with db_engine.connect() as conn:
+            with engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
             logger.info("Engine created using RDS IAM and connection validated")
+            return engine
+
+        try:
+            db_engine = _connect_static()
+        except Exception as e:
+            logger.warning(f"Static credentials failed: {type(e).__name__}: {e}")
+            db_engine = _connect_iam()
 
         with db_engine.connect() as conn:
             with conn.begin():
@@ -86,7 +91,6 @@ def _ensure_rds_iam_user():
                 ).scalar()
 
                 if current_role == DB_ADMIN_USERNAME:
-                    # Always ensure permissions are up to date
                     logger.info(f"Current role is {DB_ADMIN_USERNAME}, setting up permissions for airflow_user")
                     conn.execute(text(f"GRANT rds_iam TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'))
@@ -98,7 +102,6 @@ def _ensure_rds_iam_user():
                     conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f"GRANT {DB_ADMIN_USERNAME} TO {DB_IAM_USERNAME}"))
-
                 elif current_role == "airflow_user":
                     logger.info("Current role is airflow_user")
     except Exception as e:

--- a/images/airflow/2.11.0/python/mwaa/utils/db_retry.py
+++ b/images/airflow/2.11.0/python/mwaa/utils/db_retry.py
@@ -1,0 +1,35 @@
+"""Database connection retry utilities for MWAA maintenance workflows."""
+
+import logging
+import os
+
+from sqlalchemy.exc import InterfaceError, OperationalError
+from sqlalchemy.pool import NullPool
+from tenacity import (
+    after_log,
+    before_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
+
+_RETRY_ATTEMPTS = int(os.environ.get("MWAA_DB_RETRY_ATTEMPTS", "7"))
+_RETRY_MIN_WAIT = int(os.environ.get("MWAA_DB_RETRY_MIN_WAIT", "2"))
+_RETRY_MAX_WAIT = int(os.environ.get("MWAA_DB_RETRY_MAX_WAIT", "60"))
+
+MAINTENANCE_ENGINE_KWARGS = {
+    "poolclass": NullPool,
+    "connect_args": {"connect_timeout": 3},
+}
+
+with_db_retry = retry(
+    stop=stop_after_attempt(_RETRY_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=_RETRY_MIN_WAIT, max=_RETRY_MAX_WAIT),
+    retry=retry_if_exception_type((OperationalError, InterfaceError)),
+    before=before_log(logger, logging.INFO),
+    after=after_log(logger, logging.INFO),
+    reraise=True,
+)

--- a/images/airflow/2.11.0/python/mwaa/utils/dblock.py
+++ b/images/airflow/2.11.0/python/mwaa/utils/dblock.py
@@ -13,15 +13,23 @@ from typing import Any, Awaitable, Callable, TypeVar, Union, cast
 
 # 3rd party imports
 from sqlalchemy import create_engine, text
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Connection
 
 # Our imports
 from mwaa.config.database import get_db_connection_string
+from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 
 logger = logging.getLogger(__name__)
 
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+@with_db_retry
+def _connect_with_retry() -> Connection:
+    """Establish a DB connection with retry on transient RDS Proxy failures."""
+    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    return engine.connect()
 
 
 def _obtain_db_lock(conn: Any, lock_id: int, timeout_ms: int, friendly_name: str):
@@ -95,23 +103,27 @@ def with_db_lock(
     ) -> Union[Callable[..., Any], Callable[..., Awaitable[Any]]]:
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
             func_name: str = func.__name__
-            db_engine: Engine = create_engine(get_db_connection_string())
-            with db_engine.connect() as conn:  # type: ignore
+            conn = _connect_with_retry()
+            try:
+                _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
+                return await func(*args, **kwargs)
+            finally:
                 try:
-                    _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
-                    return await func(*args, **kwargs)
-                finally:
                     _release_db_lock(conn, lock_id, func_name)
+                finally:
+                    conn.close()
 
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
             func_name: str = func.__name__
-            db_engine: Engine = create_engine(get_db_connection_string())
-            with db_engine.connect() as conn:  # type: ignore
+            conn = _connect_with_retry()
+            try:
+                _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
+                return func(*args, **kwargs)
+            finally:
                 try:
-                    _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
-                    return func(*args, **kwargs)
-                finally:
                     _release_db_lock(conn, lock_id, func_name)
+                finally:
+                    conn.close()
 
         if asyncio.iscoroutinefunction(func):
             return cast(Callable[..., Awaitable[Any]], async_wrapper)

--- a/images/airflow/2.11.2/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.11.2/python/mwaa/database/migrate_with_downgrade.py
@@ -10,15 +10,16 @@ connect to the meta database, thus all configurations need to be set.
 from argparse import Namespace
 from packaging.version import Version
 from sqlalchemy import create_engine, text
+import logging
 import logging.config
 import os
 import sys
 
 from mwaa.config.database import get_db_connection_string
+from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 from mwaa.utils.dblock import with_db_lock
-from airflow.cli.commands import db_command as airflow_db_command
-
 from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+from airflow.cli.commands import db_command as airflow_db_command
 
 DB_IAM_USERNAME = "airflow_user"
 DB_ADMIN_USERNAME = "adminuser"
@@ -43,33 +44,37 @@ def _verify_environ():
 
 def _ensure_rds_iam_user():
     try:
-        # Set db_connection_url using RDS IAM credentials
-        try:
-            # On default, try to connect to engine using admin user to create/update airflow_user
+        def _connect_static():
             logger.info("Creating db_connection_url using static credentials")
-            db_connection_url = get_db_connection_string()
-            db_engine = create_engine(
-                db_connection_url,
-                connect_args={"connect_timeout": 3}
+            engine = create_engine(
+                get_db_connection_string(),
+                **MAINTENANCE_ENGINE_KWARGS,
             )
-            with db_engine.connect() as conn:
+            with engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
             logger.info("Engine created using static credentials")
-            
-        except Exception as e:
-            logger.warning(f"Exception type: {type(e).__name__}, message: {e}")
-            # If adminuser connection fails due to RDS IAM set up, then use RDS IAM for connection
+            return engine
+
+        @with_db_retry
+        def _connect_iam():
             logger.info("Creating db_connection_url using RDS IAM credentials")
             token = RDSIAMCredentialProvider.get_token()
             db_connection_url = RDSIAMCredentialProvider.create_db_connection_url(token)
             logger.info("Creating engine using RDS IAM and validating connection")
-            db_engine = create_engine(
+            engine = create_engine(
                 db_connection_url,
-                connect_args={"connect_timeout": 3}
+                **MAINTENANCE_ENGINE_KWARGS,
             )
-            with db_engine.connect() as conn:
+            with engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
             logger.info("Engine created using RDS IAM and connection validated")
+            return engine
+
+        try:
+            db_engine = _connect_static()
+        except Exception as e:
+            logger.warning(f"Static credentials failed: {type(e).__name__}: {e}")
+            db_engine = _connect_iam()
 
         with db_engine.connect() as conn:
             with conn.begin():
@@ -86,7 +91,6 @@ def _ensure_rds_iam_user():
                 ).scalar()
 
                 if current_role == DB_ADMIN_USERNAME:
-                    # Always ensure permissions are up to date
                     logger.info(f"Current role is {DB_ADMIN_USERNAME}, setting up permissions for airflow_user")
                     conn.execute(text(f"GRANT rds_iam TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'))
@@ -98,7 +102,6 @@ def _ensure_rds_iam_user():
                     conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f"GRANT {DB_ADMIN_USERNAME} TO {DB_IAM_USERNAME}"))
-
                 elif current_role == "airflow_user":
                     logger.info("Current role is airflow_user")
     except Exception as e:

--- a/images/airflow/2.11.2/python/mwaa/utils/db_retry.py
+++ b/images/airflow/2.11.2/python/mwaa/utils/db_retry.py
@@ -1,0 +1,35 @@
+"""Database connection retry utilities for MWAA maintenance workflows."""
+
+import logging
+import os
+
+from sqlalchemy.exc import InterfaceError, OperationalError
+from sqlalchemy.pool import NullPool
+from tenacity import (
+    after_log,
+    before_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
+
+_RETRY_ATTEMPTS = int(os.environ.get("MWAA_DB_RETRY_ATTEMPTS", "7"))
+_RETRY_MIN_WAIT = int(os.environ.get("MWAA_DB_RETRY_MIN_WAIT", "2"))
+_RETRY_MAX_WAIT = int(os.environ.get("MWAA_DB_RETRY_MAX_WAIT", "60"))
+
+MAINTENANCE_ENGINE_KWARGS = {
+    "poolclass": NullPool,
+    "connect_args": {"connect_timeout": 3},
+}
+
+with_db_retry = retry(
+    stop=stop_after_attempt(_RETRY_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=_RETRY_MIN_WAIT, max=_RETRY_MAX_WAIT),
+    retry=retry_if_exception_type((OperationalError, InterfaceError)),
+    before=before_log(logger, logging.INFO),
+    after=after_log(logger, logging.INFO),
+    reraise=True,
+)

--- a/images/airflow/2.11.2/python/mwaa/utils/dblock.py
+++ b/images/airflow/2.11.2/python/mwaa/utils/dblock.py
@@ -13,15 +13,23 @@ from typing import Any, Awaitable, Callable, TypeVar, Union, cast
 
 # 3rd party imports
 from sqlalchemy import create_engine, text
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Connection
 
 # Our imports
 from mwaa.config.database import get_db_connection_string
+from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 
 logger = logging.getLogger(__name__)
 
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+@with_db_retry
+def _connect_with_retry() -> Connection:
+    """Establish a DB connection with retry on transient RDS Proxy failures."""
+    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    return engine.connect()
 
 
 def _obtain_db_lock(conn: Any, lock_id: int, timeout_ms: int, friendly_name: str):
@@ -95,23 +103,27 @@ def with_db_lock(
     ) -> Union[Callable[..., Any], Callable[..., Awaitable[Any]]]:
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
             func_name: str = func.__name__
-            db_engine: Engine = create_engine(get_db_connection_string())
-            with db_engine.connect() as conn:  # type: ignore
+            conn = _connect_with_retry()
+            try:
+                _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
+                return await func(*args, **kwargs)
+            finally:
                 try:
-                    _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
-                    return await func(*args, **kwargs)
-                finally:
                     _release_db_lock(conn, lock_id, func_name)
+                finally:
+                    conn.close()
 
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
             func_name: str = func.__name__
-            db_engine: Engine = create_engine(get_db_connection_string())
-            with db_engine.connect() as conn:  # type: ignore
+            conn = _connect_with_retry()
+            try:
+                _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
+                return func(*args, **kwargs)
+            finally:
                 try:
-                    _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
-                    return func(*args, **kwargs)
-                finally:
                     _release_db_lock(conn, lock_id, func_name)
+                finally:
+                    conn.close()
 
         if asyncio.iscoroutinefunction(func):
             return cast(Callable[..., Awaitable[Any]], async_wrapper)

--- a/images/airflow/2.9.2/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/2.9.2/python/mwaa/database/migrate_with_downgrade.py
@@ -10,15 +10,16 @@ connect to the meta database, thus all configurations need to be set.
 from argparse import Namespace
 from packaging.version import Version
 from sqlalchemy import create_engine, text
+import logging
 import logging.config
 import os
 import sys
 
 from mwaa.config.database import get_db_connection_string
+from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 from mwaa.utils.dblock import with_db_lock
-from airflow.cli.commands import db_command as airflow_db_command
-
 from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+from airflow.cli.commands import db_command as airflow_db_command
 
 DB_IAM_USERNAME = "airflow_user"
 DB_ADMIN_USERNAME = "adminuser"
@@ -43,33 +44,37 @@ def _verify_environ():
 
 def _ensure_rds_iam_user():
     try:
-        # Set db_connection_url using RDS IAM credentials
-        try:
-            # On default, try to connect to engine using admin user to create/update airflow_user
+        def _connect_static():
             logger.info("Creating db_connection_url using static credentials")
-            db_connection_url = get_db_connection_string()
-            db_engine = create_engine(
-                db_connection_url,
-                connect_args={"connect_timeout": 3}
+            engine = create_engine(
+                get_db_connection_string(),
+                **MAINTENANCE_ENGINE_KWARGS,
             )
-            with db_engine.connect() as conn:
+            with engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
             logger.info("Engine created using static credentials")
-            
-        except Exception as e:
-            logger.warning(f"Exception type: {type(e).__name__}, message: {e}")
-            # If adminuser connection fails due to RDS IAM set up, then use RDS IAM for connection
+            return engine
+
+        @with_db_retry
+        def _connect_iam():
             logger.info("Creating db_connection_url using RDS IAM credentials")
             token = RDSIAMCredentialProvider.get_token()
             db_connection_url = RDSIAMCredentialProvider.create_db_connection_url(token)
             logger.info("Creating engine using RDS IAM and validating connection")
-            db_engine = create_engine(
+            engine = create_engine(
                 db_connection_url,
-                connect_args={"connect_timeout": 3}
+                **MAINTENANCE_ENGINE_KWARGS,
             )
-            with db_engine.connect() as conn:
+            with engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
             logger.info("Engine created using RDS IAM and connection validated")
+            return engine
+
+        try:
+            db_engine = _connect_static()
+        except Exception as e:
+            logger.warning(f"Static credentials failed: {type(e).__name__}: {e}")
+            db_engine = _connect_iam()
 
         with db_engine.connect() as conn:
             with conn.begin():
@@ -86,7 +91,6 @@ def _ensure_rds_iam_user():
                 ).scalar()
 
                 if current_role == DB_ADMIN_USERNAME:
-                    # Always ensure permissions are up to date
                     logger.info(f"Current role is {DB_ADMIN_USERNAME}, setting up permissions for airflow_user")
                     conn.execute(text(f"GRANT rds_iam TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'))
@@ -98,7 +102,6 @@ def _ensure_rds_iam_user():
                     conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"))
                     conn.execute(text(f"GRANT {DB_ADMIN_USERNAME} TO {DB_IAM_USERNAME}"))
-
                 elif current_role == "airflow_user":
                     logger.info("Current role is airflow_user")
     except Exception as e:

--- a/images/airflow/2.9.2/python/mwaa/utils/db_retry.py
+++ b/images/airflow/2.9.2/python/mwaa/utils/db_retry.py
@@ -1,0 +1,35 @@
+"""Database connection retry utilities for MWAA maintenance workflows."""
+
+import logging
+import os
+
+from sqlalchemy.exc import InterfaceError, OperationalError
+from sqlalchemy.pool import NullPool
+from tenacity import (
+    after_log,
+    before_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
+
+_RETRY_ATTEMPTS = int(os.environ.get("MWAA_DB_RETRY_ATTEMPTS", "7"))
+_RETRY_MIN_WAIT = int(os.environ.get("MWAA_DB_RETRY_MIN_WAIT", "2"))
+_RETRY_MAX_WAIT = int(os.environ.get("MWAA_DB_RETRY_MAX_WAIT", "60"))
+
+MAINTENANCE_ENGINE_KWARGS = {
+    "poolclass": NullPool,
+    "connect_args": {"connect_timeout": 3},
+}
+
+with_db_retry = retry(
+    stop=stop_after_attempt(_RETRY_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=_RETRY_MIN_WAIT, max=_RETRY_MAX_WAIT),
+    retry=retry_if_exception_type((OperationalError, InterfaceError)),
+    before=before_log(logger, logging.INFO),
+    after=after_log(logger, logging.INFO),
+    reraise=True,
+)

--- a/images/airflow/2.9.2/python/mwaa/utils/dblock.py
+++ b/images/airflow/2.9.2/python/mwaa/utils/dblock.py
@@ -13,15 +13,23 @@ from typing import Any, Awaitable, Callable, TypeVar, Union, cast
 
 # 3rd party imports
 from sqlalchemy import create_engine, text
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Connection
 
 # Our imports
 from mwaa.config.database import get_db_connection_string
+from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 
 logger = logging.getLogger(__name__)
 
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+@with_db_retry
+def _connect_with_retry() -> Connection:
+    """Establish a DB connection with retry on transient RDS Proxy failures."""
+    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    return engine.connect()
 
 
 def _obtain_db_lock(conn: Any, lock_id: int, timeout_ms: int, friendly_name: str):
@@ -95,23 +103,27 @@ def with_db_lock(
     ) -> Union[Callable[..., Any], Callable[..., Awaitable[Any]]]:
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
             func_name: str = func.__name__
-            db_engine: Engine = create_engine(get_db_connection_string())
-            with db_engine.connect() as conn:  # type: ignore
+            conn = _connect_with_retry()
+            try:
+                _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
+                return await func(*args, **kwargs)
+            finally:
                 try:
-                    _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
-                    return await func(*args, **kwargs)
-                finally:
                     _release_db_lock(conn, lock_id, func_name)
+                finally:
+                    conn.close()
 
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
             func_name: str = func.__name__
-            db_engine: Engine = create_engine(get_db_connection_string())
-            with db_engine.connect() as conn:  # type: ignore
+            conn = _connect_with_retry()
+            try:
+                _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
+                return func(*args, **kwargs)
+            finally:
                 try:
-                    _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
-                    return func(*args, **kwargs)
-                finally:
                     _release_db_lock(conn, lock_id, func_name)
+                finally:
+                    conn.close()
 
         if asyncio.iscoroutinefunction(func):
             return cast(Callable[..., Awaitable[Any]], async_wrapper)

--- a/images/airflow/3.0.6/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.0.6/python/mwaa/database/migrate_with_downgrade.py
@@ -10,11 +10,13 @@ connect to the meta database, thus all configurations need to be set.
 from argparse import Namespace
 from packaging.version import Version
 from sqlalchemy import create_engine, text
+import logging
 import logging.config
 import os
 import sys
 
 from mwaa.config.database import get_db_connection_string
+from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 from mwaa.utils.dblock import with_db_lock
 from airflow.cli.commands import db_command as airflow_db_command
 
@@ -40,10 +42,17 @@ def _verify_environ():
 
 def _ensure_rds_iam_user():
     try:
-        db_engine = create_engine(
-            get_db_connection_string(),
-            connect_args={"connect_timeout": 3}
-        )
+        @with_db_retry
+        def _connect_static():
+            engine = create_engine(
+                get_db_connection_string(),
+                **MAINTENANCE_ENGINE_KWARGS,
+            )
+            with engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
+            return engine
+
+        db_engine = _connect_static()
         with db_engine.connect() as conn:
             with conn.begin():
                 result = conn.execute(text("SELECT 1 FROM pg_roles WHERE rolname = :rolename"), {"rolename": DB_IAM_USERNAME})

--- a/images/airflow/3.0.6/python/mwaa/utils/db_retry.py
+++ b/images/airflow/3.0.6/python/mwaa/utils/db_retry.py
@@ -1,0 +1,35 @@
+"""Database connection retry utilities for MWAA maintenance workflows."""
+
+import logging
+import os
+
+from sqlalchemy.exc import InterfaceError, OperationalError
+from sqlalchemy.pool import NullPool
+from tenacity import (
+    after_log,
+    before_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
+
+_RETRY_ATTEMPTS = int(os.environ.get("MWAA_DB_RETRY_ATTEMPTS", "7"))
+_RETRY_MIN_WAIT = int(os.environ.get("MWAA_DB_RETRY_MIN_WAIT", "2"))
+_RETRY_MAX_WAIT = int(os.environ.get("MWAA_DB_RETRY_MAX_WAIT", "60"))
+
+MAINTENANCE_ENGINE_KWARGS = {
+    "poolclass": NullPool,
+    "connect_args": {"connect_timeout": 3},
+}
+
+with_db_retry = retry(
+    stop=stop_after_attempt(_RETRY_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=_RETRY_MIN_WAIT, max=_RETRY_MAX_WAIT),
+    retry=retry_if_exception_type((OperationalError, InterfaceError)),
+    before=before_log(logger, logging.INFO),
+    after=after_log(logger, logging.INFO),
+    reraise=True,
+)

--- a/images/airflow/3.0.6/python/mwaa/utils/dblock.py
+++ b/images/airflow/3.0.6/python/mwaa/utils/dblock.py
@@ -13,15 +13,23 @@ from typing import Any, Awaitable, Callable, TypeVar, Union, cast
 
 # 3rd party imports
 from sqlalchemy import create_engine, text
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Connection
 
 # Our imports
 from mwaa.config.database import get_db_connection_string
+from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 
 logger = logging.getLogger(__name__)
 
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+@with_db_retry
+def _connect_with_retry() -> Connection:
+    """Establish a DB connection with retry on transient RDS Proxy failures."""
+    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    return engine.connect()
 
 
 def _obtain_db_lock(conn: Any, lock_id: int, timeout_ms: int, friendly_name: str):
@@ -95,23 +103,27 @@ def with_db_lock(
     ) -> Union[Callable[..., Any], Callable[..., Awaitable[Any]]]:
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
             func_name: str = func.__name__
-            db_engine: Engine = create_engine(get_db_connection_string())
-            with db_engine.connect() as conn:  # type: ignore
+            conn = _connect_with_retry()
+            try:
+                _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
+                return await func(*args, **kwargs)
+            finally:
                 try:
-                    _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
-                    return await func(*args, **kwargs)
-                finally:
                     _release_db_lock(conn, lock_id, func_name)
+                finally:
+                    conn.close()
 
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
             func_name: str = func.__name__
-            db_engine: Engine = create_engine(get_db_connection_string())
-            with db_engine.connect() as conn:  # type: ignore
+            conn = _connect_with_retry()
+            try:
+                _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
+                return func(*args, **kwargs)
+            finally:
                 try:
-                    _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
-                    return func(*args, **kwargs)
-                finally:
                     _release_db_lock(conn, lock_id, func_name)
+                finally:
+                    conn.close()
 
         if asyncio.iscoroutinefunction(func):
             return cast(Callable[..., Awaitable[Any]], async_wrapper)

--- a/images/airflow/3.2.1/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.2.1/python/mwaa/database/migrate_with_downgrade.py
@@ -10,11 +10,13 @@ connect to the meta database, thus all configurations need to be set.
 from argparse import Namespace
 from packaging.version import Version
 from sqlalchemy import create_engine, text
+import logging
 import logging.config
 import os
 import sys
 
 from mwaa.config.database import get_db_connection_string
+from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 from mwaa.utils.dblock import with_db_lock
 from airflow.cli.commands import db_command as airflow_db_command
 
@@ -40,10 +42,17 @@ def _verify_environ():
 
 def _ensure_rds_iam_user():
     try:
-        db_engine = create_engine(
-            get_db_connection_string(),
-            connect_args={"connect_timeout": 3}
-        )
+        @with_db_retry
+        def _connect_static():
+            engine = create_engine(
+                get_db_connection_string(),
+                **MAINTENANCE_ENGINE_KWARGS,
+            )
+            with engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
+            return engine
+
+        db_engine = _connect_static()
         with db_engine.connect() as conn:
             with conn.begin():
                 result = conn.execute(text("SELECT 1 FROM pg_roles WHERE rolname = :rolename"), {"rolename": DB_IAM_USERNAME})

--- a/images/airflow/3.2.1/python/mwaa/utils/db_retry.py
+++ b/images/airflow/3.2.1/python/mwaa/utils/db_retry.py
@@ -1,0 +1,35 @@
+"""Database connection retry utilities for MWAA maintenance workflows."""
+
+import logging
+import os
+
+from sqlalchemy.exc import InterfaceError, OperationalError
+from sqlalchemy.pool import NullPool
+from tenacity import (
+    after_log,
+    before_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
+
+_RETRY_ATTEMPTS = int(os.environ.get("MWAA_DB_RETRY_ATTEMPTS", "7"))
+_RETRY_MIN_WAIT = int(os.environ.get("MWAA_DB_RETRY_MIN_WAIT", "2"))
+_RETRY_MAX_WAIT = int(os.environ.get("MWAA_DB_RETRY_MAX_WAIT", "60"))
+
+MAINTENANCE_ENGINE_KWARGS = {
+    "poolclass": NullPool,
+    "connect_args": {"connect_timeout": 3},
+}
+
+with_db_retry = retry(
+    stop=stop_after_attempt(_RETRY_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=_RETRY_MIN_WAIT, max=_RETRY_MAX_WAIT),
+    retry=retry_if_exception_type((OperationalError, InterfaceError)),
+    before=before_log(logger, logging.INFO),
+    after=after_log(logger, logging.INFO),
+    reraise=True,
+)

--- a/images/airflow/3.2.1/python/mwaa/utils/dblock.py
+++ b/images/airflow/3.2.1/python/mwaa/utils/dblock.py
@@ -13,15 +13,23 @@ from typing import Any, Awaitable, Callable, TypeVar, Union, cast
 
 # 3rd party imports
 from sqlalchemy import create_engine, text
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Connection
 
 # Our imports
 from mwaa.config.database import get_db_connection_string
+from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 
 logger = logging.getLogger(__name__)
 
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+@with_db_retry
+def _connect_with_retry() -> Connection:
+    """Establish a DB connection with retry on transient RDS Proxy failures."""
+    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    return engine.connect()
 
 
 def _obtain_db_lock(conn: Any, lock_id: int, timeout_ms: int, friendly_name: str):
@@ -95,23 +103,27 @@ def with_db_lock(
     ) -> Union[Callable[..., Any], Callable[..., Awaitable[Any]]]:
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
             func_name: str = func.__name__
-            db_engine: Engine = create_engine(get_db_connection_string())
-            with db_engine.connect() as conn:  # type: ignore
+            conn = _connect_with_retry()
+            try:
+                _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
+                return await func(*args, **kwargs)
+            finally:
                 try:
-                    _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
-                    return await func(*args, **kwargs)
-                finally:
                     _release_db_lock(conn, lock_id, func_name)
+                finally:
+                    conn.close()
 
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
             func_name: str = func.__name__
-            db_engine: Engine = create_engine(get_db_connection_string())
-            with db_engine.connect() as conn:  # type: ignore
+            conn = _connect_with_retry()
+            try:
+                _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
+                return func(*args, **kwargs)
+            finally:
                 try:
-                    _obtain_db_lock(conn, lock_id, timeout_ms, func_name)
-                    return func(*args, **kwargs)
-                finally:
                     _release_db_lock(conn, lock_id, func_name)
+                finally:
+                    conn.close()
 
         if asyncio.iscoroutinefunction(func):
             return cast(Callable[..., Awaitable[Any]], async_wrapper)

--- a/tests/images/airflow/3.2.1/python/mwaa/utils/test_db_retry.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/utils/test_db_retry.py
@@ -1,0 +1,161 @@
+"""Tests for mwaa.utils.db_retry module."""
+
+import pytest
+from sqlalchemy.exc import InterfaceError, OperationalError, ProgrammingError
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Ensure MWAA_DB_* env vars don't leak between tests."""
+    monkeypatch.delenv("MWAA_DB_RETRY_ATTEMPTS", raising=False)
+    monkeypatch.delenv("MWAA_DB_RETRY_MIN_WAIT", raising=False)
+    monkeypatch.delenv("MWAA_DB_RETRY_MAX_WAIT", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_backoff_sleep(monkeypatch):
+    """Neutralize tenacity's exponential backoff during tests.
+
+    tenacity's wait strategy ultimately calls ``time.sleep``; without this the
+    exhaustion test would block for the full backoff sequence (~64s for 7
+    attempts: 2+2+4+8+16+32). Patching ``time.sleep`` keeps retry logic intact
+    while removing the real wall-clock delay.
+    """
+    monkeypatch.setattr("time.sleep", lambda *_args, **_kwargs: None)
+
+
+def _make_operational_error():
+    return OperationalError("connection failed", params=None, orig=Exception("timeout"))
+
+
+
+def _make_interface_error():
+    return InterfaceError("connection closed", params=None, orig=Exception("closed"))
+
+
+class TestWithDbRetry:
+    """Test the with_db_retry decorator behavior."""
+
+    def test_succeeds_without_retry(self):
+        """Function succeeds on first call — no retry triggered."""
+        from mwaa.utils.db_retry import with_db_retry
+
+        call_count = 0
+
+        @with_db_retry
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            return "ok"
+
+        assert fn() == "ok"
+        assert call_count == 1
+
+    def test_retries_on_operational_error(self):
+        """OperationalError triggers retry, succeeds on 3rd attempt."""
+        from mwaa.utils.db_retry import with_db_retry
+
+        call_count = 0
+
+        @with_db_retry
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise _make_operational_error()
+            return "recovered"
+
+        assert fn() == "recovered"
+        assert call_count == 3
+
+    def test_retries_on_interface_error(self):
+        """InterfaceError triggers retry."""
+        from mwaa.utils.db_retry import with_db_retry
+
+        call_count = 0
+
+        @with_db_retry
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise _make_interface_error()
+            return "ok"
+
+        assert fn() == "ok"
+        assert call_count == 2
+
+    def test_does_not_retry_programming_error(self):
+        """ProgrammingError (non-retryable) propagates immediately."""
+        from mwaa.utils.db_retry import with_db_retry
+
+        call_count = 0
+
+        @with_db_retry
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            raise ProgrammingError("syntax error", params=None, orig=Exception("bad sql"))
+
+        with pytest.raises(ProgrammingError):
+            fn()
+        assert call_count == 1
+
+    def test_exhausts_retries_then_raises(self):
+        """After max attempts, the exception is reraised."""
+        from mwaa.utils.db_retry import with_db_retry
+
+        call_count = 0
+
+        @with_db_retry
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            raise _make_operational_error()
+
+        with pytest.raises(OperationalError):
+            fn()
+        # Default is 7 attempts (1 initial + 6 retries); final retry lands at
+        # t~64s, covering the >60s RDS Proxy failover / SSL-reset window.
+        assert call_count == 7
+
+
+class TestEnvVarOverrides:
+    """Test MWAA_DB_* environment variable overrides."""
+
+    def test_retry_attempts_override(self, monkeypatch):
+        """MWAA_DB_RETRY_ATTEMPTS limits retry count."""
+        monkeypatch.setenv("MWAA_DB_RETRY_ATTEMPTS", "2")
+
+        # Re-import to pick up new env var
+        import importlib
+        import mwaa.utils.db_retry
+        importlib.reload(mwaa.utils.db_retry)
+        from mwaa.utils.db_retry import with_db_retry
+
+        call_count = 0
+
+        @with_db_retry
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            raise _make_operational_error()
+
+        with pytest.raises(OperationalError):
+            fn()
+        assert call_count == 2
+
+
+class TestMaintenanceEngineKwargs:
+    """Test MAINTENANCE_ENGINE_KWARGS configuration."""
+
+    def test_uses_null_pool(self):
+        from sqlalchemy.pool import NullPool
+        from mwaa.utils.db_retry import MAINTENANCE_ENGINE_KWARGS
+
+        assert MAINTENANCE_ENGINE_KWARGS["poolclass"] is NullPool
+
+    def test_connect_timeout(self):
+        from mwaa.utils.db_retry import MAINTENANCE_ENGINE_KWARGS
+
+        assert MAINTENANCE_ENGINE_KWARGS["connect_args"]["connect_timeout"] == 3


### PR DESCRIPTION
## Summary

Add tenacity-based retry with exponential backoff for DB engine connections in MWAA migration scripts and lock utilities. Makes maintenance workflows (DB migration, RDS IAM user setup, advisory locks) resilient to transient Aurora / RDS Proxy connection failures (SSL resets, failovers).

## Design

- **Retry config**: **7 attempts**, exponential backoff via `wait_exponential(min=2, max=60)`. Waits between attempts are `2, 2, 4, 8, 16, 32s`, so the 7th (final) attempt lands at **t≈64s** — deliberately covering the >60s RDS Proxy failover / SSL-reset window.
- **Pool**: `NullPool` (fresh connection per attempt; no pooling for short-lived maintenance scripts).
- **Retryable exceptions**: `OperationalError`, `InterfaceError` (narrowed from the broader `DBAPIError` so deterministic errors like `ProgrammingError` / `IntegrityError` are not retried).
- **Override env vars** (ops only, not customer-facing): `MWAA_DB_RETRY_ATTEMPTS`, `MWAA_DB_RETRY_MIN_WAIT`, `MWAA_DB_RETRY_MAX_WAIT`.
- **`_ensure_rds_iam_user` (2.x)**: `_connect_static` is fast-fail (no retry); on failure it immediately falls back to `_connect_iam` (retried).
- **`_ensure_rds_iam_user` (3.x)**: `_connect_static` is retried (no IAM fallback path on 3.x yet).
- **`dblock.py`**: retry wraps `.connect()` only; lock acquisition runs on the already-established connection (not retried). Nested `try/finally` guarantees `conn.close()` even if lock release raises.

## Changes

- New `mwaa/utils/db_retry.py` (all 6 Airflow versions: 2.9.2, 2.10.1, 2.10.3, 2.11.0, 3.0.6, 3.2.1).
- Modified `migrate_with_downgrade.py` (all 6 versions).
- Modified `dblock.py` (all 6 versions) — also removed the now-unused `Engine` import.
- New unit tests `tests/.../3.2.1/.../test_db_retry.py`.

## Testing

- **Unit tests: 8/8 pass** — retry on `OperationalError`/`InterfaceError`, no retry on `ProgrammingError`, exhaustion reraises after 7 attempts, and `MWAA_DB_RETRY_ATTEMPTS` override.
- The retry path was validated end-to-end (fault injection) on dev-account stacks for 2.10.3 and 3.0.6.