### PR TITLE
Fix log-level filtering dropping non-Airflow subprocess output for 3.2.1

### DIFF
--- a/images/airflow/3.2.1/python/mwaa/config/setup_environment.py
+++ b/images/airflow/3.2.1/python/mwaa/config/setup_environment.py
@@ -71,6 +71,7 @@ def _execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]
             ],
             friendly_name=f"{PROCESS_LOGGER_PREFIX}_startup",
             sigterm_patience_interval=STARTUP_SCRIPT_SIGTERM_PATIENCE_INTERVAL,
+            always_publish=True,
         )
         startup_script_process.start()
         end_time = time.time()
@@ -86,6 +87,7 @@ def _execute_startup_script(cmd: str, environ: Dict[str, str]) -> Dict[str, str]
                 TimeoutCondition(STARTUP_SCRIPT_MAX_EXECUTION_TIME),
             ],
             friendly_name=f"{PROCESS_LOGGER_PREFIX}_startup",
+            always_publish=True,
         )
         verification_process.start()
 

--- a/images/airflow/3.2.1/python/mwaa/subprocess/subprocess.py
+++ b/images/airflow/3.2.1/python/mwaa/subprocess/subprocess.py
@@ -97,7 +97,8 @@ class Subprocess:
         conditions: List[ProcessCondition] = [],
         sigterm_patience_interval: timedelta = _SIGTERM_DEFAULT_PATIENCE_INTERVAL,
         on_sigterm: Optional[Callable[[], None]] = None,
-        is_essential: bool = False
+        is_essential: bool = False,
+        always_publish: bool = False
     ):
         """
         Initialize the Subprocess object.
@@ -133,6 +134,7 @@ class Subprocess:
         self.conditions = conditions
         self.sigterm_patience_interval = sigterm_patience_interval
         self.on_sigterm = on_sigterm
+        self.always_publish = always_publish
 
         self.start_time: float | None = None
         self.process: Popen[Any] | None = None
@@ -267,6 +269,9 @@ class Subprocess:
                     time.sleep(_SUBPROCESS_LOG_POLL_IDLE_SLEEP_INTERVAL.total_seconds())
             else:
                 decoded_line = line.decode("utf-8", errors="replace").rstrip()
+                if self.always_publish:
+                    self.process_logger.info(decoded_line)
+                    continue
                 parsed_level = _parse_log_level(decoded_line)
                 if parsed_level is not None:
                     last_level = parsed_level

--- a/images/airflow/3.2.1/python/mwaa/utils/user_requirements.py
+++ b/images/airflow/3.2.1/python/mwaa/utils/user_requirements.py
@@ -98,6 +98,7 @@ async def install_user_requirements(cmd: str, environ: dict[str, str]):
                 TimeoutCondition(USER_REQUIREMENTS_MAX_INSTALL_TIME),
             ],
             friendly_name=f"{logger_prefix}_requirements",
+            always_publish=True,
         )
         pip_process.start()
         if pip_process.process and pip_process.process.returncode != 0:

--- a/tests/images/airflow/3.2.1/python/mwaa/logging/test_subprocess.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/logging/test_subprocess.py
@@ -170,3 +170,20 @@ class TestReadSubprocessLogStream:
         assert subprocess_instance.process_logger.info.call_count == expected_info
         assert subprocess_instance.process_logger.warning.call_count == expected_warning
         assert subprocess_instance.process_logger.error.call_count == expected_error
+
+
+    def test_always_publish_bypasses_log_level_filter(self):
+        """Subprocesses with always_publish=True should log all output regardless of level threshold."""
+        sub = Subprocess(cmd="test_command", always_publish=True)
+        mock_process = Mock()
+        mock_process.stdout = BytesIO(
+            b"Collecting boto3==1.28.0\n"
+            b"Successfully installed boto3-1.28.0\n"
+        )
+        mock_process.poll.return_value = 0
+
+        sub.process_logger = Mock()
+        with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'ERROR'}):
+            sub._read_subprocess_log_stream(mock_process)
+
+        assert sub.process_logger.info.call_count == 2


### PR DESCRIPTION
# Description

Airflow 3.2.1 introduced structlog-aware log-level filtering in `_read_subprocess_log_stream` (PR #493). This filtering correctly drops lines below the configured `AIRFLOW_CONSOLE_LOG_LEVEL` threshold for Airflow components (scheduler, worker, triggerer) which emit structlog-formatted output.

However, non-Airflow subprocesses — pip install, startup script, and post-startup verification — emit plain text that never matches the structlog (`[info ]`) or legacy Airflow (`} INFO -`) format regexes. Since `_parse_log_level()` returns `None` for these lines, they inherit `last_level=INFO` and get silently dropped when the threshold is WARNING or higher. This means customers lose visibility into requirements installation output and startup script execution when they raise their console log level.

**Fix:** Add an `always_publish` flag (default `False`) to the `Subprocess` class. When `True`, all output lines are published unconditionally via `.info()`, bypassing log-level filtering entirely. The flag is set on the three utility subprocess callers:

- `user_requirements.py` — pip install
- `setup_environment.py` — startup script execution
- `setup_environment.py` — post-startup verification

Airflow component subprocesses (scheduler, worker, triggerer, etc.) retain the default `always_publish=False` and continue using the structlog-aware filtering as intended.

# Testing

- 24 unit tests pass (23 existing + 1 new)
- New test: `test_always_publish_bypasses_log_level_filter` — verifies that with `AIRFLOW_CONSOLE_LOG_LEVEL=ERROR` and `always_publish=True`, plain-text subprocess output is still logged via `.info()`
- Verified locally against Airflow 3.2.1 with `AIRFLOW_CONSOLE_LOG_LEVEL=WARNING`:

| Subprocess | With fix | Without fix |
|---|---|---|
| `requirements_install` | All pip output visible | pip INFO lines silently dropped |
| `startup_script_execution` | All startup messages visible | Only caller timing message remains |
| `post-startup verification` | Verification output visible | Output dropped |