### PR TITLE
Add USE_CLOUDWATCH_LOGS toggle, default to local

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,20 @@ python3 create_venvs.py --target <development | production>
 python3 create_venvs.py --target <development | production> --version 3.0.6
 ```
 
-3. Build a supported Airflow version Docker image
+3. Build and run a supported Airflow version Docker image:
    - `cd <amazon-mwaa-docker-images path>/images/airflow/2.9.2`
-   - Update `run.sh` file with your account ID, environment name and account credentials, api-server URL 
-   - (`http://host_name:8080`). The permissions associated
-   with the provided credentials will be assigned to the Airflow components that would be started with the next step. 
-   So, if you receive any error message indicating lack of permissions, then try providing the permissions to the 
-   identity whose credentials were used.
-   - `./run.sh` This will build and run all the necessary containers and automatically create the following CloudWatch log groups:
+   - `./run.sh`
+
+   By default this runs fully locally (no AWS account needed): it builds the images, starts the containers, and writes logs inside the container at `/usr/local/airflow/logs/`. The web server is at `http://localhost:8080`.
+
+   To publish logs to CloudWatch instead, set `ACCOUNT_ID`, `ENV_NAME`, and real AWS credentials in `run.sh`. `./run.sh` then creates and writes to these log groups (your credentials need permission to do so):
      - `{ENV_NAME}-DAGProcessing`
      - `{ENV_NAME}-Scheduler`
      - `{ENV_NAME}-Worker`
      - `{ENV_NAME}-Task`
      - `{ENV_NAME}-WebServer`
 
-Airflow should be up and running now. You can access the web server on your localhost on port 8080.
+   The credentials you provide are also used by the Airflow components at runtime, so if you hit permission errors, grant the needed permissions to that identity.
 
 ---
 
@@ -126,6 +125,8 @@ docker compose down
 | Login fails at `http://localhost:8080` | Check the webserver container logs for the credentials printed on startup |
 | DAG not appearing | Check the scheduler container logs or verify the file exists in the `dags\` folder |
 
+---
+
 ### Authentication from version 3.0.1 onward
 For environments created using this repository starting with version 3.0.1, we default to using `SimpleAuthManager`, 
 which is also the default auth manager in Airflow 3.0.0+. By default, `SIMPLE_AUTH_MANAGER_ALL_ADMINS` is set to true, 
@@ -142,6 +143,7 @@ SIMPLE_AUTH_MANAGER_ALL_ADMINS=false
 In this mode, a password will be automatically generated for each user and printed in the webserver logs as soon as 
 webserver starts.
 
+---
 
 ### Generated Docker Images
 
@@ -177,6 +179,7 @@ Each of the postfixes added to the image tag represents a certain build type, as
   install tools like `wget` to make it possible for the user to fetch web pages. For a complete
   listing of what is installed in `dev` images, see the `bootstrap-dev` folders.
 
+---
 
 ## Extra commands
 

--- a/images/airflow/2.10.1/run.sh
+++ b/images/airflow/2.10.1/run.sh
@@ -50,6 +50,9 @@ ACCOUNT_ID="" # Put your account ID here.
 ENV_NAME="" # Choose an environment name here.
 REGION="us-west-2" # Keeping the region us-west-2 as default.
 
+# CloudWatch logging mode: "auto" (on when ACCOUNT_ID+ENV_NAME are set), "true" (force on), "false" (force off).
+USE_CLOUDWATCH_LOGS="auto"
+
 # AWS Credentials
 # For local running without a real AWS account, dummy values are sufficient —
 # ElasticMQ (local SQS) does not validate credentials, but boto3 requires
@@ -73,23 +76,65 @@ export MWAA_LOCAL_RUNNER
 # MWAA Configuration
 MWAA__CORE__REQUIREMENTS_PATH="/usr/local/airflow/requirements/requirements.txt"
 MWAA__CORE__STARTUP_SCRIPT_PATH="/usr/local/airflow/startup/startup.sh"
-MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-DAGProcessing"
+# Logging values derived from USE_CLOUDWATCH_LOGS.
+case "$USE_CLOUDWATCH_LOGS" in
+    auto)
+        if [ -n "$ACCOUNT_ID" ] && [ -n "$ENV_NAME" ]; then
+            LOGS_ENABLED="true"
+        else
+            LOGS_ENABLED="false"
+        fi
+        ;;
+    true)
+        if [ -z "$ACCOUNT_ID" ] || [ -z "$ENV_NAME" ]; then
+            echo "ERROR: USE_CLOUDWATCH_LOGS=\"true\" requires ACCOUNT_ID and ENV_NAME (or use \"auto\"/\"false\")." >&2
+            exit 1
+        fi
+        LOGS_ENABLED="true"
+        ;;
+    false)
+        LOGS_ENABLED="false"
+        ;;
+    *)
+        echo "ERROR: USE_CLOUDWATCH_LOGS must be auto, true, or false (got \"$USE_CLOUDWATCH_LOGS\")." >&2
+        exit 1
+        ;;
+esac
+
+if [ "$LOGS_ENABLED" == "true" ]; then
+    arn_prefix="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}"
+    DAGPROCESSOR_LOG_GROUP_ARN="${arn_prefix}-DAGProcessing"
+    SCHEDULER_LOG_GROUP_ARN="${arn_prefix}-Scheduler"
+    TASK_LOG_GROUP_ARN="${arn_prefix}-Task"
+    TRIGGERER_LOG_GROUP_ARN="${arn_prefix}-Scheduler"  # Triggerer reuses the Scheduler log group
+    WEBSERVER_LOG_GROUP_ARN="${arn_prefix}-WebServer"
+    WORKER_LOG_GROUP_ARN="${arn_prefix}-Worker"
+else
+    DAGPROCESSOR_LOG_GROUP_ARN=""
+    SCHEDULER_LOG_GROUP_ARN=""
+    TASK_LOG_GROUP_ARN=""
+    TRIGGERER_LOG_GROUP_ARN=""
+    WEBSERVER_LOG_GROUP_ARN=""
+    WORKER_LOG_GROUP_ARN=""
+fi
+
+MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN="$DAGPROCESSOR_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Scheduler"
+MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN="$SCHEDULER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Task"
+MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN="$TASK_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_TASK_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Scheduler"
+MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN="$TRIGGERER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-WebServer"
+MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN="$WEBSERVER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Worker"
+MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN="$WORKER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL="INFO"
 MWAA__CORE__TASK_MONITORING_ENABLED="false"
 MWAA__CORE__TERMINATE_IF_IDLE="false"

--- a/images/airflow/2.10.3/run.sh
+++ b/images/airflow/2.10.3/run.sh
@@ -50,6 +50,9 @@ ACCOUNT_ID="" # Put your account ID here.
 ENV_NAME="" # Choose an environment name here.
 REGION="us-west-2" # Keeping the region us-west-2 as default.
 
+# CloudWatch logging mode: "auto" (on when ACCOUNT_ID+ENV_NAME are set), "true" (force on), "false" (force off).
+USE_CLOUDWATCH_LOGS="auto"
+
 # AWS Credentials
 # For local running without a real AWS account, dummy values are sufficient —
 # ElasticMQ (local SQS) does not validate credentials, but boto3 requires
@@ -73,23 +76,65 @@ export MWAA_LOCAL_RUNNER
 # MWAA Configuration
 MWAA__CORE__REQUIREMENTS_PATH="/usr/local/airflow/requirements/requirements.txt"
 MWAA__CORE__STARTUP_SCRIPT_PATH="/usr/local/airflow/startup/startup.sh"
-MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-DAGProcessing"
+# Logging values derived from USE_CLOUDWATCH_LOGS.
+case "$USE_CLOUDWATCH_LOGS" in
+    auto)
+        if [ -n "$ACCOUNT_ID" ] && [ -n "$ENV_NAME" ]; then
+            LOGS_ENABLED="true"
+        else
+            LOGS_ENABLED="false"
+        fi
+        ;;
+    true)
+        if [ -z "$ACCOUNT_ID" ] || [ -z "$ENV_NAME" ]; then
+            echo "ERROR: USE_CLOUDWATCH_LOGS=\"true\" requires ACCOUNT_ID and ENV_NAME (or use \"auto\"/\"false\")." >&2
+            exit 1
+        fi
+        LOGS_ENABLED="true"
+        ;;
+    false)
+        LOGS_ENABLED="false"
+        ;;
+    *)
+        echo "ERROR: USE_CLOUDWATCH_LOGS must be auto, true, or false (got \"$USE_CLOUDWATCH_LOGS\")." >&2
+        exit 1
+        ;;
+esac
+
+if [ "$LOGS_ENABLED" == "true" ]; then
+    arn_prefix="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}"
+    DAGPROCESSOR_LOG_GROUP_ARN="${arn_prefix}-DAGProcessing"
+    SCHEDULER_LOG_GROUP_ARN="${arn_prefix}-Scheduler"
+    TASK_LOG_GROUP_ARN="${arn_prefix}-Task"
+    TRIGGERER_LOG_GROUP_ARN="${arn_prefix}-Scheduler"  # Triggerer reuses the Scheduler log group
+    WEBSERVER_LOG_GROUP_ARN="${arn_prefix}-WebServer"
+    WORKER_LOG_GROUP_ARN="${arn_prefix}-Worker"
+else
+    DAGPROCESSOR_LOG_GROUP_ARN=""
+    SCHEDULER_LOG_GROUP_ARN=""
+    TASK_LOG_GROUP_ARN=""
+    TRIGGERER_LOG_GROUP_ARN=""
+    WEBSERVER_LOG_GROUP_ARN=""
+    WORKER_LOG_GROUP_ARN=""
+fi
+
+MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN="$DAGPROCESSOR_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Scheduler"
+MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN="$SCHEDULER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Task"
+MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN="$TASK_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_TASK_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Scheduler"
+MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN="$TRIGGERER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-WebServer"
+MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN="$WEBSERVER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Worker"
+MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN="$WORKER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL="INFO"
 MWAA__CORE__TASK_MONITORING_ENABLED="false"
 MWAA__CORE__TERMINATE_IF_IDLE="false"

--- a/images/airflow/2.11.0/run.sh
+++ b/images/airflow/2.11.0/run.sh
@@ -50,6 +50,9 @@ ACCOUNT_ID="" # Put your account ID here.
 ENV_NAME="" # Choose an environment name here.
 REGION="us-west-2" # Keeping the region us-west-2 as default.
 
+# CloudWatch logging mode: "auto" (on when ACCOUNT_ID+ENV_NAME are set), "true" (force on), "false" (force off).
+USE_CLOUDWATCH_LOGS="auto"
+
 # AWS Credentials
 # For local running without a real AWS account, dummy values are sufficient —
 # ElasticMQ (local SQS) does not validate credentials, but boto3 requires
@@ -73,23 +76,65 @@ export MWAA_LOCAL_RUNNER
 # MWAA Configuration
 MWAA__CORE__REQUIREMENTS_PATH="/usr/local/airflow/requirements/requirements.txt"
 MWAA__CORE__STARTUP_SCRIPT_PATH="/usr/local/airflow/startup/startup.sh"
-MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-DAGProcessing"
+# Logging values derived from USE_CLOUDWATCH_LOGS.
+case "$USE_CLOUDWATCH_LOGS" in
+    auto)
+        if [ -n "$ACCOUNT_ID" ] && [ -n "$ENV_NAME" ]; then
+            LOGS_ENABLED="true"
+        else
+            LOGS_ENABLED="false"
+        fi
+        ;;
+    true)
+        if [ -z "$ACCOUNT_ID" ] || [ -z "$ENV_NAME" ]; then
+            echo "ERROR: USE_CLOUDWATCH_LOGS=\"true\" requires ACCOUNT_ID and ENV_NAME (or use \"auto\"/\"false\")." >&2
+            exit 1
+        fi
+        LOGS_ENABLED="true"
+        ;;
+    false)
+        LOGS_ENABLED="false"
+        ;;
+    *)
+        echo "ERROR: USE_CLOUDWATCH_LOGS must be auto, true, or false (got \"$USE_CLOUDWATCH_LOGS\")." >&2
+        exit 1
+        ;;
+esac
+
+if [ "$LOGS_ENABLED" == "true" ]; then
+    arn_prefix="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}"
+    DAGPROCESSOR_LOG_GROUP_ARN="${arn_prefix}-DAGProcessing"
+    SCHEDULER_LOG_GROUP_ARN="${arn_prefix}-Scheduler"
+    TASK_LOG_GROUP_ARN="${arn_prefix}-Task"
+    TRIGGERER_LOG_GROUP_ARN="${arn_prefix}-Scheduler"  # Triggerer reuses the Scheduler log group
+    WEBSERVER_LOG_GROUP_ARN="${arn_prefix}-WebServer"
+    WORKER_LOG_GROUP_ARN="${arn_prefix}-Worker"
+else
+    DAGPROCESSOR_LOG_GROUP_ARN=""
+    SCHEDULER_LOG_GROUP_ARN=""
+    TASK_LOG_GROUP_ARN=""
+    TRIGGERER_LOG_GROUP_ARN=""
+    WEBSERVER_LOG_GROUP_ARN=""
+    WORKER_LOG_GROUP_ARN=""
+fi
+
+MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN="$DAGPROCESSOR_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Scheduler"
+MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN="$SCHEDULER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Task"
+MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN="$TASK_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_TASK_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Scheduler"
+MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN="$TRIGGERER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-WebServer"
+MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN="$WEBSERVER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Worker"
+MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN="$WORKER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL="INFO"
 MWAA__CORE__TASK_MONITORING_ENABLED="false"
 MWAA__CORE__TERMINATE_IF_IDLE="false"

--- a/images/airflow/2.11.2/run.sh
+++ b/images/airflow/2.11.2/run.sh
@@ -50,6 +50,9 @@ ACCOUNT_ID="" # Put your account ID here.
 ENV_NAME="" # Choose an environment name here.
 REGION="us-west-2" # Keeping the region us-west-2 as default.
 
+# CloudWatch logging mode: "auto" (on when ACCOUNT_ID+ENV_NAME are set), "true" (force on), "false" (force off).
+USE_CLOUDWATCH_LOGS="auto"
+
 # AWS Credentials
 # For local running without a real AWS account, dummy values are sufficient —
 # ElasticMQ (local SQS) does not validate credentials, but boto3 requires
@@ -73,23 +76,65 @@ export MWAA_LOCAL_RUNNER
 # MWAA Configuration
 MWAA__CORE__REQUIREMENTS_PATH="/usr/local/airflow/requirements/requirements.txt"
 MWAA__CORE__STARTUP_SCRIPT_PATH="/usr/local/airflow/startup/startup.sh"
-MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-DAGProcessing"
+# Logging values derived from USE_CLOUDWATCH_LOGS.
+case "$USE_CLOUDWATCH_LOGS" in
+    auto)
+        if [ -n "$ACCOUNT_ID" ] && [ -n "$ENV_NAME" ]; then
+            LOGS_ENABLED="true"
+        else
+            LOGS_ENABLED="false"
+        fi
+        ;;
+    true)
+        if [ -z "$ACCOUNT_ID" ] || [ -z "$ENV_NAME" ]; then
+            echo "ERROR: USE_CLOUDWATCH_LOGS=\"true\" requires ACCOUNT_ID and ENV_NAME (or use \"auto\"/\"false\")." >&2
+            exit 1
+        fi
+        LOGS_ENABLED="true"
+        ;;
+    false)
+        LOGS_ENABLED="false"
+        ;;
+    *)
+        echo "ERROR: USE_CLOUDWATCH_LOGS must be auto, true, or false (got \"$USE_CLOUDWATCH_LOGS\")." >&2
+        exit 1
+        ;;
+esac
+
+if [ "$LOGS_ENABLED" == "true" ]; then
+    arn_prefix="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}"
+    DAGPROCESSOR_LOG_GROUP_ARN="${arn_prefix}-DAGProcessing"
+    SCHEDULER_LOG_GROUP_ARN="${arn_prefix}-Scheduler"
+    TASK_LOG_GROUP_ARN="${arn_prefix}-Task"
+    TRIGGERER_LOG_GROUP_ARN="${arn_prefix}-Scheduler"  # Triggerer reuses the Scheduler log group
+    WEBSERVER_LOG_GROUP_ARN="${arn_prefix}-WebServer"
+    WORKER_LOG_GROUP_ARN="${arn_prefix}-Worker"
+else
+    DAGPROCESSOR_LOG_GROUP_ARN=""
+    SCHEDULER_LOG_GROUP_ARN=""
+    TASK_LOG_GROUP_ARN=""
+    TRIGGERER_LOG_GROUP_ARN=""
+    WEBSERVER_LOG_GROUP_ARN=""
+    WORKER_LOG_GROUP_ARN=""
+fi
+
+MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN="$DAGPROCESSOR_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Scheduler"
+MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN="$SCHEDULER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Task"
+MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN="$TASK_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_TASK_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Scheduler"
+MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN="$TRIGGERER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-WebServer"
+MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN="$WEBSERVER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Worker"
+MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN="$WORKER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL="INFO"
 MWAA__CORE__TASK_MONITORING_ENABLED="false"
 MWAA__CORE__TERMINATE_IF_IDLE="false"

--- a/images/airflow/2.9.2/run.sh
+++ b/images/airflow/2.9.2/run.sh
@@ -50,6 +50,9 @@ ACCOUNT_ID="" # Put your account ID here.
 ENV_NAME="" # Choose an environment name here.
 REGION="us-west-2" # Keeping the region us-west-2 as default.
 
+# CloudWatch logging mode: "auto" (on when ACCOUNT_ID+ENV_NAME are set), "true" (force on), "false" (force off).
+USE_CLOUDWATCH_LOGS="auto"
+
 # AWS Credentials
 # For local running without a real AWS account, dummy values are sufficient —
 # ElasticMQ (local SQS) does not validate credentials, but boto3 requires
@@ -73,23 +76,65 @@ export MWAA_LOCAL_RUNNER
 # MWAA Configuration
 MWAA__CORE__REQUIREMENTS_PATH="/usr/local/airflow/requirements/requirements.txt"
 MWAA__CORE__STARTUP_SCRIPT_PATH="/usr/local/airflow/startup/startup.sh"
-MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-DAGProcessing"
+# Logging values derived from USE_CLOUDWATCH_LOGS.
+case "$USE_CLOUDWATCH_LOGS" in
+    auto)
+        if [ -n "$ACCOUNT_ID" ] && [ -n "$ENV_NAME" ]; then
+            LOGS_ENABLED="true"
+        else
+            LOGS_ENABLED="false"
+        fi
+        ;;
+    true)
+        if [ -z "$ACCOUNT_ID" ] || [ -z "$ENV_NAME" ]; then
+            echo "ERROR: USE_CLOUDWATCH_LOGS=\"true\" requires ACCOUNT_ID and ENV_NAME (or use \"auto\"/\"false\")." >&2
+            exit 1
+        fi
+        LOGS_ENABLED="true"
+        ;;
+    false)
+        LOGS_ENABLED="false"
+        ;;
+    *)
+        echo "ERROR: USE_CLOUDWATCH_LOGS must be auto, true, or false (got \"$USE_CLOUDWATCH_LOGS\")." >&2
+        exit 1
+        ;;
+esac
+
+if [ "$LOGS_ENABLED" == "true" ]; then
+    arn_prefix="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}"
+    DAGPROCESSOR_LOG_GROUP_ARN="${arn_prefix}-DAGProcessing"
+    SCHEDULER_LOG_GROUP_ARN="${arn_prefix}-Scheduler"
+    TASK_LOG_GROUP_ARN="${arn_prefix}-Task"
+    TRIGGERER_LOG_GROUP_ARN="${arn_prefix}-Scheduler"  # Triggerer reuses the Scheduler log group
+    WEBSERVER_LOG_GROUP_ARN="${arn_prefix}-WebServer"
+    WORKER_LOG_GROUP_ARN="${arn_prefix}-Worker"
+else
+    DAGPROCESSOR_LOG_GROUP_ARN=""
+    SCHEDULER_LOG_GROUP_ARN=""
+    TASK_LOG_GROUP_ARN=""
+    TRIGGERER_LOG_GROUP_ARN=""
+    WEBSERVER_LOG_GROUP_ARN=""
+    WORKER_LOG_GROUP_ARN=""
+fi
+
+MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN="$DAGPROCESSOR_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Scheduler"
+MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN="$SCHEDULER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Task"
+MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN="$TASK_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_TASK_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Scheduler"
+MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN="$TRIGGERER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-WebServer"
+MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN="$WEBSERVER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Worker"
+MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN="$WORKER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL="INFO"
 MWAA__CORE__TASK_MONITORING_ENABLED="false"
 MWAA__CORE__TERMINATE_IF_IDLE="false"

--- a/images/airflow/3.0.6/run.sh
+++ b/images/airflow/3.0.6/run.sh
@@ -51,6 +51,9 @@ ENV_NAME="" # Choose an environment name here.
 REGION="us-west-2" # Keeping the region us-west-2 as default.
 export REGION
 
+# CloudWatch logging mode: "auto" (on when ACCOUNT_ID+ENV_NAME are set), "true" (force on), "false" (force off).
+USE_CLOUDWATCH_LOGS="auto"
+
 # AWS Credentials
 # For local running without a real AWS account, dummy values are sufficient —
 # ElasticMQ (local SQS) does not validate credentials, but boto3 requires
@@ -73,23 +76,65 @@ export GENERATE_BILL_OF_MATERIALS
 # MWAA Configuration
 MWAA__CORE__REQUIREMENTS_PATH="/usr/local/airflow/requirements/requirements.txt"
 MWAA__CORE__STARTUP_SCRIPT_PATH="/usr/local/airflow/startup/startup.sh"
-MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-DAGProcessing"
+# Logging values derived from USE_CLOUDWATCH_LOGS.
+case "$USE_CLOUDWATCH_LOGS" in
+    auto)
+        if [ -n "$ACCOUNT_ID" ] && [ -n "$ENV_NAME" ]; then
+            LOGS_ENABLED="true"
+        else
+            LOGS_ENABLED="false"
+        fi
+        ;;
+    true)
+        if [ -z "$ACCOUNT_ID" ] || [ -z "$ENV_NAME" ]; then
+            echo "ERROR: USE_CLOUDWATCH_LOGS=\"true\" requires ACCOUNT_ID and ENV_NAME (or use \"auto\"/\"false\")." >&2
+            exit 1
+        fi
+        LOGS_ENABLED="true"
+        ;;
+    false)
+        LOGS_ENABLED="false"
+        ;;
+    *)
+        echo "ERROR: USE_CLOUDWATCH_LOGS must be auto, true, or false (got \"$USE_CLOUDWATCH_LOGS\")." >&2
+        exit 1
+        ;;
+esac
+
+if [ "$LOGS_ENABLED" == "true" ]; then
+    arn_prefix="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}"
+    DAGPROCESSOR_LOG_GROUP_ARN="${arn_prefix}-DAGProcessing"
+    SCHEDULER_LOG_GROUP_ARN="${arn_prefix}-Scheduler"
+    TASK_LOG_GROUP_ARN="${arn_prefix}-Task"
+    TRIGGERER_LOG_GROUP_ARN="${arn_prefix}-Scheduler"  # Triggerer reuses the Scheduler log group
+    WEBSERVER_LOG_GROUP_ARN="${arn_prefix}-WebServer"
+    WORKER_LOG_GROUP_ARN="${arn_prefix}-Worker"
+else
+    DAGPROCESSOR_LOG_GROUP_ARN=""
+    SCHEDULER_LOG_GROUP_ARN=""
+    TASK_LOG_GROUP_ARN=""
+    TRIGGERER_LOG_GROUP_ARN=""
+    WEBSERVER_LOG_GROUP_ARN=""
+    WORKER_LOG_GROUP_ARN=""
+fi
+
+MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN="$DAGPROCESSOR_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Scheduler"
+MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN="$SCHEDULER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Task"
+MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN="$TASK_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_TASK_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Scheduler"
+MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN="$TRIGGERER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-WebServer"
+MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN="$WEBSERVER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Worker"
+MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN="$WORKER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL="INFO"
 MWAA__CORE__TASK_MONITORING_ENABLED="false"
 MWAA__CORE__TERMINATE_IF_IDLE="false"

--- a/images/airflow/3.2.1/run.sh
+++ b/images/airflow/3.2.1/run.sh
@@ -51,6 +51,9 @@ ENV_NAME="" # Choose an environment name here.
 REGION="us-west-2" # Keeping the region us-west-2 as default.
 export REGION
 
+# CloudWatch logging mode: "auto" (on when ACCOUNT_ID+ENV_NAME are set), "true" (force on), "false" (force off).
+USE_CLOUDWATCH_LOGS="auto"
+
 # AWS Credentials
 # For local running without a real AWS account, dummy values are sufficient —
 # ElasticMQ (local SQS) does not validate credentials, but boto3 requires
@@ -73,23 +76,65 @@ export GENERATE_BILL_OF_MATERIALS
 # MWAA Configuration
 MWAA__CORE__REQUIREMENTS_PATH="/usr/local/airflow/requirements/requirements.txt"
 MWAA__CORE__STARTUP_SCRIPT_PATH="/usr/local/airflow/startup/startup.sh"
-MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-DAGProcessing"
+# Logging values derived from USE_CLOUDWATCH_LOGS.
+case "$USE_CLOUDWATCH_LOGS" in
+    auto)
+        if [ -n "$ACCOUNT_ID" ] && [ -n "$ENV_NAME" ]; then
+            LOGS_ENABLED="true"
+        else
+            LOGS_ENABLED="false"
+        fi
+        ;;
+    true)
+        if [ -z "$ACCOUNT_ID" ] || [ -z "$ENV_NAME" ]; then
+            echo "ERROR: USE_CLOUDWATCH_LOGS=\"true\" requires ACCOUNT_ID and ENV_NAME (or use \"auto\"/\"false\")." >&2
+            exit 1
+        fi
+        LOGS_ENABLED="true"
+        ;;
+    false)
+        LOGS_ENABLED="false"
+        ;;
+    *)
+        echo "ERROR: USE_CLOUDWATCH_LOGS must be auto, true, or false (got \"$USE_CLOUDWATCH_LOGS\")." >&2
+        exit 1
+        ;;
+esac
+
+if [ "$LOGS_ENABLED" == "true" ]; then
+    arn_prefix="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}"
+    DAGPROCESSOR_LOG_GROUP_ARN="${arn_prefix}-DAGProcessing"
+    SCHEDULER_LOG_GROUP_ARN="${arn_prefix}-Scheduler"
+    TASK_LOG_GROUP_ARN="${arn_prefix}-Task"
+    TRIGGERER_LOG_GROUP_ARN="${arn_prefix}-Scheduler"  # Triggerer reuses the Scheduler log group
+    WEBSERVER_LOG_GROUP_ARN="${arn_prefix}-WebServer"
+    WORKER_LOG_GROUP_ARN="${arn_prefix}-Worker"
+else
+    DAGPROCESSOR_LOG_GROUP_ARN=""
+    SCHEDULER_LOG_GROUP_ARN=""
+    TASK_LOG_GROUP_ARN=""
+    TRIGGERER_LOG_GROUP_ARN=""
+    WEBSERVER_LOG_GROUP_ARN=""
+    WORKER_LOG_GROUP_ARN=""
+fi
+
+MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_GROUP_ARN="$DAGPROCESSOR_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_DAGPROCESSOR_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Scheduler"
+MWAA__LOGGING__AIRFLOW_SCHEDULER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_GROUP_ARN="$SCHEDULER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Task"
+MWAA__LOGGING__AIRFLOW_TASK_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_TASK_LOG_GROUP_ARN="$TASK_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_TASK_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Scheduler"
+MWAA__LOGGING__AIRFLOW_TRIGGERER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_GROUP_ARN="$TRIGGERER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_TRIGGERER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-WebServer"
+MWAA__LOGGING__AIRFLOW_WEBSERVER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_GROUP_ARN="$WEBSERVER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_LEVEL="INFO"
-MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED="true"
-MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${ENV_NAME}-Worker"
+MWAA__LOGGING__AIRFLOW_WORKER_LOGS_ENABLED="$LOGS_ENABLED"
+MWAA__LOGGING__AIRFLOW_WORKER_LOG_GROUP_ARN="$WORKER_LOG_GROUP_ARN"
 MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL="INFO"
 MWAA__CORE__TASK_MONITORING_ENABLED="false"
 MWAA__CORE__TERMINATE_IF_IDLE="false"


### PR DESCRIPTION
Add a `USE_CLOUDWATCH_LOGS` mode to each version's `run.sh`: `auto` (default), `true`, `false`.

- **auto**: CloudWatch logging on when `ACCOUNT_ID` and `ENV_NAME` are set, otherwise logs locally to `/usr/local/airflow/logs/`.
- **true**/**false**: force on/off.

This makes a fresh checkout run locally out of the box. Previously it built a malformed log-group ARN from blank values and tried (and failed) to use CloudWatch. Behavior is unchanged when `ACCOUNT_ID`/`ENV_NAME` are set.

*Issue #, if available:*
https://github.com/aws/amazon-mwaa-docker-images/issues/366

*Description of changes:*

- Add the `USE_CLOUDWATCH_LOGS` toggle to `run.sh` for all versions.
- Derive the existing `MWAA__LOGGING__*` values from it; the `MWAA__LOGGING__*` variable names (and compose references) are unchanged.
- Update the README to cover local-by-default vs. opting into CloudWatch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.