### PR TITLE
Use IAM Credentials for dblock engine creations

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/utils/dblock.py
+++ b/images/airflow/2.10.1/python/mwaa/utils/dblock.py
@@ -28,7 +28,14 @@ F = TypeVar("F", bound=Callable[..., Any])
 @with_db_retry
 def _connect_with_retry() -> Connection:
     """Establish a DB connection with retry on transient RDS Proxy failures."""
-    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    from mwaa.config.airflow_rds_iam_patch import use_iam_credentials
+    if use_iam_credentials():
+        from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+        token = RDSIAMCredentialProvider.get_token()
+        conn_url = RDSIAMCredentialProvider.create_db_connection_url(token)
+    else:
+        conn_url = get_db_connection_string()
+    engine = create_engine(conn_url, **MAINTENANCE_ENGINE_KWARGS)
     return engine.connect()
 
 

--- a/images/airflow/2.10.3/python/mwaa/utils/dblock.py
+++ b/images/airflow/2.10.3/python/mwaa/utils/dblock.py
@@ -28,7 +28,14 @@ F = TypeVar("F", bound=Callable[..., Any])
 @with_db_retry
 def _connect_with_retry() -> Connection:
     """Establish a DB connection with retry on transient RDS Proxy failures."""
-    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    from mwaa.config.airflow_rds_iam_patch import use_iam_credentials
+    if use_iam_credentials():
+        from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+        token = RDSIAMCredentialProvider.get_token()
+        conn_url = RDSIAMCredentialProvider.create_db_connection_url(token)
+    else:
+        conn_url = get_db_connection_string()
+    engine = create_engine(conn_url, **MAINTENANCE_ENGINE_KWARGS)
     return engine.connect()
 
 

--- a/images/airflow/2.11.0/python/mwaa/utils/dblock.py
+++ b/images/airflow/2.11.0/python/mwaa/utils/dblock.py
@@ -28,7 +28,14 @@ F = TypeVar("F", bound=Callable[..., Any])
 @with_db_retry
 def _connect_with_retry() -> Connection:
     """Establish a DB connection with retry on transient RDS Proxy failures."""
-    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    from mwaa.config.airflow_rds_iam_patch import use_iam_credentials
+    if use_iam_credentials():
+        from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+        token = RDSIAMCredentialProvider.get_token()
+        conn_url = RDSIAMCredentialProvider.create_db_connection_url(token)
+    else:
+        conn_url = get_db_connection_string()
+    engine = create_engine(conn_url, **MAINTENANCE_ENGINE_KWARGS)
     return engine.connect()
 
 

--- a/images/airflow/2.11.2/python/mwaa/utils/dblock.py
+++ b/images/airflow/2.11.2/python/mwaa/utils/dblock.py
@@ -28,7 +28,14 @@ F = TypeVar("F", bound=Callable[..., Any])
 @with_db_retry
 def _connect_with_retry() -> Connection:
     """Establish a DB connection with retry on transient RDS Proxy failures."""
-    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    from mwaa.config.airflow_rds_iam_patch import use_iam_credentials
+    if use_iam_credentials():
+        from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+        token = RDSIAMCredentialProvider.get_token()
+        conn_url = RDSIAMCredentialProvider.create_db_connection_url(token)
+    else:
+        conn_url = get_db_connection_string()
+    engine = create_engine(conn_url, **MAINTENANCE_ENGINE_KWARGS)
     return engine.connect()
 
 

--- a/images/airflow/2.9.2/python/mwaa/utils/dblock.py
+++ b/images/airflow/2.9.2/python/mwaa/utils/dblock.py
@@ -28,7 +28,14 @@ F = TypeVar("F", bound=Callable[..., Any])
 @with_db_retry
 def _connect_with_retry() -> Connection:
     """Establish a DB connection with retry on transient RDS Proxy failures."""
-    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    from mwaa.config.airflow_rds_iam_patch import use_iam_credentials
+    if use_iam_credentials():
+        from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+        token = RDSIAMCredentialProvider.get_token()
+        conn_url = RDSIAMCredentialProvider.create_db_connection_url(token)
+    else:
+        conn_url = get_db_connection_string()
+    engine = create_engine(conn_url, **MAINTENANCE_ENGINE_KWARGS)
     return engine.connect()
 
 

--- a/tests/images/airflow/2.10.1/python/mwaa/utils/test_dblock_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/utils/test_dblock_2_10_1.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def test_connect_with_retry_uses_static_credentials_when_iam_disabled():
+    """Test that _connect_with_retry uses get_db_connection_string when IAM is disabled."""
+    from mwaa.utils.dblock import _connect_with_retry
+
+    with patch('mwaa.config.airflow_rds_iam_patch.use_iam_credentials', return_value=False), \
+         patch('mwaa.utils.dblock.create_engine') as mock_create_engine, \
+         patch('mwaa.utils.dblock.get_db_connection_string', return_value='postgresql://static/airflow'):
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        result = _connect_with_retry()
+
+        mock_create_engine.assert_called_once()
+        call_args = mock_create_engine.call_args
+        assert call_args[0][0] == 'postgresql://static/airflow'
+        assert result == mock_conn
+
+
+def test_connect_with_retry_uses_iam_credentials_when_enabled():
+    """Test that _connect_with_retry uses RDSIAMCredentialProvider when IAM is enabled."""
+    from mwaa.utils.dblock import _connect_with_retry
+
+    with patch('mwaa.config.airflow_rds_iam_patch.use_iam_credentials', return_value=True), \
+         patch('mwaa.utils.get_rds_iam_credentials.RDSIAMCredentialProvider') as mock_provider, \
+         patch('mwaa.utils.dblock.create_engine') as mock_create_engine, \
+         patch('mwaa.utils.dblock.get_db_connection_string', return_value='postgresql://static/airflow'):
+        mock_provider.get_token.return_value = 'iam-token-123'
+        mock_provider.create_db_connection_url.return_value = 'postgresql://airflow_user:iam-token-123@host/db'
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        result = _connect_with_retry()
+
+        mock_provider.get_token.assert_called_once()
+        mock_provider.create_db_connection_url.assert_called_once_with('iam-token-123')
+        mock_create_engine.assert_called_once()
+        call_args = mock_create_engine.call_args
+        assert call_args[0][0] == 'postgresql://airflow_user:iam-token-123@host/db'
+        assert result == mock_conn

--- a/tests/images/airflow/2.10.3/python/mwaa/utils/test_dblock_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/utils/test_dblock_2_10_3.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def test_connect_with_retry_uses_static_credentials_when_iam_disabled():
+    """Test that _connect_with_retry uses get_db_connection_string when IAM is disabled."""
+    from mwaa.utils.dblock import _connect_with_retry
+
+    with patch('mwaa.config.airflow_rds_iam_patch.use_iam_credentials', return_value=False), \
+         patch('mwaa.utils.dblock.create_engine') as mock_create_engine, \
+         patch('mwaa.utils.dblock.get_db_connection_string', return_value='postgresql://static/airflow'):
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        result = _connect_with_retry()
+
+        mock_create_engine.assert_called_once()
+        call_args = mock_create_engine.call_args
+        assert call_args[0][0] == 'postgresql://static/airflow'
+        assert result == mock_conn
+
+
+def test_connect_with_retry_uses_iam_credentials_when_enabled():
+    """Test that _connect_with_retry uses RDSIAMCredentialProvider when IAM is enabled."""
+    from mwaa.utils.dblock import _connect_with_retry
+
+    with patch('mwaa.config.airflow_rds_iam_patch.use_iam_credentials', return_value=True), \
+         patch('mwaa.utils.get_rds_iam_credentials.RDSIAMCredentialProvider') as mock_provider, \
+         patch('mwaa.utils.dblock.create_engine') as mock_create_engine, \
+         patch('mwaa.utils.dblock.get_db_connection_string', return_value='postgresql://static/airflow'):
+        mock_provider.get_token.return_value = 'iam-token-123'
+        mock_provider.create_db_connection_url.return_value = 'postgresql://airflow_user:iam-token-123@host/db'
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        result = _connect_with_retry()
+
+        mock_provider.get_token.assert_called_once()
+        mock_provider.create_db_connection_url.assert_called_once_with('iam-token-123')
+        mock_create_engine.assert_called_once()
+        call_args = mock_create_engine.call_args
+        assert call_args[0][0] == 'postgresql://airflow_user:iam-token-123@host/db'
+        assert result == mock_conn

--- a/tests/images/airflow/2.11.0/python/mwaa/utils/test_dblock_2_11_0.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/utils/test_dblock_2_11_0.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def test_connect_with_retry_uses_static_credentials_when_iam_disabled():
+    """Test that _connect_with_retry uses get_db_connection_string when IAM is disabled."""
+    from mwaa.utils.dblock import _connect_with_retry
+
+    with patch('mwaa.config.airflow_rds_iam_patch.use_iam_credentials', return_value=False), \
+         patch('mwaa.utils.dblock.create_engine') as mock_create_engine, \
+         patch('mwaa.utils.dblock.get_db_connection_string', return_value='postgresql://static/airflow'):
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        result = _connect_with_retry()
+
+        mock_create_engine.assert_called_once()
+        call_args = mock_create_engine.call_args
+        assert call_args[0][0] == 'postgresql://static/airflow'
+        assert result == mock_conn
+
+
+def test_connect_with_retry_uses_iam_credentials_when_enabled():
+    """Test that _connect_with_retry uses RDSIAMCredentialProvider when IAM is enabled."""
+    from mwaa.utils.dblock import _connect_with_retry
+
+    with patch('mwaa.config.airflow_rds_iam_patch.use_iam_credentials', return_value=True), \
+         patch('mwaa.utils.get_rds_iam_credentials.RDSIAMCredentialProvider') as mock_provider, \
+         patch('mwaa.utils.dblock.create_engine') as mock_create_engine, \
+         patch('mwaa.utils.dblock.get_db_connection_string', return_value='postgresql://static/airflow'):
+        mock_provider.get_token.return_value = 'iam-token-123'
+        mock_provider.create_db_connection_url.return_value = 'postgresql://airflow_user:iam-token-123@host/db'
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        result = _connect_with_retry()
+
+        mock_provider.get_token.assert_called_once()
+        mock_provider.create_db_connection_url.assert_called_once_with('iam-token-123')
+        mock_create_engine.assert_called_once()
+        call_args = mock_create_engine.call_args
+        assert call_args[0][0] == 'postgresql://airflow_user:iam-token-123@host/db'
+        assert result == mock_conn

--- a/tests/images/airflow/2.9.2/python/mwaa/utils/test_dblock_2_9_2.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/utils/test_dblock_2_9_2.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def test_connect_with_retry_uses_static_credentials_when_iam_disabled():
+    """Test that _connect_with_retry uses get_db_connection_string when IAM is disabled."""
+    from mwaa.utils.dblock import _connect_with_retry
+
+    with patch('mwaa.config.airflow_rds_iam_patch.use_iam_credentials', return_value=False), \
+         patch('mwaa.utils.dblock.create_engine') as mock_create_engine, \
+         patch('mwaa.utils.dblock.get_db_connection_string', return_value='postgresql://static/airflow'):
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        result = _connect_with_retry()
+
+        mock_create_engine.assert_called_once()
+        call_args = mock_create_engine.call_args
+        assert call_args[0][0] == 'postgresql://static/airflow'
+        assert result == mock_conn
+
+
+def test_connect_with_retry_uses_iam_credentials_when_enabled():
+    """Test that _connect_with_retry uses RDSIAMCredentialProvider when IAM is enabled."""
+    from mwaa.utils.dblock import _connect_with_retry
+
+    with patch('mwaa.config.airflow_rds_iam_patch.use_iam_credentials', return_value=True), \
+         patch('mwaa.utils.get_rds_iam_credentials.RDSIAMCredentialProvider') as mock_provider, \
+         patch('mwaa.utils.dblock.create_engine') as mock_create_engine, \
+         patch('mwaa.utils.dblock.get_db_connection_string', return_value='postgresql://static/airflow'):
+        mock_provider.get_token.return_value = 'iam-token-123'
+        mock_provider.create_db_connection_url.return_value = 'postgresql://airflow_user:iam-token-123@host/db'
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        result = _connect_with_retry()
+
+        mock_provider.get_token.assert_called_once()
+        mock_provider.create_db_connection_url.assert_called_once_with('iam-token-123')
+        mock_create_engine.assert_called_once()
+        call_args = mock_create_engine.call_args
+        assert call_args[0][0] == 'postgresql://airflow_user:iam-token-123@host/db'
+        assert result == mock_conn


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The dblock module creates its own SQLAlchemy engine for advisory locks. In non-migrate-db contexts, the global IAM patch (airflow_rds_iam_patch) intercepts connections at the Engine class level. However, for migrate-db the global patch is explicitly excluded, leaving dblock using static credentials only.

This change makes _connect_with_retry IAM-aware by checking the USE_IAM_CREDENTIALS flag and using RDSIAMCredentialProvider directly, ensuring passwordless auth works in all contexts.

Affected versions: 2.9.2, 2.10.1, 2.10.3, 2.11.0, 2.11.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
