### PR TITLE
Add configuration option for faster unhealthy worker replacement

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/execute_command.py
+++ b/images/airflow/2.10.1/python/mwaa/execute_command.py
@@ -138,7 +138,7 @@ def _create_airflow_webserver_subprocesses(environ: Dict[str, str]):
 
 
 def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patience_interval: timedelta | None = None):
-    conditions = _create_airflow_process_conditions('worker')
+    conditions = _create_airflow_process_conditions('worker', environ)
     # MWAA__CORE__TASK_MONITORING_ENABLED is set to 'true' for workers where we want to monitor count of tasks currently getting
     # executed on the worker. This will be used to determine if idle worker checks are to be enabled.
     task_monitoring_enabled = (
@@ -220,22 +220,27 @@ def _create_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: 
         ]
 
 
-def _create_airflow_process_conditions(airflow_cmd: str):
+def _create_airflow_process_conditions(airflow_cmd: str, environ: Dict[str, str] | None = None):
     """
     Get conditions for the given Airflow command.
 
     :param airflow_cmd: The command to get conditions for, e.g. "scheduler"
+    :param environ: The environment variables dict (used for config lookup).
     :returns: A list of conditions for the given Airflow command.
     """
     conditions: List[ProcessCondition] = [
         AirflowDbReachableCondition(airflow_component=airflow_cmd),
     ]
     if _is_sidecar_health_monitoring_enabled():
+        replacement_threshold = int(
+            (environ or os.environ).get("AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0")
+        )
         conditions.append(
             SidecarHealthCondition(
                 airflow_component=airflow_cmd,
                 container_start_time=CONTAINER_START_TIME,
                 port=_get_sidecar_health_port(),
+                replacement_threshold=replacement_threshold,
             ),
         )
     return conditions

--- a/images/airflow/2.10.1/python/mwaa/execute_command.py
+++ b/images/airflow/2.10.1/python/mwaa/execute_command.py
@@ -232,9 +232,25 @@ def _create_airflow_process_conditions(airflow_cmd: str, environ: Dict[str, str]
         AirflowDbReachableCondition(airflow_component=airflow_cmd),
     ]
     if _is_sidecar_health_monitoring_enabled():
-        replacement_threshold = int(
-            (environ or os.environ).get("AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0")
+        raw_threshold = (environ or os.environ).get(
+            "AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0"
         )
+        try:
+            replacement_threshold = int(float(raw_threshold))
+        except (ValueError, TypeError):
+            logger.warning(
+                "Invalid WORKER_REPLACEMENT_THRESHOLD_SECONDS value: %r. "
+                "Defaulting to 0 (disabled).",
+                raw_threshold,
+            )
+            replacement_threshold = 0
+        if replacement_threshold < 0:
+            logger.warning(
+                "Negative WORKER_REPLACEMENT_THRESHOLD_SECONDS value: %d. "
+                "Defaulting to 0 (disabled).",
+                replacement_threshold,
+            )
+            replacement_threshold = 0
         conditions.append(
             SidecarHealthCondition(
                 airflow_component=airflow_cmd,

--- a/images/airflow/2.10.1/python/mwaa/subprocess/conditions.py
+++ b/images/airflow/2.10.1/python/mwaa/subprocess/conditions.py
@@ -17,6 +17,7 @@ from functools import cached_property
 from types import FrameType, TracebackType
 from typing import Callable, Deque, Optional
 import logging
+import os
 import signal
 import socket
 import sys
@@ -186,18 +187,22 @@ class SidecarHealthCondition(ProcessCondition):
         airflow_component: str,
         container_start_time: float,
         port: int = SIDECAR_DEFAULT_HEALTH_PORT,
+        replacement_threshold: int = 0,
     ):
         """
         :param airflow_component: The airflow component to check.
         :param container_start_time: The epoch in seconds, i.e. time.time(), when the
           container started.
         :param port: The port the sidecar sends health monitoring results to.
+        :param replacement_threshold: Seconds after which an unhealthy worker should be replaced.
         """
         super().__init__()
         self.airflow_component = airflow_component
         self.port = port
         self.socket: socket.socket | None
         self.container_start_time: float = container_start_time
+        self.last_healthy_time: float = container_start_time
+        self.replacement_threshold: int = replacement_threshold
 
     def prepare(self):
         """
@@ -261,13 +266,32 @@ class SidecarHealthCondition(ProcessCondition):
                 case "blue" | "yellow":
                     # We treat blue/yellow as healthy to avoid unnecessary restarts,
                     # but we log a warning.
-                    response = ProcessConditionResponse(
-                        condition=self,
-                        successful=True,
-                        message=f"Status received from sidecar: {status}",
-                    )
-                    logger.warning(response.message)
+                    # However, if the customer has configured a replacement threshold
+                    # and sufficient time has passed without a healthy heartbeat,
+                    # we treat this as a failure to trigger worker replacement.
+                    seconds_since_healthy = time.time() - self.last_healthy_time
+                    if (
+                        self.replacement_threshold > 0
+                        and self.airflow_component.lower() == "worker"
+                        and seconds_since_healthy >= self.replacement_threshold
+                    ):
+                        response = ProcessConditionResponse(
+                            condition=self,
+                            successful=False,
+                            message=f"No healthy heartbeat for {seconds_since_healthy:.0f}s "
+                            f"(configured threshold: {self.replacement_threshold}s). "
+                            f"Last sidecar status: {status}",
+                        )
+                        logger.error(response.message)
+                    else:
+                        response = ProcessConditionResponse(
+                            condition=self,
+                            successful=True,
+                            message=f"Status received from sidecar: {status}",
+                        )
+                        logger.warning(response.message)
                 case "healthy":
+                    self.last_healthy_time = time.time()
                     response = ProcessConditionResponse(
                         condition=self,
                         successful=True,

--- a/images/airflow/2.10.3/python/mwaa/execute_command.py
+++ b/images/airflow/2.10.3/python/mwaa/execute_command.py
@@ -138,7 +138,7 @@ def _create_airflow_webserver_subprocesses(environ: Dict[str, str]):
 
 
 def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patience_interval: timedelta | None = None):
-    conditions = _create_airflow_process_conditions('worker')
+    conditions = _create_airflow_process_conditions('worker', environ)
     # MWAA__CORE__TASK_MONITORING_ENABLED is set to 'true' for workers where we want to monitor count of tasks currently getting
     # executed on the worker. This will be used to determine if idle worker checks are to be enabled.
     task_monitoring_enabled = (
@@ -220,22 +220,27 @@ def _create_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: 
         ]
 
 
-def _create_airflow_process_conditions(airflow_cmd: str):
+def _create_airflow_process_conditions(airflow_cmd: str, environ: Dict[str, str] | None = None):
     """
     Get conditions for the given Airflow command.
 
     :param airflow_cmd: The command to get conditions for, e.g. "scheduler"
+    :param environ: The environment variables dict (used for config lookup).
     :returns: A list of conditions for the given Airflow command.
     """
     conditions: List[ProcessCondition] = [
         AirflowDbReachableCondition(airflow_component=airflow_cmd),
     ]
     if _is_sidecar_health_monitoring_enabled():
+        replacement_threshold = int(
+            (environ or os.environ).get("AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0")
+        )
         conditions.append(
             SidecarHealthCondition(
                 airflow_component=airflow_cmd,
                 container_start_time=CONTAINER_START_TIME,
                 port=_get_sidecar_health_port(),
+                replacement_threshold=replacement_threshold,
             ),
         )
     return conditions

--- a/images/airflow/2.10.3/python/mwaa/execute_command.py
+++ b/images/airflow/2.10.3/python/mwaa/execute_command.py
@@ -232,8 +232,29 @@ def _create_airflow_process_conditions(airflow_cmd: str, environ: Dict[str, str]
         AirflowDbReachableCondition(airflow_component=airflow_cmd),
     ]
     if _is_sidecar_health_monitoring_enabled():
-        replacement_threshold = int(
-            (environ or os.environ).get("AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0")
+        raw_threshold = (environ or os.environ).get(
+            "AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0"
+        )
+        try:
+            replacement_threshold = int(float(raw_threshold))
+        except (ValueError, TypeError):
+            logger.warning(
+                "Invalid WORKER_REPLACEMENT_THRESHOLD_SECONDS value: %r. "
+                "Defaulting to 0 (disabled).",
+                raw_threshold,
+            )
+            replacement_threshold = 0
+        if replacement_threshold < 0:
+            logger.warning(
+                "Negative WORKER_REPLACEMENT_THRESHOLD_SECONDS value: %d. "
+                "Defaulting to 0 (disabled).",
+                replacement_threshold,
+            )
+            replacement_threshold = 0
+        logger.debug(
+            "FastReplace: replacement_threshold=%d seconds (raw=%r)",
+            replacement_threshold,
+            raw_threshold,
         )
         conditions.append(
             SidecarHealthCondition(

--- a/images/airflow/2.10.3/python/mwaa/subprocess/conditions.py
+++ b/images/airflow/2.10.3/python/mwaa/subprocess/conditions.py
@@ -17,6 +17,7 @@ from functools import cached_property
 from types import FrameType, TracebackType
 from typing import Callable, Deque, Optional
 import logging
+import os
 import signal
 import socket
 import sys
@@ -186,18 +187,22 @@ class SidecarHealthCondition(ProcessCondition):
         airflow_component: str,
         container_start_time: float,
         port: int = SIDECAR_DEFAULT_HEALTH_PORT,
+        replacement_threshold: int = 0,
     ):
         """
         :param airflow_component: The airflow component to check.
         :param container_start_time: The epoch in seconds, i.e. time.time(), when the
           container started.
         :param port: The port the sidecar sends health monitoring results to.
+        :param replacement_threshold: Seconds after which an unhealthy worker should be replaced.
         """
         super().__init__()
         self.airflow_component = airflow_component
         self.port = port
         self.socket: socket.socket | None
         self.container_start_time: float = container_start_time
+        self.last_healthy_time: float = container_start_time
+        self.replacement_threshold: int = replacement_threshold
 
     def prepare(self):
         """
@@ -261,13 +266,32 @@ class SidecarHealthCondition(ProcessCondition):
                 case "blue" | "yellow":
                     # We treat blue/yellow as healthy to avoid unnecessary restarts,
                     # but we log a warning.
-                    response = ProcessConditionResponse(
-                        condition=self,
-                        successful=True,
-                        message=f"Status received from sidecar: {status}",
-                    )
-                    logger.warning(response.message)
+                    # However, if the customer has configured a replacement threshold
+                    # and sufficient time has passed without a healthy heartbeat,
+                    # we treat this as a failure to trigger worker replacement.
+                    seconds_since_healthy = time.time() - self.last_healthy_time
+                    if (
+                        self.replacement_threshold > 0
+                        and self.airflow_component.lower() == "worker"
+                        and seconds_since_healthy >= self.replacement_threshold
+                    ):
+                        response = ProcessConditionResponse(
+                            condition=self,
+                            successful=False,
+                            message=f"No healthy heartbeat for {seconds_since_healthy:.0f}s "
+                            f"(configured threshold: {self.replacement_threshold}s). "
+                            f"Last sidecar status: {status}",
+                        )
+                        logger.error(response.message)
+                    else:
+                        response = ProcessConditionResponse(
+                            condition=self,
+                            successful=True,
+                            message=f"Status received from sidecar: {status}",
+                        )
+                        logger.warning(response.message)
                 case "healthy":
+                    self.last_healthy_time = time.time()
                     response = ProcessConditionResponse(
                         condition=self,
                         successful=True,

--- a/images/airflow/2.11.0/python/mwaa/execute_command.py
+++ b/images/airflow/2.11.0/python/mwaa/execute_command.py
@@ -138,7 +138,7 @@ def _create_airflow_webserver_subprocesses(environ: Dict[str, str]):
 
 
 def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patience_interval: timedelta | None = None):
-    conditions = _create_airflow_process_conditions('worker')
+    conditions = _create_airflow_process_conditions('worker', environ)
     # MWAA__CORE__TASK_MONITORING_ENABLED is set to 'true' for workers where we want to monitor count of tasks currently getting
     # executed on the worker. This will be used to determine if idle worker checks are to be enabled.
     task_monitoring_enabled = (
@@ -220,22 +220,27 @@ def _create_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: 
         ]
 
 
-def _create_airflow_process_conditions(airflow_cmd: str):
+def _create_airflow_process_conditions(airflow_cmd: str, environ: Dict[str, str] | None = None):
     """
     Get conditions for the given Airflow command.
 
     :param airflow_cmd: The command to get conditions for, e.g. "scheduler"
+    :param environ: The environment variables dict (used for config lookup).
     :returns: A list of conditions for the given Airflow command.
     """
     conditions: List[ProcessCondition] = [
         AirflowDbReachableCondition(airflow_component=airflow_cmd),
     ]
     if _is_sidecar_health_monitoring_enabled():
+        replacement_threshold = int(
+            (environ or os.environ).get("AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0")
+        )
         conditions.append(
             SidecarHealthCondition(
                 airflow_component=airflow_cmd,
                 container_start_time=CONTAINER_START_TIME,
                 port=_get_sidecar_health_port(),
+                replacement_threshold=replacement_threshold,
             ),
         )
     return conditions

--- a/images/airflow/2.11.0/python/mwaa/execute_command.py
+++ b/images/airflow/2.11.0/python/mwaa/execute_command.py
@@ -232,9 +232,25 @@ def _create_airflow_process_conditions(airflow_cmd: str, environ: Dict[str, str]
         AirflowDbReachableCondition(airflow_component=airflow_cmd),
     ]
     if _is_sidecar_health_monitoring_enabled():
-        replacement_threshold = int(
-            (environ or os.environ).get("AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0")
+        raw_threshold = (environ or os.environ).get(
+            "AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0"
         )
+        try:
+            replacement_threshold = int(float(raw_threshold))
+        except (ValueError, TypeError):
+            logger.warning(
+                "Invalid WORKER_REPLACEMENT_THRESHOLD_SECONDS value: %r. "
+                "Defaulting to 0 (disabled).",
+                raw_threshold,
+            )
+            replacement_threshold = 0
+        if replacement_threshold < 0:
+            logger.warning(
+                "Negative WORKER_REPLACEMENT_THRESHOLD_SECONDS value: %d. "
+                "Defaulting to 0 (disabled).",
+                replacement_threshold,
+            )
+            replacement_threshold = 0
         conditions.append(
             SidecarHealthCondition(
                 airflow_component=airflow_cmd,

--- a/images/airflow/2.11.0/python/mwaa/subprocess/conditions.py
+++ b/images/airflow/2.11.0/python/mwaa/subprocess/conditions.py
@@ -17,6 +17,7 @@ from functools import cached_property
 from types import FrameType, TracebackType
 from typing import Callable, Deque, Optional
 import logging
+import os
 import signal
 import socket
 import sys
@@ -186,18 +187,22 @@ class SidecarHealthCondition(ProcessCondition):
         airflow_component: str,
         container_start_time: float,
         port: int = SIDECAR_DEFAULT_HEALTH_PORT,
+        replacement_threshold: int = 0,
     ):
         """
         :param airflow_component: The airflow component to check.
         :param container_start_time: The epoch in seconds, i.e. time.time(), when the
           container started.
         :param port: The port the sidecar sends health monitoring results to.
+        :param replacement_threshold: Seconds after which an unhealthy worker should be replaced.
         """
         super().__init__()
         self.airflow_component = airflow_component
         self.port = port
         self.socket: socket.socket | None
         self.container_start_time: float = container_start_time
+        self.last_healthy_time: float = container_start_time
+        self.replacement_threshold: int = replacement_threshold
 
     def prepare(self):
         """
@@ -261,13 +266,32 @@ class SidecarHealthCondition(ProcessCondition):
                 case "blue" | "yellow":
                     # We treat blue/yellow as healthy to avoid unnecessary restarts,
                     # but we log a warning.
-                    response = ProcessConditionResponse(
-                        condition=self,
-                        successful=True,
-                        message=f"Status received from sidecar: {status}",
-                    )
-                    logger.warning(response.message)
+                    # However, if the customer has configured a replacement threshold
+                    # and sufficient time has passed without a healthy heartbeat,
+                    # we treat this as a failure to trigger worker replacement.
+                    seconds_since_healthy = time.time() - self.last_healthy_time
+                    if (
+                        self.replacement_threshold > 0
+                        and self.airflow_component.lower() == "worker"
+                        and seconds_since_healthy >= self.replacement_threshold
+                    ):
+                        response = ProcessConditionResponse(
+                            condition=self,
+                            successful=False,
+                            message=f"No healthy heartbeat for {seconds_since_healthy:.0f}s "
+                            f"(configured threshold: {self.replacement_threshold}s). "
+                            f"Last sidecar status: {status}",
+                        )
+                        logger.error(response.message)
+                    else:
+                        response = ProcessConditionResponse(
+                            condition=self,
+                            successful=True,
+                            message=f"Status received from sidecar: {status}",
+                        )
+                        logger.warning(response.message)
                 case "healthy":
+                    self.last_healthy_time = time.time()
                     response = ProcessConditionResponse(
                         condition=self,
                         successful=True,

--- a/images/airflow/2.11.2/python/mwaa/execute_command.py
+++ b/images/airflow/2.11.2/python/mwaa/execute_command.py
@@ -138,7 +138,7 @@ def _create_airflow_webserver_subprocesses(environ: Dict[str, str]):
 
 
 def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patience_interval: timedelta | None = None):
-    conditions = _create_airflow_process_conditions('worker')
+    conditions = _create_airflow_process_conditions('worker', environ)
     # MWAA__CORE__TASK_MONITORING_ENABLED is set to 'true' for workers where we want to monitor count of tasks currently getting
     # executed on the worker. This will be used to determine if idle worker checks are to be enabled.
     task_monitoring_enabled = (
@@ -220,22 +220,27 @@ def _create_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: 
         ]
 
 
-def _create_airflow_process_conditions(airflow_cmd: str):
+def _create_airflow_process_conditions(airflow_cmd: str, environ: Dict[str, str] | None = None):
     """
     Get conditions for the given Airflow command.
 
     :param airflow_cmd: The command to get conditions for, e.g. "scheduler"
+    :param environ: The environment variables dict (used for config lookup).
     :returns: A list of conditions for the given Airflow command.
     """
     conditions: List[ProcessCondition] = [
         AirflowDbReachableCondition(airflow_component=airflow_cmd),
     ]
     if _is_sidecar_health_monitoring_enabled():
+        replacement_threshold = int(
+            (environ or os.environ).get("AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0")
+        )
         conditions.append(
             SidecarHealthCondition(
                 airflow_component=airflow_cmd,
                 container_start_time=CONTAINER_START_TIME,
                 port=_get_sidecar_health_port(),
+                replacement_threshold=replacement_threshold,
             ),
         )
     return conditions

--- a/images/airflow/2.11.2/python/mwaa/execute_command.py
+++ b/images/airflow/2.11.2/python/mwaa/execute_command.py
@@ -232,9 +232,25 @@ def _create_airflow_process_conditions(airflow_cmd: str, environ: Dict[str, str]
         AirflowDbReachableCondition(airflow_component=airflow_cmd),
     ]
     if _is_sidecar_health_monitoring_enabled():
-        replacement_threshold = int(
-            (environ or os.environ).get("AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0")
+        raw_threshold = (environ or os.environ).get(
+            "AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0"
         )
+        try:
+            replacement_threshold = int(float(raw_threshold))
+        except (ValueError, TypeError):
+            logger.warning(
+                "Invalid WORKER_REPLACEMENT_THRESHOLD_SECONDS value: %r. "
+                "Defaulting to 0 (disabled).",
+                raw_threshold,
+            )
+            replacement_threshold = 0
+        if replacement_threshold < 0:
+            logger.warning(
+                "Negative WORKER_REPLACEMENT_THRESHOLD_SECONDS value: %d. "
+                "Defaulting to 0 (disabled).",
+                replacement_threshold,
+            )
+            replacement_threshold = 0
         conditions.append(
             SidecarHealthCondition(
                 airflow_component=airflow_cmd,

--- a/images/airflow/2.11.2/python/mwaa/subprocess/conditions.py
+++ b/images/airflow/2.11.2/python/mwaa/subprocess/conditions.py
@@ -17,6 +17,7 @@ from functools import cached_property
 from types import FrameType, TracebackType
 from typing import Callable, Deque, Optional
 import logging
+import os
 import signal
 import socket
 import sys
@@ -186,18 +187,22 @@ class SidecarHealthCondition(ProcessCondition):
         airflow_component: str,
         container_start_time: float,
         port: int = SIDECAR_DEFAULT_HEALTH_PORT,
+        replacement_threshold: int = 0,
     ):
         """
         :param airflow_component: The airflow component to check.
         :param container_start_time: The epoch in seconds, i.e. time.time(), when the
           container started.
         :param port: The port the sidecar sends health monitoring results to.
+        :param replacement_threshold: Seconds after which an unhealthy worker should be replaced.
         """
         super().__init__()
         self.airflow_component = airflow_component
         self.port = port
         self.socket: socket.socket | None
         self.container_start_time: float = container_start_time
+        self.last_healthy_time: float = container_start_time
+        self.replacement_threshold: int = replacement_threshold
 
     def prepare(self):
         """
@@ -261,13 +266,32 @@ class SidecarHealthCondition(ProcessCondition):
                 case "blue" | "yellow":
                     # We treat blue/yellow as healthy to avoid unnecessary restarts,
                     # but we log a warning.
-                    response = ProcessConditionResponse(
-                        condition=self,
-                        successful=True,
-                        message=f"Status received from sidecar: {status}",
-                    )
-                    logger.warning(response.message)
+                    # However, if the customer has configured a replacement threshold
+                    # and sufficient time has passed without a healthy heartbeat,
+                    # we treat this as a failure to trigger worker replacement.
+                    seconds_since_healthy = time.time() - self.last_healthy_time
+                    if (
+                        self.replacement_threshold > 0
+                        and self.airflow_component.lower() == "worker"
+                        and seconds_since_healthy >= self.replacement_threshold
+                    ):
+                        response = ProcessConditionResponse(
+                            condition=self,
+                            successful=False,
+                            message=f"No healthy heartbeat for {seconds_since_healthy:.0f}s "
+                            f"(configured threshold: {self.replacement_threshold}s). "
+                            f"Last sidecar status: {status}",
+                        )
+                        logger.error(response.message)
+                    else:
+                        response = ProcessConditionResponse(
+                            condition=self,
+                            successful=True,
+                            message=f"Status received from sidecar: {status}",
+                        )
+                        logger.warning(response.message)
                 case "healthy":
+                    self.last_healthy_time = time.time()
                     response = ProcessConditionResponse(
                         condition=self,
                         successful=True,

--- a/images/airflow/2.9.2/python/mwaa/execute_command.py
+++ b/images/airflow/2.9.2/python/mwaa/execute_command.py
@@ -138,7 +138,7 @@ def _create_airflow_webserver_subprocesses(environ: Dict[str, str]):
 
 
 def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patience_interval: timedelta | None = None):
-    conditions = _create_airflow_process_conditions('worker')
+    conditions = _create_airflow_process_conditions('worker', environ)
     # MWAA__CORE__TASK_MONITORING_ENABLED is set to 'true' for workers where we want to monitor count of tasks currently getting
     # executed on the worker. This will be used to determine if idle worker checks are to be enabled.
     task_monitoring_enabled = (
@@ -220,22 +220,27 @@ def _create_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: 
         ]
 
 
-def _create_airflow_process_conditions(airflow_cmd: str):
+def _create_airflow_process_conditions(airflow_cmd: str, environ: Dict[str, str] | None = None):
     """
     Get conditions for the given Airflow command.
 
     :param airflow_cmd: The command to get conditions for, e.g. "scheduler"
+    :param environ: The environment variables dict (used for config lookup).
     :returns: A list of conditions for the given Airflow command.
     """
     conditions: List[ProcessCondition] = [
         AirflowDbReachableCondition(airflow_component=airflow_cmd),
     ]
     if _is_sidecar_health_monitoring_enabled():
+        replacement_threshold = int(
+            (environ or os.environ).get("AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0")
+        )
         conditions.append(
             SidecarHealthCondition(
                 airflow_component=airflow_cmd,
                 container_start_time=CONTAINER_START_TIME,
                 port=_get_sidecar_health_port(),
+                replacement_threshold=replacement_threshold,
             ),
         )
     return conditions

--- a/images/airflow/2.9.2/python/mwaa/execute_command.py
+++ b/images/airflow/2.9.2/python/mwaa/execute_command.py
@@ -232,9 +232,25 @@ def _create_airflow_process_conditions(airflow_cmd: str, environ: Dict[str, str]
         AirflowDbReachableCondition(airflow_component=airflow_cmd),
     ]
     if _is_sidecar_health_monitoring_enabled():
-        replacement_threshold = int(
-            (environ or os.environ).get("AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0")
+        raw_threshold = (environ or os.environ).get(
+            "AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0"
         )
+        try:
+            replacement_threshold = int(float(raw_threshold))
+        except (ValueError, TypeError):
+            logger.warning(
+                "Invalid WORKER_REPLACEMENT_THRESHOLD_SECONDS value: %r. "
+                "Defaulting to 0 (disabled).",
+                raw_threshold,
+            )
+            replacement_threshold = 0
+        if replacement_threshold < 0:
+            logger.warning(
+                "Negative WORKER_REPLACEMENT_THRESHOLD_SECONDS value: %d. "
+                "Defaulting to 0 (disabled).",
+                replacement_threshold,
+            )
+            replacement_threshold = 0
         conditions.append(
             SidecarHealthCondition(
                 airflow_component=airflow_cmd,

--- a/images/airflow/2.9.2/python/mwaa/subprocess/conditions.py
+++ b/images/airflow/2.9.2/python/mwaa/subprocess/conditions.py
@@ -17,6 +17,7 @@ from functools import cached_property
 from types import FrameType, TracebackType
 from typing import Callable, Deque, Optional
 import logging
+import os
 import signal
 import socket
 import sys
@@ -186,18 +187,22 @@ class SidecarHealthCondition(ProcessCondition):
         airflow_component: str,
         container_start_time: float,
         port: int = SIDECAR_DEFAULT_HEALTH_PORT,
+        replacement_threshold: int = 0,
     ):
         """
         :param airflow_component: The airflow component to check.
         :param container_start_time: The epoch in seconds, i.e. time.time(), when the
           container started.
         :param port: The port the sidecar sends health monitoring results to.
+        :param replacement_threshold: Seconds after which an unhealthy worker should be replaced.
         """
         super().__init__()
         self.airflow_component = airflow_component
         self.port = port
         self.socket: socket.socket | None
         self.container_start_time: float = container_start_time
+        self.last_healthy_time: float = container_start_time
+        self.replacement_threshold: int = replacement_threshold
 
     def prepare(self):
         """
@@ -261,13 +266,32 @@ class SidecarHealthCondition(ProcessCondition):
                 case "blue" | "yellow":
                     # We treat blue/yellow as healthy to avoid unnecessary restarts,
                     # but we log a warning.
-                    response = ProcessConditionResponse(
-                        condition=self,
-                        successful=True,
-                        message=f"Status received from sidecar: {status}",
-                    )
-                    logger.warning(response.message)
+                    # However, if the customer has configured a replacement threshold
+                    # and sufficient time has passed without a healthy heartbeat,
+                    # we treat this as a failure to trigger worker replacement.
+                    seconds_since_healthy = time.time() - self.last_healthy_time
+                    if (
+                        self.replacement_threshold > 0
+                        and self.airflow_component.lower() == "worker"
+                        and seconds_since_healthy >= self.replacement_threshold
+                    ):
+                        response = ProcessConditionResponse(
+                            condition=self,
+                            successful=False,
+                            message=f"No healthy heartbeat for {seconds_since_healthy:.0f}s "
+                            f"(configured threshold: {self.replacement_threshold}s). "
+                            f"Last sidecar status: {status}",
+                        )
+                        logger.error(response.message)
+                    else:
+                        response = ProcessConditionResponse(
+                            condition=self,
+                            successful=True,
+                            message=f"Status received from sidecar: {status}",
+                        )
+                        logger.warning(response.message)
                 case "healthy":
+                    self.last_healthy_time = time.time()
                     response = ProcessConditionResponse(
                         condition=self,
                         successful=True,

--- a/images/airflow/3.0.6/python/mwaa/execute_command.py
+++ b/images/airflow/3.0.6/python/mwaa/execute_command.py
@@ -138,7 +138,7 @@ def _create_airflow_webserver_subprocesses(environ: Dict[str, str]):
 
 
 def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patience_interval: timedelta | None = None):
-    conditions = _create_airflow_process_conditions('worker')
+    conditions = _create_airflow_process_conditions('worker', environ)
     # MWAA__CORE__TASK_MONITORING_ENABLED is set to 'true' for workers where we want to monitor count of tasks currently getting
     # executed on the worker. This will be used to determine if idle worker checks are to be enabled.
     task_monitoring_enabled = (
@@ -220,22 +220,27 @@ def _create_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: 
     ]
 
 
-def _create_airflow_process_conditions(airflow_cmd: str):
+def _create_airflow_process_conditions(airflow_cmd: str, environ: Dict[str, str] | None = None):
     """
     Get conditions for the given Airflow command.
 
     :param airflow_cmd: The command to get conditions for, e.g. "scheduler"
+    :param environ: The environment variables dict (used for config lookup).
     :returns: A list of conditions for the given Airflow command.
     """
     conditions: List[ProcessCondition] = [
         AirflowDbReachableCondition(airflow_component=airflow_cmd),
     ]
     if _is_sidecar_health_monitoring_enabled():
+        replacement_threshold = int(
+            (environ or os.environ).get("AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0")
+        )
         conditions.append(
             SidecarHealthCondition(
                 airflow_component=airflow_cmd,
                 container_start_time=CONTAINER_START_TIME,
                 port=_get_sidecar_health_port(),
+                replacement_threshold=replacement_threshold,
             ),
         )
     return conditions

--- a/images/airflow/3.0.6/python/mwaa/execute_command.py
+++ b/images/airflow/3.0.6/python/mwaa/execute_command.py
@@ -232,9 +232,25 @@ def _create_airflow_process_conditions(airflow_cmd: str, environ: Dict[str, str]
         AirflowDbReachableCondition(airflow_component=airflow_cmd),
     ]
     if _is_sidecar_health_monitoring_enabled():
-        replacement_threshold = int(
-            (environ or os.environ).get("AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0")
+        raw_threshold = (environ or os.environ).get(
+            "AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0"
         )
+        try:
+            replacement_threshold = int(float(raw_threshold))
+        except (ValueError, TypeError):
+            logger.warning(
+                "Invalid WORKER_REPLACEMENT_THRESHOLD_SECONDS value: %r. "
+                "Defaulting to 0 (disabled).",
+                raw_threshold,
+            )
+            replacement_threshold = 0
+        if replacement_threshold < 0:
+            logger.warning(
+                "Negative WORKER_REPLACEMENT_THRESHOLD_SECONDS value: %d. "
+                "Defaulting to 0 (disabled).",
+                replacement_threshold,
+            )
+            replacement_threshold = 0
         conditions.append(
             SidecarHealthCondition(
                 airflow_component=airflow_cmd,

--- a/images/airflow/3.0.6/python/mwaa/subprocess/conditions.py
+++ b/images/airflow/3.0.6/python/mwaa/subprocess/conditions.py
@@ -17,6 +17,7 @@ from functools import cached_property
 from types import FrameType, TracebackType
 from typing import Callable, Deque, Optional
 import logging
+import os
 import signal
 import socket
 import sys
@@ -186,18 +187,22 @@ class SidecarHealthCondition(ProcessCondition):
         airflow_component: str,
         container_start_time: float,
         port: int = SIDECAR_DEFAULT_HEALTH_PORT,
+        replacement_threshold: int = 0,
     ):
         """
         :param airflow_component: The airflow component to check.
         :param container_start_time: The epoch in seconds, i.e. time.time(), when the
           container started.
         :param port: The port the sidecar sends health monitoring results to.
+        :param replacement_threshold: Seconds after which an unhealthy worker should be replaced.
         """
         super().__init__()
         self.airflow_component = airflow_component
         self.port = port
         self.socket: socket.socket | None
         self.container_start_time: float = container_start_time
+        self.last_healthy_time: float = container_start_time
+        self.replacement_threshold: int = replacement_threshold
 
     def prepare(self):
         """
@@ -261,13 +266,32 @@ class SidecarHealthCondition(ProcessCondition):
                 case "blue" | "yellow":
                     # We treat blue/yellow as healthy to avoid unnecessary restarts,
                     # but we log a warning.
-                    response = ProcessConditionResponse(
-                        condition=self,
-                        successful=True,
-                        message=f"Status received from sidecar: {status}",
-                    )
-                    logger.warning(response.message)
+                    # However, if the customer has configured a replacement threshold
+                    # and sufficient time has passed without a healthy heartbeat,
+                    # we treat this as a failure to trigger worker replacement.
+                    seconds_since_healthy = time.time() - self.last_healthy_time
+                    if (
+                        self.replacement_threshold > 0
+                        and self.airflow_component.lower() == "worker"
+                        and seconds_since_healthy >= self.replacement_threshold
+                    ):
+                        response = ProcessConditionResponse(
+                            condition=self,
+                            successful=False,
+                            message=f"No healthy heartbeat for {seconds_since_healthy:.0f}s "
+                            f"(configured threshold: {self.replacement_threshold}s). "
+                            f"Last sidecar status: {status}",
+                        )
+                        logger.error(response.message)
+                    else:
+                        response = ProcessConditionResponse(
+                            condition=self,
+                            successful=True,
+                            message=f"Status received from sidecar: {status}",
+                        )
+                        logger.warning(response.message)
                 case "healthy":
+                    self.last_healthy_time = time.time()
                     response = ProcessConditionResponse(
                         condition=self,
                         successful=True,

--- a/images/airflow/3.2.1/python/mwaa/execute_command.py
+++ b/images/airflow/3.2.1/python/mwaa/execute_command.py
@@ -138,7 +138,7 @@ def _create_airflow_webserver_subprocesses(environ: Dict[str, str]):
 
 
 def _create_airflow_worker_subprocesses(environ: Dict[str, str], sigterm_patience_interval: timedelta | None = None):
-    conditions = _create_airflow_process_conditions('worker')
+    conditions = _create_airflow_process_conditions('worker', environ)
     # MWAA__CORE__TASK_MONITORING_ENABLED is set to 'true' for workers where we want to monitor count of tasks currently getting
     # executed on the worker. This will be used to determine if idle worker checks are to be enabled.
     task_monitoring_enabled = (
@@ -220,22 +220,27 @@ def _create_airflow_scheduler_subprocesses(environ: Dict[str, str], conditions: 
     ]
 
 
-def _create_airflow_process_conditions(airflow_cmd: str):
+def _create_airflow_process_conditions(airflow_cmd: str, environ: Dict[str, str] | None = None):
     """
     Get conditions for the given Airflow command.
 
     :param airflow_cmd: The command to get conditions for, e.g. "scheduler"
+    :param environ: The environment variables dict (used for config lookup).
     :returns: A list of conditions for the given Airflow command.
     """
     conditions: List[ProcessCondition] = [
         AirflowDbReachableCondition(airflow_component=airflow_cmd),
     ]
     if _is_sidecar_health_monitoring_enabled():
+        replacement_threshold = int(
+            (environ or os.environ).get("AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0")
+        )
         conditions.append(
             SidecarHealthCondition(
                 airflow_component=airflow_cmd,
                 container_start_time=CONTAINER_START_TIME,
                 port=_get_sidecar_health_port(),
+                replacement_threshold=replacement_threshold,
             ),
         )
     return conditions

--- a/images/airflow/3.2.1/python/mwaa/execute_command.py
+++ b/images/airflow/3.2.1/python/mwaa/execute_command.py
@@ -232,9 +232,25 @@ def _create_airflow_process_conditions(airflow_cmd: str, environ: Dict[str, str]
         AirflowDbReachableCondition(airflow_component=airflow_cmd),
     ]
     if _is_sidecar_health_monitoring_enabled():
-        replacement_threshold = int(
-            (environ or os.environ).get("AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0")
+        raw_threshold = (environ or os.environ).get(
+            "AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS", "0"
         )
+        try:
+            replacement_threshold = int(float(raw_threshold))
+        except (ValueError, TypeError):
+            logger.warning(
+                "Invalid WORKER_REPLACEMENT_THRESHOLD_SECONDS value: %r. "
+                "Defaulting to 0 (disabled).",
+                raw_threshold,
+            )
+            replacement_threshold = 0
+        if replacement_threshold < 0:
+            logger.warning(
+                "Negative WORKER_REPLACEMENT_THRESHOLD_SECONDS value: %d. "
+                "Defaulting to 0 (disabled).",
+                replacement_threshold,
+            )
+            replacement_threshold = 0
         conditions.append(
             SidecarHealthCondition(
                 airflow_component=airflow_cmd,

--- a/images/airflow/3.2.1/python/mwaa/subprocess/conditions.py
+++ b/images/airflow/3.2.1/python/mwaa/subprocess/conditions.py
@@ -17,6 +17,7 @@ from functools import cached_property
 from types import FrameType, TracebackType
 from typing import Callable, Deque, Optional
 import logging
+import os
 import signal
 import socket
 import sys
@@ -186,18 +187,22 @@ class SidecarHealthCondition(ProcessCondition):
         airflow_component: str,
         container_start_time: float,
         port: int = SIDECAR_DEFAULT_HEALTH_PORT,
+        replacement_threshold: int = 0,
     ):
         """
         :param airflow_component: The airflow component to check.
         :param container_start_time: The epoch in seconds, i.e. time.time(), when the
           container started.
         :param port: The port the sidecar sends health monitoring results to.
+        :param replacement_threshold: Seconds after which an unhealthy worker should be replaced.
         """
         super().__init__()
         self.airflow_component = airflow_component
         self.port = port
         self.socket: socket.socket | None
         self.container_start_time: float = container_start_time
+        self.last_healthy_time: float = container_start_time
+        self.replacement_threshold: int = replacement_threshold
 
     def prepare(self):
         """
@@ -261,13 +266,32 @@ class SidecarHealthCondition(ProcessCondition):
                 case "blue" | "yellow":
                     # We treat blue/yellow as healthy to avoid unnecessary restarts,
                     # but we log a warning.
-                    response = ProcessConditionResponse(
-                        condition=self,
-                        successful=True,
-                        message=f"Status received from sidecar: {status}",
-                    )
-                    logger.warning(response.message)
+                    # However, if the customer has configured a replacement threshold
+                    # and sufficient time has passed without a healthy heartbeat,
+                    # we treat this as a failure to trigger worker replacement.
+                    seconds_since_healthy = time.time() - self.last_healthy_time
+                    if (
+                        self.replacement_threshold > 0
+                        and self.airflow_component.lower() == "worker"
+                        and seconds_since_healthy >= self.replacement_threshold
+                    ):
+                        response = ProcessConditionResponse(
+                            condition=self,
+                            successful=False,
+                            message=f"No healthy heartbeat for {seconds_since_healthy:.0f}s "
+                            f"(configured threshold: {self.replacement_threshold}s). "
+                            f"Last sidecar status: {status}",
+                        )
+                        logger.error(response.message)
+                    else:
+                        response = ProcessConditionResponse(
+                            condition=self,
+                            successful=True,
+                            message=f"Status received from sidecar: {status}",
+                        )
+                        logger.warning(response.message)
                 case "healthy":
+                    self.last_healthy_time = time.time()
                     response = ProcessConditionResponse(
                         condition=self,
                         successful=True,

--- a/tests/images/airflow/2.10.1/python/mwaa/subprocess/test_sidecar_health_condition_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/subprocess/test_sidecar_health_condition_2_10_1.py
@@ -1,0 +1,325 @@
+import time
+import socket
+import pytest
+from unittest.mock import patch, MagicMock
+
+from mwaa.subprocess.conditions import SidecarHealthCondition, ProcessStatus, ProcessConditionResponse
+
+
+# ------------------------
+# Fixtures
+# ------------------------
+@pytest.fixture
+def sidecar_condition():
+    """Create a SidecarHealthCondition with no replacement threshold (default behavior)."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=0,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+@pytest.fixture
+def sidecar_condition_with_threshold():
+    """Create a SidecarHealthCondition with a 60-second replacement threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=60,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+@pytest.fixture
+def sidecar_condition_scheduler_with_threshold():
+    """Create a SidecarHealthCondition for scheduler with a 60-second replacement threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="scheduler",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=60,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+# ------------------------
+# Test: Initialization
+# ------------------------
+def test_initialization_default_threshold():
+    """Test that SidecarHealthCondition initializes with correct defaults."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+    )
+    assert condition.airflow_component == "worker"
+    assert condition.container_start_time == 1000.0
+    assert condition.last_healthy_time == 1000.0
+    assert condition.replacement_threshold == 0
+    assert condition.port == 8200
+
+
+def test_initialization_with_threshold():
+    """Test that SidecarHealthCondition initializes with custom threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=500.0,
+        port=9000,
+        replacement_threshold=1800,
+    )
+    assert condition.last_healthy_time == 500.0
+    assert condition.replacement_threshold == 1800
+    assert condition.port == 9000
+
+
+# ------------------------
+# Test: Healthy status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_healthy_status_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Healthy' status returns SUCCESS and updates last_healthy_time."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Healthy", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Healthy" in response.message
+    assert sidecar_condition.last_healthy_time == 2000.0
+    mock_logger.info.assert_called()
+
+
+# ------------------------
+# Test: Red status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_red_status_returns_fail(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Red' status returns FAIL and generates autorestart plog."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Red", ("127.0.0.1", 8200))
+
+    with patch('builtins.print') as mock_print:
+        response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is False
+    assert "Status received from sidecar: Red" in response.message
+    mock_logger.error.assert_called()
+    # Autorestart plog should be generated for failed responses
+    mock_print.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with no threshold (default behavior)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_no_threshold_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Blue' with no threshold configured returns SUCCESS."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_yellow_status_no_threshold_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Yellow' with no threshold configured returns SUCCESS."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Yellow", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Yellow" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold NOT exceeded
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_not_exceeded_returns_success(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Blue' with threshold configured but not exceeded returns SUCCESS."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1030.0 → 30s < 60s
+    mock_time.time.return_value = 1030.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold exceeded (worker)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_exceeded_worker_returns_fail(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Blue' with threshold exceeded on a worker returns FAIL."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1060.0 → 60s >= 60s
+    mock_time.time.return_value = 1060.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    with patch('builtins.print'):
+        response = sidecar_condition_with_threshold._check.__wrapped__(
+            sidecar_condition_with_threshold, ProcessStatus.RUNNING
+        )
+
+    assert response.successful is False
+    assert "No healthy heartbeat for 60s" in response.message
+    assert "configured threshold: 60s" in response.message
+    assert "Last sidecar status: Blue" in response.message
+    mock_logger.error.assert_called()
+
+
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_yellow_status_threshold_exceeded_worker_returns_fail(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Yellow' with threshold exceeded on a worker returns FAIL."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1120.0 → 120s >= 60s
+    mock_time.time.return_value = 1120.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Yellow", ("127.0.0.1", 8200))
+
+    with patch('builtins.print'):
+        response = sidecar_condition_with_threshold._check.__wrapped__(
+            sidecar_condition_with_threshold, ProcessStatus.RUNNING
+        )
+
+    assert response.successful is False
+    assert "No healthy heartbeat for 120s" in response.message
+    assert "Last sidecar status: Yellow" in response.message
+    mock_logger.error.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold exceeded (scheduler — should NOT trigger)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_exceeded_scheduler_returns_success(
+    mock_logger, mock_time, sidecar_condition_scheduler_with_threshold
+):
+    """Test that 'Blue' with threshold exceeded on a scheduler still returns SUCCESS."""
+    # Threshold only applies to workers, not schedulers
+    mock_time.time.return_value = 1120.0
+    sidecar_condition_scheduler_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_scheduler_with_threshold._check.__wrapped__(
+        sidecar_condition_scheduler_with_threshold, ProcessStatus.RUNNING
+    )
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Unknown/unexpected status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_unknown_status_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that an unexpected status string returns SUCCESS with a warning."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"SomethingUnexpected", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Unexpected response retrieved from sidecar" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Socket timeout after warmup period
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_socket_timeout_after_warmup_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that a socket timeout after the warmup period returns SUCCESS with error log."""
+    # container_start_time = 1000.0, _SIDECAR_WAIT_PERIOD = 300s
+    # current time = 1400.0 → 400s > 300s (past warmup)
+    mock_time.time.return_value = 1400.0
+    sidecar_condition.socket.recvfrom.side_effect = socket.timeout("timed out")
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "timed out" in response.message.lower()
+    mock_logger.error.assert_called()
+
+
+# ------------------------
+# Test: Socket timeout during warmup period
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_socket_timeout_during_warmup_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that a socket timeout during warmup returns SUCCESS with info log."""
+    # container_start_time = 1000.0, _SIDECAR_WAIT_PERIOD = 300s
+    # current time = 1100.0 → 100s < 300s (within warmup)
+    mock_time.time.return_value = 1100.0
+    sidecar_condition.socket.recvfrom.side_effect = socket.timeout("timed out")
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "just started" in response.message or "ignoring" in response.message.lower()
+    mock_logger.info.assert_called()
+
+
+# ------------------------
+# Test: Socket is None raises RuntimeError
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+def test_socket_none_raises_runtime_error(mock_time, sidecar_condition):
+    """Test that _check raises RuntimeError when socket is None."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket = None
+
+    with pytest.raises(RuntimeError, match="socket object and start time shouldn't be None"):
+        sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+
+# ------------------------
+# Test: Healthy status resets last_healthy_time (enables threshold recovery)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_healthy_resets_timer_preventing_threshold_trigger(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that receiving 'Healthy' resets last_healthy_time so threshold doesn't trigger later."""
+    # First call: receive Healthy at t=1050 → updates last_healthy_time
+    mock_time.time.return_value = 1050.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Healthy", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+    assert response.successful is True
+    assert sidecar_condition_with_threshold.last_healthy_time == 1050.0
+
+    # Second call: receive Blue at t=1090 → only 40s since last healthy (< 60s threshold)
+    mock_time.time.return_value = 1090.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+    assert response.successful is True

--- a/tests/images/airflow/2.10.1/python/mwaa/test_execute_command_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/test_execute_command_2_10_1.py
@@ -146,3 +146,83 @@ def test_execute_command_task_monitoring_enabled(mock_shared_memory, mock_worker
 
 
 
+
+
+
+# ------------------------
+# Tests for replacement threshold parsing
+# ------------------------
+
+class TestReplacementThresholdParsing:
+    """Tests for WORKER_REPLACEMENT_THRESHOLD_SECONDS env var parsing in _create_airflow_process_conditions."""
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_valid_positive_threshold(self, mock_port, mock_enabled):
+        """Valid positive integer is accepted."""
+        from mwaa.execute_command import _create_airflow_process_conditions, CONTAINER_START_TIME
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "300"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert len(sidecar_cond) == 1
+        assert sidecar_cond[0].replacement_threshold == 300
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_zero_threshold(self, mock_port, mock_enabled):
+        """Zero means disabled."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "0"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_negative_threshold_defaults_to_zero(self, mock_port, mock_enabled):
+        """Negative value is clamped to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "-100"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_non_integer_string_defaults_to_zero(self, mock_port, mock_enabled):
+        """Arbitrary string like 'abc' defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "abc"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_decimal_string_is_floored(self, mock_port, mock_enabled):
+        """Decimal like '30.5' is floored to 30."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "30.5"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 30
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_empty_string_defaults_to_zero(self, mock_port, mock_enabled):
+        """Empty string defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": ""}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_env_var_not_set_defaults_to_zero(self, mock_port, mock_enabled):
+        """When the env var is not set, defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0

--- a/tests/images/airflow/2.10.3/python/mwaa/subprocess/test_sidecar_health_condition_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/subprocess/test_sidecar_health_condition_2_10_3.py
@@ -1,0 +1,325 @@
+import time
+import socket
+import pytest
+from unittest.mock import patch, MagicMock
+
+from mwaa.subprocess.conditions import SidecarHealthCondition, ProcessStatus, ProcessConditionResponse
+
+
+# ------------------------
+# Fixtures
+# ------------------------
+@pytest.fixture
+def sidecar_condition():
+    """Create a SidecarHealthCondition with no replacement threshold (default behavior)."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=0,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+@pytest.fixture
+def sidecar_condition_with_threshold():
+    """Create a SidecarHealthCondition with a 60-second replacement threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=60,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+@pytest.fixture
+def sidecar_condition_scheduler_with_threshold():
+    """Create a SidecarHealthCondition for scheduler with a 60-second replacement threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="scheduler",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=60,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+# ------------------------
+# Test: Initialization
+# ------------------------
+def test_initialization_default_threshold():
+    """Test that SidecarHealthCondition initializes with correct defaults."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+    )
+    assert condition.airflow_component == "worker"
+    assert condition.container_start_time == 1000.0
+    assert condition.last_healthy_time == 1000.0
+    assert condition.replacement_threshold == 0
+    assert condition.port == 8200
+
+
+def test_initialization_with_threshold():
+    """Test that SidecarHealthCondition initializes with custom threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=500.0,
+        port=9000,
+        replacement_threshold=1800,
+    )
+    assert condition.last_healthy_time == 500.0
+    assert condition.replacement_threshold == 1800
+    assert condition.port == 9000
+
+
+# ------------------------
+# Test: Healthy status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_healthy_status_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Healthy' status returns SUCCESS and updates last_healthy_time."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Healthy", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Healthy" in response.message
+    assert sidecar_condition.last_healthy_time == 2000.0
+    mock_logger.info.assert_called()
+
+
+# ------------------------
+# Test: Red status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_red_status_returns_fail(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Red' status returns FAIL and generates autorestart plog."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Red", ("127.0.0.1", 8200))
+
+    with patch('builtins.print') as mock_print:
+        response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is False
+    assert "Status received from sidecar: Red" in response.message
+    mock_logger.error.assert_called()
+    # Autorestart plog should be generated for failed responses
+    mock_print.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with no threshold (default behavior)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_no_threshold_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Blue' with no threshold configured returns SUCCESS."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_yellow_status_no_threshold_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Yellow' with no threshold configured returns SUCCESS."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Yellow", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Yellow" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold NOT exceeded
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_not_exceeded_returns_success(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Blue' with threshold configured but not exceeded returns SUCCESS."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1030.0 → 30s < 60s
+    mock_time.time.return_value = 1030.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold exceeded (worker)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_exceeded_worker_returns_fail(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Blue' with threshold exceeded on a worker returns FAIL."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1060.0 → 60s >= 60s
+    mock_time.time.return_value = 1060.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    with patch('builtins.print'):
+        response = sidecar_condition_with_threshold._check.__wrapped__(
+            sidecar_condition_with_threshold, ProcessStatus.RUNNING
+        )
+
+    assert response.successful is False
+    assert "No healthy heartbeat for 60s" in response.message
+    assert "configured threshold: 60s" in response.message
+    assert "Last sidecar status: Blue" in response.message
+    mock_logger.error.assert_called()
+
+
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_yellow_status_threshold_exceeded_worker_returns_fail(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Yellow' with threshold exceeded on a worker returns FAIL."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1120.0 → 120s >= 60s
+    mock_time.time.return_value = 1120.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Yellow", ("127.0.0.1", 8200))
+
+    with patch('builtins.print'):
+        response = sidecar_condition_with_threshold._check.__wrapped__(
+            sidecar_condition_with_threshold, ProcessStatus.RUNNING
+        )
+
+    assert response.successful is False
+    assert "No healthy heartbeat for 120s" in response.message
+    assert "Last sidecar status: Yellow" in response.message
+    mock_logger.error.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold exceeded (scheduler — should NOT trigger)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_exceeded_scheduler_returns_success(
+    mock_logger, mock_time, sidecar_condition_scheduler_with_threshold
+):
+    """Test that 'Blue' with threshold exceeded on a scheduler still returns SUCCESS."""
+    # Threshold only applies to workers, not schedulers
+    mock_time.time.return_value = 1120.0
+    sidecar_condition_scheduler_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_scheduler_with_threshold._check.__wrapped__(
+        sidecar_condition_scheduler_with_threshold, ProcessStatus.RUNNING
+    )
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Unknown/unexpected status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_unknown_status_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that an unexpected status string returns SUCCESS with a warning."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"SomethingUnexpected", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Unexpected response retrieved from sidecar" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Socket timeout after warmup period
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_socket_timeout_after_warmup_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that a socket timeout after the warmup period returns SUCCESS with error log."""
+    # container_start_time = 1000.0, _SIDECAR_WAIT_PERIOD = 300s
+    # current time = 1400.0 → 400s > 300s (past warmup)
+    mock_time.time.return_value = 1400.0
+    sidecar_condition.socket.recvfrom.side_effect = socket.timeout("timed out")
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "timed out" in response.message.lower()
+    mock_logger.error.assert_called()
+
+
+# ------------------------
+# Test: Socket timeout during warmup period
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_socket_timeout_during_warmup_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that a socket timeout during warmup returns SUCCESS with info log."""
+    # container_start_time = 1000.0, _SIDECAR_WAIT_PERIOD = 300s
+    # current time = 1100.0 → 100s < 300s (within warmup)
+    mock_time.time.return_value = 1100.0
+    sidecar_condition.socket.recvfrom.side_effect = socket.timeout("timed out")
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "just started" in response.message or "ignoring" in response.message.lower()
+    mock_logger.info.assert_called()
+
+
+# ------------------------
+# Test: Socket is None raises RuntimeError
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+def test_socket_none_raises_runtime_error(mock_time, sidecar_condition):
+    """Test that _check raises RuntimeError when socket is None."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket = None
+
+    with pytest.raises(RuntimeError, match="socket object and start time shouldn't be None"):
+        sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+
+# ------------------------
+# Test: Healthy status resets last_healthy_time (enables threshold recovery)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_healthy_resets_timer_preventing_threshold_trigger(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that receiving 'Healthy' resets last_healthy_time so threshold doesn't trigger later."""
+    # First call: receive Healthy at t=1050 → updates last_healthy_time
+    mock_time.time.return_value = 1050.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Healthy", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+    assert response.successful is True
+    assert sidecar_condition_with_threshold.last_healthy_time == 1050.0
+
+    # Second call: receive Blue at t=1090 → only 40s since last healthy (< 60s threshold)
+    mock_time.time.return_value = 1090.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+    assert response.successful is True

--- a/tests/images/airflow/2.10.3/python/mwaa/test_execute_command_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/test_execute_command_2_10_3.py
@@ -146,3 +146,82 @@ def test_execute_command_task_monitoring_enabled(mock_shared_memory, mock_worker
 
 
 
+
+
+# ------------------------
+# Tests for replacement threshold parsing
+# ------------------------
+
+class TestReplacementThresholdParsing:
+    """Tests for WORKER_REPLACEMENT_THRESHOLD_SECONDS env var parsing in _create_airflow_process_conditions."""
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_valid_positive_threshold(self, mock_port, mock_enabled):
+        """Valid positive integer is accepted."""
+        from mwaa.execute_command import _create_airflow_process_conditions, CONTAINER_START_TIME
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "300"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert len(sidecar_cond) == 1
+        assert sidecar_cond[0].replacement_threshold == 300
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_zero_threshold(self, mock_port, mock_enabled):
+        """Zero means disabled."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "0"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_negative_threshold_defaults_to_zero(self, mock_port, mock_enabled):
+        """Negative value is clamped to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "-100"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_non_integer_string_defaults_to_zero(self, mock_port, mock_enabled):
+        """Arbitrary string like 'abc' defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "abc"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_decimal_string_is_floored(self, mock_port, mock_enabled):
+        """Decimal like '30.5' is floored to 30."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "30.5"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 30
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_empty_string_defaults_to_zero(self, mock_port, mock_enabled):
+        """Empty string defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": ""}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_env_var_not_set_defaults_to_zero(self, mock_port, mock_enabled):
+        """When the env var is not set, defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0

--- a/tests/images/airflow/2.11.0/python/mwaa/subprocess/test_sidecar_health_condition_2_11_0.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/subprocess/test_sidecar_health_condition_2_11_0.py
@@ -1,0 +1,325 @@
+import time
+import socket
+import pytest
+from unittest.mock import patch, MagicMock
+
+from mwaa.subprocess.conditions import SidecarHealthCondition, ProcessStatus, ProcessConditionResponse
+
+
+# ------------------------
+# Fixtures
+# ------------------------
+@pytest.fixture
+def sidecar_condition():
+    """Create a SidecarHealthCondition with no replacement threshold (default behavior)."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=0,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+@pytest.fixture
+def sidecar_condition_with_threshold():
+    """Create a SidecarHealthCondition with a 60-second replacement threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=60,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+@pytest.fixture
+def sidecar_condition_scheduler_with_threshold():
+    """Create a SidecarHealthCondition for scheduler with a 60-second replacement threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="scheduler",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=60,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+# ------------------------
+# Test: Initialization
+# ------------------------
+def test_initialization_default_threshold():
+    """Test that SidecarHealthCondition initializes with correct defaults."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+    )
+    assert condition.airflow_component == "worker"
+    assert condition.container_start_time == 1000.0
+    assert condition.last_healthy_time == 1000.0
+    assert condition.replacement_threshold == 0
+    assert condition.port == 8200
+
+
+def test_initialization_with_threshold():
+    """Test that SidecarHealthCondition initializes with custom threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=500.0,
+        port=9000,
+        replacement_threshold=1800,
+    )
+    assert condition.last_healthy_time == 500.0
+    assert condition.replacement_threshold == 1800
+    assert condition.port == 9000
+
+
+# ------------------------
+# Test: Healthy status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_healthy_status_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Healthy' status returns SUCCESS and updates last_healthy_time."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Healthy", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Healthy" in response.message
+    assert sidecar_condition.last_healthy_time == 2000.0
+    mock_logger.info.assert_called()
+
+
+# ------------------------
+# Test: Red status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_red_status_returns_fail(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Red' status returns FAIL and generates autorestart plog."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Red", ("127.0.0.1", 8200))
+
+    with patch('builtins.print') as mock_print:
+        response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is False
+    assert "Status received from sidecar: Red" in response.message
+    mock_logger.error.assert_called()
+    # Autorestart plog should be generated for failed responses
+    mock_print.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with no threshold (default behavior)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_no_threshold_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Blue' with no threshold configured returns SUCCESS."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_yellow_status_no_threshold_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Yellow' with no threshold configured returns SUCCESS."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Yellow", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Yellow" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold NOT exceeded
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_not_exceeded_returns_success(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Blue' with threshold configured but not exceeded returns SUCCESS."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1030.0 → 30s < 60s
+    mock_time.time.return_value = 1030.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold exceeded (worker)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_exceeded_worker_returns_fail(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Blue' with threshold exceeded on a worker returns FAIL."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1060.0 → 60s >= 60s
+    mock_time.time.return_value = 1060.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    with patch('builtins.print'):
+        response = sidecar_condition_with_threshold._check.__wrapped__(
+            sidecar_condition_with_threshold, ProcessStatus.RUNNING
+        )
+
+    assert response.successful is False
+    assert "No healthy heartbeat for 60s" in response.message
+    assert "configured threshold: 60s" in response.message
+    assert "Last sidecar status: Blue" in response.message
+    mock_logger.error.assert_called()
+
+
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_yellow_status_threshold_exceeded_worker_returns_fail(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Yellow' with threshold exceeded on a worker returns FAIL."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1120.0 → 120s >= 60s
+    mock_time.time.return_value = 1120.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Yellow", ("127.0.0.1", 8200))
+
+    with patch('builtins.print'):
+        response = sidecar_condition_with_threshold._check.__wrapped__(
+            sidecar_condition_with_threshold, ProcessStatus.RUNNING
+        )
+
+    assert response.successful is False
+    assert "No healthy heartbeat for 120s" in response.message
+    assert "Last sidecar status: Yellow" in response.message
+    mock_logger.error.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold exceeded (scheduler — should NOT trigger)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_exceeded_scheduler_returns_success(
+    mock_logger, mock_time, sidecar_condition_scheduler_with_threshold
+):
+    """Test that 'Blue' with threshold exceeded on a scheduler still returns SUCCESS."""
+    # Threshold only applies to workers, not schedulers
+    mock_time.time.return_value = 1120.0
+    sidecar_condition_scheduler_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_scheduler_with_threshold._check.__wrapped__(
+        sidecar_condition_scheduler_with_threshold, ProcessStatus.RUNNING
+    )
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Unknown/unexpected status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_unknown_status_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that an unexpected status string returns SUCCESS with a warning."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"SomethingUnexpected", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Unexpected response retrieved from sidecar" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Socket timeout after warmup period
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_socket_timeout_after_warmup_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that a socket timeout after the warmup period returns SUCCESS with error log."""
+    # container_start_time = 1000.0, _SIDECAR_WAIT_PERIOD = 300s
+    # current time = 1400.0 → 400s > 300s (past warmup)
+    mock_time.time.return_value = 1400.0
+    sidecar_condition.socket.recvfrom.side_effect = socket.timeout("timed out")
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "timed out" in response.message.lower()
+    mock_logger.error.assert_called()
+
+
+# ------------------------
+# Test: Socket timeout during warmup period
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_socket_timeout_during_warmup_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that a socket timeout during warmup returns SUCCESS with info log."""
+    # container_start_time = 1000.0, _SIDECAR_WAIT_PERIOD = 300s
+    # current time = 1100.0 → 100s < 300s (within warmup)
+    mock_time.time.return_value = 1100.0
+    sidecar_condition.socket.recvfrom.side_effect = socket.timeout("timed out")
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "just started" in response.message or "ignoring" in response.message.lower()
+    mock_logger.info.assert_called()
+
+
+# ------------------------
+# Test: Socket is None raises RuntimeError
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+def test_socket_none_raises_runtime_error(mock_time, sidecar_condition):
+    """Test that _check raises RuntimeError when socket is None."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket = None
+
+    with pytest.raises(RuntimeError, match="socket object and start time shouldn't be None"):
+        sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+
+# ------------------------
+# Test: Healthy status resets last_healthy_time (enables threshold recovery)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_healthy_resets_timer_preventing_threshold_trigger(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that receiving 'Healthy' resets last_healthy_time so threshold doesn't trigger later."""
+    # First call: receive Healthy at t=1050 → updates last_healthy_time
+    mock_time.time.return_value = 1050.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Healthy", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+    assert response.successful is True
+    assert sidecar_condition_with_threshold.last_healthy_time == 1050.0
+
+    # Second call: receive Blue at t=1090 → only 40s since last healthy (< 60s threshold)
+    mock_time.time.return_value = 1090.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+    assert response.successful is True

--- a/tests/images/airflow/2.11.0/python/mwaa/test_execute_command_2_11_0.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/test_execute_command_2_11_0.py
@@ -146,3 +146,83 @@ def test_execute_command_task_monitoring_enabled(mock_shared_memory, mock_worker
 
 
 
+
+
+
+# ------------------------
+# Tests for replacement threshold parsing
+# ------------------------
+
+class TestReplacementThresholdParsing:
+    """Tests for WORKER_REPLACEMENT_THRESHOLD_SECONDS env var parsing in _create_airflow_process_conditions."""
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_valid_positive_threshold(self, mock_port, mock_enabled):
+        """Valid positive integer is accepted."""
+        from mwaa.execute_command import _create_airflow_process_conditions, CONTAINER_START_TIME
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "300"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert len(sidecar_cond) == 1
+        assert sidecar_cond[0].replacement_threshold == 300
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_zero_threshold(self, mock_port, mock_enabled):
+        """Zero means disabled."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "0"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_negative_threshold_defaults_to_zero(self, mock_port, mock_enabled):
+        """Negative value is clamped to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "-100"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_non_integer_string_defaults_to_zero(self, mock_port, mock_enabled):
+        """Arbitrary string like 'abc' defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "abc"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_decimal_string_is_floored(self, mock_port, mock_enabled):
+        """Decimal like '30.5' is floored to 30."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "30.5"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 30
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_empty_string_defaults_to_zero(self, mock_port, mock_enabled):
+        """Empty string defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": ""}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_env_var_not_set_defaults_to_zero(self, mock_port, mock_enabled):
+        """When the env var is not set, defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0

--- a/tests/images/airflow/2.9.2/python/mwaa/subprocess/test_sidecar_health_condition_2_9_2.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/subprocess/test_sidecar_health_condition_2_9_2.py
@@ -1,0 +1,325 @@
+import time
+import socket
+import pytest
+from unittest.mock import patch, MagicMock
+
+from mwaa.subprocess.conditions import SidecarHealthCondition, ProcessStatus, ProcessConditionResponse
+
+
+# ------------------------
+# Fixtures
+# ------------------------
+@pytest.fixture
+def sidecar_condition():
+    """Create a SidecarHealthCondition with no replacement threshold (default behavior)."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=0,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+@pytest.fixture
+def sidecar_condition_with_threshold():
+    """Create a SidecarHealthCondition with a 60-second replacement threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=60,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+@pytest.fixture
+def sidecar_condition_scheduler_with_threshold():
+    """Create a SidecarHealthCondition for scheduler with a 60-second replacement threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="scheduler",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=60,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+# ------------------------
+# Test: Initialization
+# ------------------------
+def test_initialization_default_threshold():
+    """Test that SidecarHealthCondition initializes with correct defaults."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+    )
+    assert condition.airflow_component == "worker"
+    assert condition.container_start_time == 1000.0
+    assert condition.last_healthy_time == 1000.0
+    assert condition.replacement_threshold == 0
+    assert condition.port == 8200
+
+
+def test_initialization_with_threshold():
+    """Test that SidecarHealthCondition initializes with custom threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=500.0,
+        port=9000,
+        replacement_threshold=1800,
+    )
+    assert condition.last_healthy_time == 500.0
+    assert condition.replacement_threshold == 1800
+    assert condition.port == 9000
+
+
+# ------------------------
+# Test: Healthy status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_healthy_status_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Healthy' status returns SUCCESS and updates last_healthy_time."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Healthy", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Healthy" in response.message
+    assert sidecar_condition.last_healthy_time == 2000.0
+    mock_logger.info.assert_called()
+
+
+# ------------------------
+# Test: Red status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_red_status_returns_fail(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Red' status returns FAIL and generates autorestart plog."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Red", ("127.0.0.1", 8200))
+
+    with patch('builtins.print') as mock_print:
+        response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is False
+    assert "Status received from sidecar: Red" in response.message
+    mock_logger.error.assert_called()
+    # Autorestart plog should be generated for failed responses
+    mock_print.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with no threshold (default behavior)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_no_threshold_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Blue' with no threshold configured returns SUCCESS."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_yellow_status_no_threshold_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Yellow' with no threshold configured returns SUCCESS."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Yellow", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Yellow" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold NOT exceeded
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_not_exceeded_returns_success(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Blue' with threshold configured but not exceeded returns SUCCESS."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1030.0 → 30s < 60s
+    mock_time.time.return_value = 1030.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold exceeded (worker)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_exceeded_worker_returns_fail(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Blue' with threshold exceeded on a worker returns FAIL."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1060.0 → 60s >= 60s
+    mock_time.time.return_value = 1060.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    with patch('builtins.print'):
+        response = sidecar_condition_with_threshold._check.__wrapped__(
+            sidecar_condition_with_threshold, ProcessStatus.RUNNING
+        )
+
+    assert response.successful is False
+    assert "No healthy heartbeat for 60s" in response.message
+    assert "configured threshold: 60s" in response.message
+    assert "Last sidecar status: Blue" in response.message
+    mock_logger.error.assert_called()
+
+
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_yellow_status_threshold_exceeded_worker_returns_fail(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Yellow' with threshold exceeded on a worker returns FAIL."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1120.0 → 120s >= 60s
+    mock_time.time.return_value = 1120.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Yellow", ("127.0.0.1", 8200))
+
+    with patch('builtins.print'):
+        response = sidecar_condition_with_threshold._check.__wrapped__(
+            sidecar_condition_with_threshold, ProcessStatus.RUNNING
+        )
+
+    assert response.successful is False
+    assert "No healthy heartbeat for 120s" in response.message
+    assert "Last sidecar status: Yellow" in response.message
+    mock_logger.error.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold exceeded (scheduler — should NOT trigger)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_exceeded_scheduler_returns_success(
+    mock_logger, mock_time, sidecar_condition_scheduler_with_threshold
+):
+    """Test that 'Blue' with threshold exceeded on a scheduler still returns SUCCESS."""
+    # Threshold only applies to workers, not schedulers
+    mock_time.time.return_value = 1120.0
+    sidecar_condition_scheduler_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_scheduler_with_threshold._check.__wrapped__(
+        sidecar_condition_scheduler_with_threshold, ProcessStatus.RUNNING
+    )
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Unknown/unexpected status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_unknown_status_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that an unexpected status string returns SUCCESS with a warning."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"SomethingUnexpected", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Unexpected response retrieved from sidecar" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Socket timeout after warmup period
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_socket_timeout_after_warmup_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that a socket timeout after the warmup period returns SUCCESS with error log."""
+    # container_start_time = 1000.0, _SIDECAR_WAIT_PERIOD = 300s
+    # current time = 1400.0 → 400s > 300s (past warmup)
+    mock_time.time.return_value = 1400.0
+    sidecar_condition.socket.recvfrom.side_effect = socket.timeout("timed out")
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "timed out" in response.message.lower()
+    mock_logger.error.assert_called()
+
+
+# ------------------------
+# Test: Socket timeout during warmup period
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_socket_timeout_during_warmup_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that a socket timeout during warmup returns SUCCESS with info log."""
+    # container_start_time = 1000.0, _SIDECAR_WAIT_PERIOD = 300s
+    # current time = 1100.0 → 100s < 300s (within warmup)
+    mock_time.time.return_value = 1100.0
+    sidecar_condition.socket.recvfrom.side_effect = socket.timeout("timed out")
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "just started" in response.message or "ignoring" in response.message.lower()
+    mock_logger.info.assert_called()
+
+
+# ------------------------
+# Test: Socket is None raises RuntimeError
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+def test_socket_none_raises_runtime_error(mock_time, sidecar_condition):
+    """Test that _check raises RuntimeError when socket is None."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket = None
+
+    with pytest.raises(RuntimeError, match="socket object and start time shouldn't be None"):
+        sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+
+# ------------------------
+# Test: Healthy status resets last_healthy_time (enables threshold recovery)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_healthy_resets_timer_preventing_threshold_trigger(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that receiving 'Healthy' resets last_healthy_time so threshold doesn't trigger later."""
+    # First call: receive Healthy at t=1050 → updates last_healthy_time
+    mock_time.time.return_value = 1050.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Healthy", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+    assert response.successful is True
+    assert sidecar_condition_with_threshold.last_healthy_time == 1050.0
+
+    # Second call: receive Blue at t=1090 → only 40s since last healthy (< 60s threshold)
+    mock_time.time.return_value = 1090.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+    assert response.successful is True

--- a/tests/images/airflow/2.9.2/python/mwaa/test_execute_command_2_9_2.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/test_execute_command_2_9_2.py
@@ -146,3 +146,83 @@ def test_execute_command_task_monitoring_enabled(mock_shared_memory, mock_worker
 
 
 
+
+
+
+# ------------------------
+# Tests for replacement threshold parsing
+# ------------------------
+
+class TestReplacementThresholdParsing:
+    """Tests for WORKER_REPLACEMENT_THRESHOLD_SECONDS env var parsing in _create_airflow_process_conditions."""
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_valid_positive_threshold(self, mock_port, mock_enabled):
+        """Valid positive integer is accepted."""
+        from mwaa.execute_command import _create_airflow_process_conditions, CONTAINER_START_TIME
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "300"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert len(sidecar_cond) == 1
+        assert sidecar_cond[0].replacement_threshold == 300
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_zero_threshold(self, mock_port, mock_enabled):
+        """Zero means disabled."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "0"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_negative_threshold_defaults_to_zero(self, mock_port, mock_enabled):
+        """Negative value is clamped to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "-100"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_non_integer_string_defaults_to_zero(self, mock_port, mock_enabled):
+        """Arbitrary string like 'abc' defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "abc"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_decimal_string_is_floored(self, mock_port, mock_enabled):
+        """Decimal like '30.5' is floored to 30."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "30.5"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 30
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_empty_string_defaults_to_zero(self, mock_port, mock_enabled):
+        """Empty string defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": ""}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_env_var_not_set_defaults_to_zero(self, mock_port, mock_enabled):
+        """When the env var is not set, defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0

--- a/tests/images/airflow/3.0.6/python/mwaa/subprocess/test_sidecar_health_condition_3_0_6.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/subprocess/test_sidecar_health_condition_3_0_6.py
@@ -1,0 +1,325 @@
+import time
+import socket
+import pytest
+from unittest.mock import patch, MagicMock
+
+from mwaa.subprocess.conditions import SidecarHealthCondition, ProcessStatus, ProcessConditionResponse
+
+
+# ------------------------
+# Fixtures
+# ------------------------
+@pytest.fixture
+def sidecar_condition():
+    """Create a SidecarHealthCondition with no replacement threshold (default behavior)."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=0,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+@pytest.fixture
+def sidecar_condition_with_threshold():
+    """Create a SidecarHealthCondition with a 60-second replacement threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=60,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+@pytest.fixture
+def sidecar_condition_scheduler_with_threshold():
+    """Create a SidecarHealthCondition for scheduler with a 60-second replacement threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="scheduler",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=60,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+# ------------------------
+# Test: Initialization
+# ------------------------
+def test_initialization_default_threshold():
+    """Test that SidecarHealthCondition initializes with correct defaults."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+    )
+    assert condition.airflow_component == "worker"
+    assert condition.container_start_time == 1000.0
+    assert condition.last_healthy_time == 1000.0
+    assert condition.replacement_threshold == 0
+    assert condition.port == 8200
+
+
+def test_initialization_with_threshold():
+    """Test that SidecarHealthCondition initializes with custom threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=500.0,
+        port=9000,
+        replacement_threshold=1800,
+    )
+    assert condition.last_healthy_time == 500.0
+    assert condition.replacement_threshold == 1800
+    assert condition.port == 9000
+
+
+# ------------------------
+# Test: Healthy status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_healthy_status_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Healthy' status returns SUCCESS and updates last_healthy_time."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Healthy", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Healthy" in response.message
+    assert sidecar_condition.last_healthy_time == 2000.0
+    mock_logger.info.assert_called()
+
+
+# ------------------------
+# Test: Red status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_red_status_returns_fail(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Red' status returns FAIL and generates autorestart plog."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Red", ("127.0.0.1", 8200))
+
+    with patch('builtins.print') as mock_print:
+        response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is False
+    assert "Status received from sidecar: Red" in response.message
+    mock_logger.error.assert_called()
+    # Autorestart plog should be generated for failed responses
+    mock_print.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with no threshold (default behavior)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_no_threshold_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Blue' with no threshold configured returns SUCCESS."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_yellow_status_no_threshold_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Yellow' with no threshold configured returns SUCCESS."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Yellow", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Yellow" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold NOT exceeded
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_not_exceeded_returns_success(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Blue' with threshold configured but not exceeded returns SUCCESS."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1030.0 → 30s < 60s
+    mock_time.time.return_value = 1030.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold exceeded (worker)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_exceeded_worker_returns_fail(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Blue' with threshold exceeded on a worker returns FAIL."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1060.0 → 60s >= 60s
+    mock_time.time.return_value = 1060.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    with patch('builtins.print'):
+        response = sidecar_condition_with_threshold._check.__wrapped__(
+            sidecar_condition_with_threshold, ProcessStatus.RUNNING
+        )
+
+    assert response.successful is False
+    assert "No healthy heartbeat for 60s" in response.message
+    assert "configured threshold: 60s" in response.message
+    assert "Last sidecar status: Blue" in response.message
+    mock_logger.error.assert_called()
+
+
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_yellow_status_threshold_exceeded_worker_returns_fail(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Yellow' with threshold exceeded on a worker returns FAIL."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1120.0 → 120s >= 60s
+    mock_time.time.return_value = 1120.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Yellow", ("127.0.0.1", 8200))
+
+    with patch('builtins.print'):
+        response = sidecar_condition_with_threshold._check.__wrapped__(
+            sidecar_condition_with_threshold, ProcessStatus.RUNNING
+        )
+
+    assert response.successful is False
+    assert "No healthy heartbeat for 120s" in response.message
+    assert "Last sidecar status: Yellow" in response.message
+    mock_logger.error.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold exceeded (scheduler — should NOT trigger)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_exceeded_scheduler_returns_success(
+    mock_logger, mock_time, sidecar_condition_scheduler_with_threshold
+):
+    """Test that 'Blue' with threshold exceeded on a scheduler still returns SUCCESS."""
+    # Threshold only applies to workers, not schedulers
+    mock_time.time.return_value = 1120.0
+    sidecar_condition_scheduler_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_scheduler_with_threshold._check.__wrapped__(
+        sidecar_condition_scheduler_with_threshold, ProcessStatus.RUNNING
+    )
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Unknown/unexpected status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_unknown_status_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that an unexpected status string returns SUCCESS with a warning."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"SomethingUnexpected", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Unexpected response retrieved from sidecar" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Socket timeout after warmup period
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_socket_timeout_after_warmup_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that a socket timeout after the warmup period returns SUCCESS with error log."""
+    # container_start_time = 1000.0, _SIDECAR_WAIT_PERIOD = 300s
+    # current time = 1400.0 → 400s > 300s (past warmup)
+    mock_time.time.return_value = 1400.0
+    sidecar_condition.socket.recvfrom.side_effect = socket.timeout("timed out")
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "timed out" in response.message.lower()
+    mock_logger.error.assert_called()
+
+
+# ------------------------
+# Test: Socket timeout during warmup period
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_socket_timeout_during_warmup_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that a socket timeout during warmup returns SUCCESS with info log."""
+    # container_start_time = 1000.0, _SIDECAR_WAIT_PERIOD = 300s
+    # current time = 1100.0 → 100s < 300s (within warmup)
+    mock_time.time.return_value = 1100.0
+    sidecar_condition.socket.recvfrom.side_effect = socket.timeout("timed out")
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "just started" in response.message or "ignoring" in response.message.lower()
+    mock_logger.info.assert_called()
+
+
+# ------------------------
+# Test: Socket is None raises RuntimeError
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+def test_socket_none_raises_runtime_error(mock_time, sidecar_condition):
+    """Test that _check raises RuntimeError when socket is None."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket = None
+
+    with pytest.raises(RuntimeError, match="socket object and start time shouldn't be None"):
+        sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+
+# ------------------------
+# Test: Healthy status resets last_healthy_time (enables threshold recovery)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_healthy_resets_timer_preventing_threshold_trigger(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that receiving 'Healthy' resets last_healthy_time so threshold doesn't trigger later."""
+    # First call: receive Healthy at t=1050 → updates last_healthy_time
+    mock_time.time.return_value = 1050.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Healthy", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+    assert response.successful is True
+    assert sidecar_condition_with_threshold.last_healthy_time == 1050.0
+
+    # Second call: receive Blue at t=1090 → only 40s since last healthy (< 60s threshold)
+    mock_time.time.return_value = 1090.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+    assert response.successful is True

--- a/tests/images/airflow/3.0.6/python/mwaa/test_execute_command.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/test_execute_command.py
@@ -143,3 +143,83 @@ def test_execute_command_task_monitoring_enabled(mock_shared_memory, mock_worker
 
     # Verify run_subprocesses was called
     mock_run_subprocesses.assert_called()
+
+
+
+# ------------------------
+# Tests for replacement threshold parsing
+# ------------------------
+
+class TestReplacementThresholdParsing:
+    """Tests for WORKER_REPLACEMENT_THRESHOLD_SECONDS env var parsing in _create_airflow_process_conditions."""
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_valid_positive_threshold(self, mock_port, mock_enabled):
+        """Valid positive integer is accepted."""
+        from mwaa.execute_command import _create_airflow_process_conditions, CONTAINER_START_TIME
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "300"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert len(sidecar_cond) == 1
+        assert sidecar_cond[0].replacement_threshold == 300
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_zero_threshold(self, mock_port, mock_enabled):
+        """Zero means disabled."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "0"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_negative_threshold_defaults_to_zero(self, mock_port, mock_enabled):
+        """Negative value is clamped to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "-100"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_non_integer_string_defaults_to_zero(self, mock_port, mock_enabled):
+        """Arbitrary string like 'abc' defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "abc"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_decimal_string_is_floored(self, mock_port, mock_enabled):
+        """Decimal like '30.5' is floored to 30."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "30.5"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 30
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_empty_string_defaults_to_zero(self, mock_port, mock_enabled):
+        """Empty string defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": ""}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_env_var_not_set_defaults_to_zero(self, mock_port, mock_enabled):
+        """When the env var is not set, defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0

--- a/tests/images/airflow/3.2.1/python/mwaa/subprocess/test_sidecar_health_condition_3_2_1.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/subprocess/test_sidecar_health_condition_3_2_1.py
@@ -1,0 +1,325 @@
+import time
+import socket
+import pytest
+from unittest.mock import patch, MagicMock
+
+from mwaa.subprocess.conditions import SidecarHealthCondition, ProcessStatus, ProcessConditionResponse
+
+
+# ------------------------
+# Fixtures
+# ------------------------
+@pytest.fixture
+def sidecar_condition():
+    """Create a SidecarHealthCondition with no replacement threshold (default behavior)."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=0,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+@pytest.fixture
+def sidecar_condition_with_threshold():
+    """Create a SidecarHealthCondition with a 60-second replacement threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=60,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+@pytest.fixture
+def sidecar_condition_scheduler_with_threshold():
+    """Create a SidecarHealthCondition for scheduler with a 60-second replacement threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="scheduler",
+        container_start_time=1000.0,
+        port=8200,
+        replacement_threshold=60,
+    )
+    condition.socket = MagicMock()
+    return condition
+
+
+# ------------------------
+# Test: Initialization
+# ------------------------
+def test_initialization_default_threshold():
+    """Test that SidecarHealthCondition initializes with correct defaults."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=1000.0,
+    )
+    assert condition.airflow_component == "worker"
+    assert condition.container_start_time == 1000.0
+    assert condition.last_healthy_time == 1000.0
+    assert condition.replacement_threshold == 0
+    assert condition.port == 8200
+
+
+def test_initialization_with_threshold():
+    """Test that SidecarHealthCondition initializes with custom threshold."""
+    condition = SidecarHealthCondition(
+        airflow_component="worker",
+        container_start_time=500.0,
+        port=9000,
+        replacement_threshold=1800,
+    )
+    assert condition.last_healthy_time == 500.0
+    assert condition.replacement_threshold == 1800
+    assert condition.port == 9000
+
+
+# ------------------------
+# Test: Healthy status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_healthy_status_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Healthy' status returns SUCCESS and updates last_healthy_time."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Healthy", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Healthy" in response.message
+    assert sidecar_condition.last_healthy_time == 2000.0
+    mock_logger.info.assert_called()
+
+
+# ------------------------
+# Test: Red status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_red_status_returns_fail(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Red' status returns FAIL and generates autorestart plog."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Red", ("127.0.0.1", 8200))
+
+    with patch('builtins.print') as mock_print:
+        response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is False
+    assert "Status received from sidecar: Red" in response.message
+    mock_logger.error.assert_called()
+    # Autorestart plog should be generated for failed responses
+    mock_print.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with no threshold (default behavior)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_no_threshold_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Blue' with no threshold configured returns SUCCESS."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_yellow_status_no_threshold_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that 'Yellow' with no threshold configured returns SUCCESS."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"Yellow", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Status received from sidecar: Yellow" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold NOT exceeded
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_not_exceeded_returns_success(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Blue' with threshold configured but not exceeded returns SUCCESS."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1030.0 → 30s < 60s
+    mock_time.time.return_value = 1030.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold exceeded (worker)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_exceeded_worker_returns_fail(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Blue' with threshold exceeded on a worker returns FAIL."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1060.0 → 60s >= 60s
+    mock_time.time.return_value = 1060.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    with patch('builtins.print'):
+        response = sidecar_condition_with_threshold._check.__wrapped__(
+            sidecar_condition_with_threshold, ProcessStatus.RUNNING
+        )
+
+    assert response.successful is False
+    assert "No healthy heartbeat for 60s" in response.message
+    assert "configured threshold: 60s" in response.message
+    assert "Last sidecar status: Blue" in response.message
+    mock_logger.error.assert_called()
+
+
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_yellow_status_threshold_exceeded_worker_returns_fail(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that 'Yellow' with threshold exceeded on a worker returns FAIL."""
+    # last_healthy_time = 1000.0, threshold = 60s, current time = 1120.0 → 120s >= 60s
+    mock_time.time.return_value = 1120.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Yellow", ("127.0.0.1", 8200))
+
+    with patch('builtins.print'):
+        response = sidecar_condition_with_threshold._check.__wrapped__(
+            sidecar_condition_with_threshold, ProcessStatus.RUNNING
+        )
+
+    assert response.successful is False
+    assert "No healthy heartbeat for 120s" in response.message
+    assert "Last sidecar status: Yellow" in response.message
+    mock_logger.error.assert_called()
+
+
+# ------------------------
+# Test: Blue/Yellow with threshold exceeded (scheduler — should NOT trigger)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_blue_status_threshold_exceeded_scheduler_returns_success(
+    mock_logger, mock_time, sidecar_condition_scheduler_with_threshold
+):
+    """Test that 'Blue' with threshold exceeded on a scheduler still returns SUCCESS."""
+    # Threshold only applies to workers, not schedulers
+    mock_time.time.return_value = 1120.0
+    sidecar_condition_scheduler_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_scheduler_with_threshold._check.__wrapped__(
+        sidecar_condition_scheduler_with_threshold, ProcessStatus.RUNNING
+    )
+
+    assert response.successful is True
+    assert "Status received from sidecar: Blue" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Unknown/unexpected status
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_unknown_status_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that an unexpected status string returns SUCCESS with a warning."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket.recvfrom.return_value = (b"SomethingUnexpected", ("127.0.0.1", 8200))
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "Unexpected response retrieved from sidecar" in response.message
+    mock_logger.warning.assert_called()
+
+
+# ------------------------
+# Test: Socket timeout after warmup period
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_socket_timeout_after_warmup_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that a socket timeout after the warmup period returns SUCCESS with error log."""
+    # container_start_time = 1000.0, _SIDECAR_WAIT_PERIOD = 300s
+    # current time = 1400.0 → 400s > 300s (past warmup)
+    mock_time.time.return_value = 1400.0
+    sidecar_condition.socket.recvfrom.side_effect = socket.timeout("timed out")
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "timed out" in response.message.lower()
+    mock_logger.error.assert_called()
+
+
+# ------------------------
+# Test: Socket timeout during warmup period
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_socket_timeout_during_warmup_returns_success(mock_logger, mock_time, sidecar_condition):
+    """Test that a socket timeout during warmup returns SUCCESS with info log."""
+    # container_start_time = 1000.0, _SIDECAR_WAIT_PERIOD = 300s
+    # current time = 1100.0 → 100s < 300s (within warmup)
+    mock_time.time.return_value = 1100.0
+    sidecar_condition.socket.recvfrom.side_effect = socket.timeout("timed out")
+
+    response = sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+    assert response.successful is True
+    assert "just started" in response.message or "ignoring" in response.message.lower()
+    mock_logger.info.assert_called()
+
+
+# ------------------------
+# Test: Socket is None raises RuntimeError
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+def test_socket_none_raises_runtime_error(mock_time, sidecar_condition):
+    """Test that _check raises RuntimeError when socket is None."""
+    mock_time.time.return_value = 2000.0
+    sidecar_condition.socket = None
+
+    with pytest.raises(RuntimeError, match="socket object and start time shouldn't be None"):
+        sidecar_condition._check.__wrapped__(sidecar_condition, ProcessStatus.RUNNING)
+
+
+# ------------------------
+# Test: Healthy status resets last_healthy_time (enables threshold recovery)
+# ------------------------
+@patch('mwaa.subprocess.conditions.time')
+@patch('mwaa.subprocess.conditions.logger')
+def test_healthy_resets_timer_preventing_threshold_trigger(mock_logger, mock_time, sidecar_condition_with_threshold):
+    """Test that receiving 'Healthy' resets last_healthy_time so threshold doesn't trigger later."""
+    # First call: receive Healthy at t=1050 → updates last_healthy_time
+    mock_time.time.return_value = 1050.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Healthy", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+    assert response.successful is True
+    assert sidecar_condition_with_threshold.last_healthy_time == 1050.0
+
+    # Second call: receive Blue at t=1090 → only 40s since last healthy (< 60s threshold)
+    mock_time.time.return_value = 1090.0
+    sidecar_condition_with_threshold.socket.recvfrom.return_value = (b"Blue", ("127.0.0.1", 8200))
+
+    response = sidecar_condition_with_threshold._check.__wrapped__(
+        sidecar_condition_with_threshold, ProcessStatus.RUNNING
+    )
+    assert response.successful is True

--- a/tests/images/airflow/3.2.1/python/mwaa/test_execute_command.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/test_execute_command.py
@@ -143,3 +143,83 @@ def test_execute_command_task_monitoring_enabled(mock_shared_memory, mock_worker
 
     # Verify run_subprocesses was called
     mock_run_subprocesses.assert_called()
+
+
+
+# ------------------------
+# Tests for replacement threshold parsing
+# ------------------------
+
+class TestReplacementThresholdParsing:
+    """Tests for WORKER_REPLACEMENT_THRESHOLD_SECONDS env var parsing in _create_airflow_process_conditions."""
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_valid_positive_threshold(self, mock_port, mock_enabled):
+        """Valid positive integer is accepted."""
+        from mwaa.execute_command import _create_airflow_process_conditions, CONTAINER_START_TIME
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "300"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert len(sidecar_cond) == 1
+        assert sidecar_cond[0].replacement_threshold == 300
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_zero_threshold(self, mock_port, mock_enabled):
+        """Zero means disabled."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "0"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_negative_threshold_defaults_to_zero(self, mock_port, mock_enabled):
+        """Negative value is clamped to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "-100"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_non_integer_string_defaults_to_zero(self, mock_port, mock_enabled):
+        """Arbitrary string like 'abc' defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "abc"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_decimal_string_is_floored(self, mock_port, mock_enabled):
+        """Decimal like '30.5' is floored to 30."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": "30.5"}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 30
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_empty_string_defaults_to_zero(self, mock_port, mock_enabled):
+        """Empty string defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {"AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS": ""}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0
+
+    @patch('mwaa.execute_command._is_sidecar_health_monitoring_enabled', return_value=True)
+    @patch('mwaa.execute_command._get_sidecar_health_port', return_value=8200)
+    def test_env_var_not_set_defaults_to_zero(self, mock_port, mock_enabled):
+        """When the env var is not set, defaults to 0."""
+        from mwaa.execute_command import _create_airflow_process_conditions
+        env = {}
+        conditions = _create_airflow_process_conditions("worker", env)
+        sidecar_cond = [c for c in conditions if hasattr(c, 'replacement_threshold')]
+        assert sidecar_cond[0].replacement_threshold == 0


### PR DESCRIPTION
*Description of changes:*

This PR adds a new customer-configurable option `AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS` that allows customers to control how quickly an unhealthy worker gets replaced.

Currently, when a worker enters `blue` or `yellow` sidecar health status, it continues running until it reaches `red`. This change allows customers to set a threshold (in seconds) after which a worker that has not received a `healthy` heartbeat will be terminated and replaced.

  ### How it works

  - When `AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS` is set to a value > 0, the `SidecarHealthCondition` tracks the last time a `healthy` status was received.
  - On each `blue` or `yellow` heartbeat, it checks whether the elapsed time since the last healthy heartbeat exceeds the configured threshold.
  - If the threshold is exceeded **and** the component is a worker, the condition returns `successful=False`, triggering worker replacement.
  - If the config is not set or set to `0` (default), existing behavior is preserved: `blue`/`yellow` states do not trigger replacement.

  ### Changes

  - `conditions.py` (all Airflow versions): Added `replacement_threshold` parameter and `last_healthy_time` tracking to `SidecarHealthCondition`. The `blue`/`yellow` case now checks whether the time since last
  healthy heartbeat exceeds the threshold.
  - `execute_command.py` (all Airflow versions): Reads `AIRFLOW__MWAA__WORKER_REPLACEMENT_THRESHOLD_SECONDS` from environment and passes it to `SidecarHealthCondition`.

  Applied to all supported Airflow versions: 2.9.2, 2.10.1, 2.10.3, 2.11.0, 2.11.2, 3.0.6, 3.2.1.

  ### Testing

  #### Airflow 2.10.3

  | Test Case | Config | Scenario | Expected | Result |
  |-----------|--------|----------|----------|--------|
  | TC#1 | Not set | Healthy worker, 24hr overnight | No replacement | ✅ PASS - Three environments (10s, 30s, 60min thresholds) ran over the weekend with no false replacements |
  | TC#2 | Not set (0) | Broken worker | Replace at red | ✅ PASS - Broken DAG triggered 2026-06-29 10:26 UTC. Yellow 10:32, Red 11:27, Replaced 11:30 UTC |
  | TC#3 | 50 min (3000s) | Broken worker | Replace < 95 min | ✅ PASS - Broken DAG triggered 10:27, Blue 10:30, Yellow 10:34, Replaced 11:22 UTC (~55 min) |
  | TC#4 | 3 min (180s) | Broken worker | Replace < 40 min | ✅ PASS - Broken DAG triggered 10:28, Blue 10:29, Replaced 10:35 UTC (~7 min) |
  | TC#5 | 10 sec | Broken worker | Replace < 35 min | ✅ PASS - Broken DAG triggered 07:31, Blue 07:35, Replaced 07:39 UTC (~4 min) |

  #### Airflow 3.2.1

  | Test Case | Config | Scenario | Expected | Result |
  |-----------|--------|----------|----------|--------|
  | TC#1 | Not set | Healthy worker, 24hr overnight | No replacement | ✅ PASS |
  | TC#2 | Not set (0) | Broken worker | Replace at red | ✅ PASS - Broken DAG triggered 2026-06-30 05:30 UTC. Blue 05:33, Yellow 05:37, Red 06:32, Replaced 06:34 UTC |
  | TC#3 | 50 min (3000s) | Broken worker | Replace < 95 min | ✅ PASS - Broken DAG triggered 2026-06-30 05:29 UTC. Blue 05:32, Yellow 05:36, Replaced 06:25 UTC (~55 min) |
  | TC#4 | 3 min (180s) | Broken worker | Replace < 40 min | ✅ PASS - Broken DAG triggered 05:19, Blue 05:22, Replaced 05:26 UTC (~7 min) |
  | TC#5 | 10 sec | Broken worker | Replace < 35 min | ✅ PASS - Broken DAG triggered 05:09, Blue 05:11, Replaced 05:13 UTC (~4 min) |


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
