### PR TITLE
Add unit tests for Airflow 2.11.2 image

### DIFF
--- a/tests/images/airflow/2.11.2/conftest.py
+++ b/tests/images/airflow/2.11.2/conftest.py
@@ -1,0 +1,53 @@
+import os
+import subprocess
+import sys
+
+
+def pytest_configure(config):
+    airflow_version = "2.11.2"
+    requirements_path = os.path.join(
+        os.path.dirname(__file__),
+        "requirements.txt"
+    )
+    airflow_path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "..",
+            "images",
+            "airflow",
+            airflow_version,
+            "python"
+        )
+    )
+    # Add to Python path
+    sys.path.insert(0, airflow_path)
+
+    os.environ["MWAA__CORE__TESTING_MODE"] = "true"
+    os.environ["MWAA__CORE__STARTUP_SCRIPT_PATH"] = "../../startup/startup.sh"
+
+    # Set required database environment variables for module imports
+    os.environ["MWAA__DB__POSTGRES_HOST"] = "localhost"
+    os.environ["MWAA__DB__POSTGRES_PORT"] = "5432"
+    os.environ["MWAA__DB__POSTGRES_DB"] = "airflow"
+    os.environ["MWAA__DB__POSTGRES_USER"] = "airflow"
+    os.environ["MWAA__DB__POSTGRES_PASSWORD"] = "airflow"
+    os.environ["MWAA__DB__POSTGRES_SSLMODE"] = "disable"
+
+    if os.path.exists(requirements_path):
+        try:
+            print(f"Installing requirements from: {requirements_path}")
+            subprocess.check_call([
+                "pip",
+                "install",
+                "--no-cache-dir",
+                "-r",
+                requirements_path
+            ])
+        except subprocess.CalledProcessError as e:
+            print(f"Error installing requirements: {e}")
+            raise
+    else:
+        print(f"Requirements file not found at: {requirements_path}")

--- a/tests/images/airflow/2.11.2/python/mwaa/celery/test_sqs_broker_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/celery/test_sqs_broker_2_11_2.py
@@ -1,0 +1,204 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from mwaa.celery.sqs_broker import Channel
+
+
+class TestChannelBasicPublish:
+
+    @pytest.fixture
+    def mock_channel(self):
+        mock_connection = MagicMock()
+
+        mock_connection.channel_max = 65535
+        mock_connection._used_channel_ids = []
+        mock_connection.channels = []
+        mock_connection.state = MagicMock()
+
+        mock_connection.client.transport_options = {
+            'predefined_queues': {},
+            'queue_name_prefix': '',
+            'visibility_timeout': 1800,
+            'wait_time_seconds': 10,
+            'region': 'us-east-1'
+        }
+        mock_connection.client.virtual_host = '/'
+
+        with patch('mwaa.celery.sqs_broker.boto3'), \
+             patch('mwaa.celery.sqs_broker.shared_memory.SharedMemory') as mock_shared_mem, \
+             patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env, \
+             patch('mwaa.celery.sqs_broker.get_event_loop'):
+
+            mock_env.side_effect = lambda key, default=None: {
+                'MWAA__CORE__TASK_MONITORING_ENABLED': 'false',
+                'AIRFLOW_ENV_ID': 'test',
+                'AIRFLOW__CELERY__WORKER_AUTOSCALE': '20,20',
+                'AIRFLOW__MWAA__TEST_ABANDONED_SQS_MESSAGE_SCENARIOS': 'false',
+                'AIRFLOW__MWAA__TEST_UNDEAD_PROCESS_SCENARIOS': 'false'
+            }.get(key, default)
+
+            mock_shared_mem.return_value = MagicMock()
+
+            channel = Channel(connection=mock_connection)
+
+            with patch.object(channel.__class__.__bases__[0], 'basic_publish') as mock_super_publish:
+                channel._super_basic_publish = mock_super_publish
+                yield channel
+
+    @pytest.mark.parametrize("env_value", ['false', None])
+    def test_health_monitoring_disabled_calls_super(self, mock_channel, env_value):
+        """When health monitoring is disabled or not set, should always call super."""
+        message = {'test': 'message'}
+        kwargs = {'extra': 'args'}
+        exchange = 'celeryev'
+        routing_key = 'worker.heartbeat'
+
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = env_value
+
+            mock_channel.basic_publish(message, exchange, routing_key, **kwargs)
+
+            mock_channel._super_basic_publish.assert_called_once_with(
+                message, exchange, routing_key, **kwargs
+            )
+
+    @pytest.mark.parametrize("routing_key", ['worker.heartbeat', 'other.routing.key'])
+    def test_celeryev_exchange_blocks_super(self, mock_channel, routing_key):
+        """When health monitoring is enabled and exchange is celeryev, should not call super."""
+        message = {'test': 'message'}
+        kwargs = {'extra': 'args'}
+        exchange = 'celeryev'
+
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = 'true'
+
+            mock_channel.basic_publish(message, exchange, routing_key, **kwargs)
+
+            mock_channel._super_basic_publish.assert_not_called()
+
+    @pytest.mark.parametrize("exchange,routing_key", [
+        ('other_exchange', 'worker.heartbeat'),
+        ('task_exchange', 'task.routing.key')
+    ])
+    def test_non_celeryev_exchange_calls_super(self, mock_channel, exchange, routing_key):
+        """When health monitoring is enabled but exchange is not celeryev, should call super."""
+        message = {'test': 'message'}
+        kwargs = {'extra': 'args'}
+
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = 'true'
+
+            mock_channel.basic_publish(message, exchange, routing_key, **kwargs)
+
+            mock_channel._super_basic_publish.assert_called_once_with(
+                message, exchange, routing_key, **kwargs
+            )
+
+    def test_size_with_attributes(self, mock_channel):
+        """Test _size returns message count when Attributes exist."""
+        queue = 'test-queue'
+        mock_sqs = MagicMock()
+        mock_sqs.get_queue_attributes.return_value = {
+            'Attributes': {'ApproximateNumberOfMessages': '5'}
+        }
+
+        with patch.object(mock_channel, '_new_queue', return_value='queue-url'), \
+                patch.object(mock_channel, 'canonical_queue_name', return_value=queue), \
+                patch.object(mock_channel, 'sqs', return_value=mock_sqs):
+            result = mock_channel._size(queue)
+
+            assert result == 5
+            mock_sqs.get_queue_attributes.assert_called_once_with(
+                QueueUrl='queue-url', AttributeNames=['ApproximateNumberOfMessages']
+            )
+
+    def test_size_without_attributes(self, mock_channel):
+        """Test _size raises exception when Attributes missing."""
+        queue = 'test-queue'
+        mock_sqs = MagicMock()
+        mock_sqs.get_queue_attributes.return_value = {}
+
+        with patch.object(mock_channel, '_new_queue', return_value='queue-url'), \
+                patch.object(mock_channel, 'canonical_queue_name', return_value=queue), \
+                patch.object(mock_channel, 'sqs', return_value=mock_sqs), \
+                patch('mwaa.celery.sqs_broker.logger') as mock_logger:
+            with pytest.raises(KeyError):
+                mock_channel._size(queue)
+
+            mock_logger.error.assert_called_once()
+
+    def test_celery_worker_task_limit_constant_parsing(self):
+        """Test CELERY_WORKER_TASK_LIMIT correctly parses environment variable."""
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = '20,10'
+
+            # Re-import to trigger constant re-evaluation
+            import importlib
+            import mwaa.celery.sqs_broker
+            importlib.reload(mwaa.celery.sqs_broker)
+
+            from mwaa.celery.sqs_broker import CELERY_WORKER_TASK_LIMIT
+            assert CELERY_WORKER_TASK_LIMIT == 20
+
+    @pytest.mark.parametrize("monitoring_enabled,expected_tasks", [
+        (True, 15),  # When monitoring enabled, use actual task count
+        (False, 20),  # When monitoring disabled, use CELERY_WORKER_TASK_LIMIT
+    ])
+    @patch('mwaa.celery.sqs_broker.Stats')
+    def test_worker_heartbeat_active_tasks_calculation(self, mock_stats, mock_channel, monitoring_enabled,
+                                                       expected_tasks):
+        """Test num_active_tasks calculation logic."""
+        message = {'test': 'message'}
+        exchange = 'celeryev'
+        routing_key = 'worker.heartbeat'
+
+        mock_channel._get_tasks_from_state = MagicMock(return_value=[{'task': 'test'}] * 15)
+        mock_channel._is_task_consumption_paused = MagicMock(return_value=False)
+        mock_channel.idle_worker_monitoring_enabled = monitoring_enabled
+
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = 'true'
+
+            mock_channel.basic_publish(message, exchange, routing_key)
+
+            if expected_tasks >= 20:  # CELERY_WORKER_TASK_LIMIT
+                mock_stats.gauge.assert_any_call("mwaa.celery.at_max_concurrency", expected_tasks)
+            else:
+                assert not any(call[0][0] == "mwaa.celery.at_max_concurrency"
+                               for call in mock_stats.gauge.call_args_list)
+
+    @pytest.mark.parametrize("num_tasks,is_paused,expect_max_concurrency,expect_consumption_paused", [
+        (25, False, True, False),  # Above limit, not paused
+        (15, True, False, True),  # Below limit, paused
+        (20, False, True, False),  # At limit, not paused
+        (10, False, False, False),  # Below limit, not paused
+    ])
+    @patch('mwaa.celery.sqs_broker.Stats')
+    def test_worker_heartbeat_conditional_metrics(self, mock_stats, mock_channel, num_tasks, is_paused,
+                                                  expect_max_concurrency, expect_consumption_paused):
+        """Test conditional metric emission logic."""
+        message = {'test': 'message'}
+        exchange = 'celeryev'
+        routing_key = 'worker.heartbeat'
+
+        mock_channel._get_tasks_from_state = MagicMock(return_value=[{'task': 'test'}] * num_tasks)
+        mock_channel._is_task_consumption_paused = MagicMock(return_value=is_paused)
+        mock_channel.idle_worker_monitoring_enabled = True
+
+        with patch('mwaa.celery.sqs_broker.os.environ.get') as mock_env_get:
+            mock_env_get.return_value = 'true'
+
+            mock_channel.basic_publish(message, exchange, routing_key)
+
+            mock_stats.gauge.assert_any_call("mwaa.celery.process.heartbeat", 1)
+
+            if expect_max_concurrency:
+                mock_stats.gauge.assert_any_call("mwaa.celery.at_max_concurrency", num_tasks)
+            else:
+                assert not any(call[0][0] == "mwaa.celery.at_max_concurrency"
+                               for call in mock_stats.gauge.call_args_list)
+
+            if expect_consumption_paused:
+                mock_stats.gauge.assert_any_call("mwaa.celery.sqs.consumption_paused", 1)
+            else:
+                assert not any(call[0][0] == "mwaa.celery.sqs.consumption_paused"
+                               for call in mock_stats.gauge.call_args_list)

--- a/tests/images/airflow/2.11.2/python/mwaa/celery/test_task_monitor_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/celery/test_task_monitor_2_11_2.py
@@ -1,0 +1,199 @@
+"""
+Unit tests for task_monitor.py focusing on the type annotation fix for _get_next_unprocessed_signal method.
+"""
+
+import json
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import patch, mock_open, MagicMock
+
+from dateutil.tz import tz
+from mwaa.celery.task_monitor import (
+    WorkerTaskMonitor, 
+    SignalData, 
+    SignalType, 
+    MWAA_SIGNALS_DIRECTORY, 
+    _get_airflow_process_id_mapping
+)
+
+
+@pytest.fixture
+def task_monitor():
+    """Create a minimal WorkerTaskMonitor instance for testing"""
+    with patch('mwaa.celery.task_monitor._create_shared_mem_celery_state'), \
+         patch('mwaa.celery.task_monitor._create_shared_mem_work_consumption_block'), \
+         patch('mwaa.celery.task_monitor._create_shared_mem_cleanup_celery_state'), \
+         patch('mwaa.celery.task_monitor.get_statsd'):
+        monitor = WorkerTaskMonitor(mwaa_signal_handling_enabled=True, idleness_verification_interval=5)
+        yield monitor
+
+
+def test_get_next_unprocessed_signal_returns_none_tuple_no_directory(task_monitor):
+    """Test returns tuple[None, None] when signals directory doesn't exist"""
+    with patch('mwaa.celery.task_monitor.os.path.exists', return_value=False):
+        result = task_monitor._get_next_unprocessed_signal()
+        assert isinstance(result, tuple) and len(result) == 2
+        assert result == (None, None)
+
+
+def test_get_next_unprocessed_signal_returns_none_tuple_empty_directory(task_monitor):
+    """Test returns tuple[None, None] when signals directory is empty"""
+    with patch('mwaa.celery.task_monitor.os.path.exists', return_value=True), \
+         patch('mwaa.celery.task_monitor.os.listdir', return_value=[]):
+        result = task_monitor._get_next_unprocessed_signal()
+        assert isinstance(result, tuple) and len(result) == 2
+        assert result == (None, None)
+
+
+def test_get_next_unprocessed_signal_returns_valid_tuple(task_monitor):
+    """Test returns tuple[str, SignalData] when valid signal exists"""
+    signal_data = {
+        'executionId': 'test-123', 
+        'signalType': 'activation', 
+        'createdAt': int(datetime.now(tz=tz.tzutc()).timestamp()), 
+        'processed': False
+    }
+    
+    with patch('mwaa.celery.task_monitor.os.path.exists', return_value=True), \
+         patch('mwaa.celery.task_monitor.os.listdir', return_value=['signal1.json']), \
+         patch('mwaa.celery.task_monitor.os.path.getctime', return_value=datetime.now(tz=tz.tzutc()).timestamp()), \
+         patch('mwaa.celery.task_monitor.os.path.join', return_value=f'{MWAA_SIGNALS_DIRECTORY}/signal1.json'), \
+         patch('builtins.open', mock_open(read_data=json.dumps(signal_data))):
+        
+        result = task_monitor._get_next_unprocessed_signal()
+        assert isinstance(result, tuple) and len(result) == 2
+        assert isinstance(result[0], str) and isinstance(result[1], SignalData)
+        assert result[0] == f'{MWAA_SIGNALS_DIRECTORY}/signal1.json'
+        assert result[1].executionId == 'test-123'
+
+
+def test_get_next_unprocessed_signal_skips_processed_signals(task_monitor):
+    """Test returns tuple[None, None] when signals are already processed"""
+    processed_signal = {
+        'executionId': 'test-processed', 
+        'signalType': 'kill', 
+        'createdAt': int(datetime.now(tz=tz.tzutc()).timestamp()), 
+        'processed': True
+    }
+    
+    with patch('mwaa.celery.task_monitor.os.path.exists', return_value=True), \
+         patch('mwaa.celery.task_monitor.os.listdir', return_value=['processed.json']), \
+         patch('mwaa.celery.task_monitor.os.path.getctime', return_value=datetime.now(tz=tz.tzutc()).timestamp()), \
+         patch('mwaa.celery.task_monitor.os.path.join', return_value=f'{MWAA_SIGNALS_DIRECTORY}/processed.json'), \
+         patch('builtins.open', mock_open(read_data=json.dumps(processed_signal))):
+        
+        result = task_monitor._get_next_unprocessed_signal()
+        assert isinstance(result, tuple) and len(result) == 2
+        assert result == (None, None)
+
+
+def test_get_next_unprocessed_signal_handles_old_signals(task_monitor):
+    """Test returns tuple[None, None] when signals are too old"""
+    old_timestamp = (datetime.now(tz=tz.tzutc()) - timedelta(hours=2)).timestamp()
+    
+    with patch('mwaa.celery.task_monitor.os.path.exists', return_value=True), \
+         patch('mwaa.celery.task_monitor.os.listdir', return_value=['old_signal.json']), \
+         patch('mwaa.celery.task_monitor.os.path.getctime', return_value=old_timestamp):
+        
+        result = task_monitor._get_next_unprocessed_signal()
+        assert isinstance(result, tuple) and len(result) == 2
+        assert result == (None, None)
+
+
+def test_get_next_unprocessed_signal_handles_file_read_error(task_monitor):
+    """Test returns tuple[None, None] and increments error metric when file read fails"""
+    mock_stats = MagicMock()
+    task_monitor.stats = mock_stats
+    
+    with patch('mwaa.celery.task_monitor.os.path.exists', return_value=True), \
+         patch('mwaa.celery.task_monitor.os.listdir', return_value=['corrupt.json']), \
+         patch('mwaa.celery.task_monitor.os.path.getctime', return_value=datetime.now(tz=tz.tzutc()).timestamp()), \
+         patch('mwaa.celery.task_monitor.os.path.join', return_value=f'{MWAA_SIGNALS_DIRECTORY}/corrupt.json'), \
+         patch('builtins.open', mock_open(read_data='invalid json')):
+        
+        result = task_monitor._get_next_unprocessed_signal()
+        assert isinstance(result, tuple) and len(result) == 2
+        assert result == (None, None)
+        mock_stats.incr.assert_called_with("mwaa.task_monitor.signal_read_error", 1)
+
+
+@pytest.mark.parametrize("signal_type", ["activation", "kill", "termination", "resume"])
+def test_signal_data_from_json_string_all_types(signal_type):
+    """Test SignalData.from_json_string works correctly for all signal types"""
+    json_data = {
+        'executionId': f'test-{signal_type}-456', 
+        'signalType': signal_type, 
+        'createdAt': 1234567890
+    }
+    
+    signal_data = SignalData.from_json_string(json.dumps(json_data))
+    
+    assert signal_data.executionId == f'test-{signal_type}-456'
+    assert signal_data.signalType == SignalType.from_string(signal_type)
+    assert signal_data.createdAt == 1234567890
+    assert signal_data.processed is False  # Default value
+
+def test_get_airflow_process_id_mapping():
+    """Test process ID extraction from airflow processes in Airflow 2.x format"""
+    # Airflow 2.x uses "airflow tasks run" command format
+    mock_processes = [
+        {
+            'pid': 1234,
+            'cmdline': ['airflow', 'tasks', 'run', 'my_dag', 'my_task', '2024-01-01']
+        },
+        {
+            'pid': 1235,
+            'cmdline': ['airflow', 'tasks', 'run', 'another_dag', 'another_task', '2024-01-02', '--local']
+        },
+        {
+            'pid': 1236,
+            'cmdline': ['python', 'some_script.py']  # Non-airflow process
+        },
+        {
+            'pid': 1237,
+            'cmdline': ['airflow', 'scheduler']  # Different airflow command
+        },
+        {
+            'pid': 1238,
+            'cmdline': []  # Empty cmdline
+        }
+    ]
+    
+    def mock_process_iter(attrs):
+        """Mock psutil.process_iter to return test processes"""
+        for proc_data in mock_processes:
+            proc = MagicMock()
+            proc.info = {
+                'pid': proc_data['pid'],
+                'cmdline': proc_data['cmdline']
+            }
+            yield proc
+    
+    with patch('mwaa.celery.task_monitor.psutil.process_iter', side_effect=mock_process_iter):
+        result = _get_airflow_process_id_mapping()
+        
+        # Verify only valid Airflow 2.x task processes are mapped
+        # The key is the command starting from "airflow tasks run"
+        assert len(result) == 2
+        assert 'airflow tasks run my_dag my_task 2024-01-01' in result
+        assert result['airflow tasks run my_dag my_task 2024-01-01'] == 1234
+        assert 'airflow tasks run another_dag another_task 2024-01-02 --local' in result
+        assert result['airflow tasks run another_dag another_task 2024-01-02 --local'] == 1235
+        
+        # Non-airflow processes and other airflow commands should not be in the mapping
+        assert 1236 not in result.values()
+        assert 1237 not in result.values()
+        assert 1238 not in result.values()
+
+
+def test_get_cleanup_task_count_returns_length(task_monitor):
+    """Test get_cleanup_task_count returns the number of tasks marked for cleanup."""
+    tasks = [{"task_id": "task1"}, {"task_id": "task2"}]
+    with patch('mwaa.celery.task_monitor._get_celery_tasks', return_value=tasks):
+        assert task_monitor.get_cleanup_task_count() == 2
+
+
+def test_get_cleanup_task_count_empty(task_monitor):
+    """Test get_cleanup_task_count returns 0 when no cleanup tasks exist."""
+    with patch('mwaa.celery.task_monitor._get_celery_tasks', return_value=[]):
+        assert task_monitor.get_cleanup_task_count() == 0

--- a/tests/images/airflow/2.11.2/python/mwaa/config/test_airflow_rds_iam_patch_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/config/test_airflow_rds_iam_patch_2_11_2.py
@@ -1,0 +1,158 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def test_is_from_migrate_db():
+    """Test migrate-db detection"""
+    from mwaa.config.airflow_rds_iam_patch import is_from_migrate_db
+    
+    with patch.dict('os.environ', {'MWAA_AIRFLOW_COMPONENT': 'migrate-db'}):
+        assert is_from_migrate_db() is True
+    
+    with patch.dict('os.environ', {'MWAA_AIRFLOW_COMPONENT': 'scheduler'}):
+        assert is_from_migrate_db() is False
+
+    with patch.dict('os.environ', {}, clear=True), patch('mwaa.config.airflow_rds_iam_patch.logger') as mock_logger:
+        assert is_from_migrate_db() is False
+        mock_logger.error.assert_called_once_with("MWAA_AIRFLOW_COMPONENT does not exist as an environment variable.")
+
+
+def test_is_using_rds_proxy():
+    """Test RDS proxy detection"""
+    from mwaa.config.airflow_rds_iam_patch import is_using_rds_proxy
+    
+    with patch.dict('os.environ', {'SSL_MODE': 'require'}):
+        assert is_using_rds_proxy() is True
+    
+    with patch.dict('os.environ', {'SSL_MODE': 'disable'}):
+        assert is_using_rds_proxy() is False
+
+    with patch.dict('os.environ', {}, clear=True), patch('mwaa.config.airflow_rds_iam_patch.logger') as mock_logger:
+        assert is_using_rds_proxy() is False
+        mock_logger.error.assert_called_once_with("SSL_MODE does not exist as an environment variable.")
+
+
+def test_use_iam_credentials():
+    """Test IAM credentials flag detection"""
+    from mwaa.config.airflow_rds_iam_patch import use_iam_credentials
+    
+    with patch.dict('os.environ', {'USE_IAM_CREDENTIALS': 'true'}):
+        assert use_iam_credentials() is True
+    
+    with patch.dict('os.environ', {'USE_IAM_CREDENTIALS': 'false'}):
+        assert use_iam_credentials() is False
+    
+    with patch.dict('os.environ', {}, clear=True):
+        assert use_iam_credentials() is False
+
+
+def test_is_accessing_metadata_db():
+    """Test metadata database detection"""
+    from mwaa.config.airflow_rds_iam_patch import is_accessing_metadata_db
+    
+    # Mock the metadata_url
+    with patch('mwaa.config.airflow_rds_iam_patch.metadata_url') as mock_url:
+        mock_url.host = 'test.rds.amazonaws.com'
+        mock_url.database = 'airflow'
+        mock_url.port = 5432
+        
+        # Test with matching parameters including username
+        cparams = {'host': 'test.rds.amazonaws.com', 'database': 'airflow', 'port': 5432, 'username': 'airflow_user'}
+        assert is_accessing_metadata_db('postgresql', [], cparams) is True
+        
+        # Test with adminuser username
+        cparams = {'host': 'test.rds.amazonaws.com', 'database': 'airflow', 'port': 5432, 'username': 'adminuser'}
+        assert is_accessing_metadata_db('postgresql', [], cparams) is True
+        
+        # Test with non-matching parameters
+        cparams = {'host': 'other.rds.amazonaws.com', 'database': 'other', 'port': 3306, 'username': 'airflow_user'}
+        assert is_accessing_metadata_db('postgresql', [], cparams) is False
+        
+        # Test with missing username
+        cparams = {'host': 'test.rds.amazonaws.com', 'database': 'airflow', 'port': 5432}
+        assert is_accessing_metadata_db('postgresql', [], cparams) is False
+
+
+def test_is_accessing_metadata_db_with_cargs():
+    """Test metadata database detection using cargs"""
+    from mwaa.config.airflow_rds_iam_patch import is_accessing_metadata_db
+    
+    with patch('mwaa.config.airflow_rds_iam_patch.metadata_url') as mock_url:
+        mock_url.host = 'test.rds.amazonaws.com'
+        mock_url.database = 'airflow'
+        mock_url.port = 5432
+        
+        # Test with matching cargs including airflow_user
+        cargs = ['postgresql://airflow_user:pass@test.rds.amazonaws.com:5432/airflow']
+        assert is_accessing_metadata_db('postgresql', cargs, {}) is True
+        
+        # Test with matching cargs including adminuser
+        cargs = ['postgresql://adminuser:pass@test.rds.amazonaws.com:5432/airflow']
+        assert is_accessing_metadata_db('postgresql', cargs, {}) is True
+
+
+def test_is_accessing_metadata_db_cargs_exception():
+    """Test metadata database detection when cargs parsing fails"""
+    from mwaa.config.airflow_rds_iam_patch import is_accessing_metadata_db
+    
+    with patch('mwaa.config.airflow_rds_iam_patch.metadata_url') as mock_url, \
+         patch('mwaa.config.airflow_rds_iam_patch.make_url') as mock_make_url:
+        
+        mock_url.host = 'test.rds.amazonaws.com'
+        mock_url.database = 'airflow'
+        mock_url.port = 5432
+        
+        # Mock make_url to raise an exception when called with cargs
+        mock_make_url.side_effect = Exception("Invalid URL")
+        
+        # Test with cargs that cause exception - should fall back to cparams with username
+        cargs = ['some_url']
+        cparams = {'host': 'test.rds.amazonaws.com', 'database': 'airflow', 'port': 5432, 'username': 'airflow_user'}
+        assert is_accessing_metadata_db('postgresql', cargs, cparams) is True
+        
+        # Verify make_url was called and raised exception
+        mock_make_url.assert_called_once_with('some_url')
+
+
+def test_event_listener_setup():
+    """Test SQLAlchemy event listener setup when conditions are met"""
+    with patch.dict('os.environ', {'SSL_MODE': 'require', 'MWAA_AIRFLOW_COMPONENT': 'scheduler', 'USE_IAM_CREDENTIALS': 'true'}), \
+         patch('mwaa.config.database.get_db_connection_string', return_value='postgresql://test:test@localhost/test'), \
+         patch('sqlalchemy.event.listen') as mock_listen:
+        
+        # Re-import to trigger conditional setup
+        import importlib
+        import mwaa.config.airflow_rds_iam_patch
+        importlib.reload(mwaa.config.airflow_rds_iam_patch)
+        
+        mock_listen.assert_called()
+
+
+def test_patch_rds_iam_authentication_function():
+    """Test the patch_rds_iam_authentication function execution"""
+    with patch.dict('os.environ', {'SSL_MODE': 'require', 'MWAA_AIRFLOW_COMPONENT': 'scheduler', 'USE_IAM_CREDENTIALS': 'true'}), \
+         patch('mwaa.config.database.get_db_connection_string', return_value='postgresql://test:test@localhost/test'), \
+         patch('mwaa.utils.get_rds_iam_credentials.RDSIAMCredentialProvider.get_token', return_value='test_token'), \
+         patch('mwaa.utils.get_rds_iam_credentials.RDSIAMCredentialProvider.create_db_connection_url', return_value='postgresql://user:token@host:5432/db?sslmode=require'):
+        
+        # Re-import to get the patch function
+        import importlib
+        import mwaa.config.airflow_rds_iam_patch
+        importlib.reload(mwaa.config.airflow_rds_iam_patch)
+        
+        # Get the patch function from the module
+        patch_func = getattr(mwaa.config.airflow_rds_iam_patch, 'patch_rds_iam_authentication', None)
+        if patch_func:
+            # Test the function with metadata DB connection
+            cparams = {}
+            with patch('mwaa.config.airflow_rds_iam_patch.is_accessing_metadata_db', return_value=True):
+                patch_func('postgresql', None, [], cparams)
+                # Verify cparams was updated
+                assert len(cparams) > 0
+            
+            # Test the function with non-metadata DB connection (should return early)
+            cparams = {}
+            with patch('mwaa.config.airflow_rds_iam_patch.is_accessing_metadata_db', return_value=False):
+                patch_func('postgresql', None, [], cparams)
+                # Verify cparams was not updated
+                assert len(cparams) == 0

--- a/tests/images/airflow/2.11.2/python/mwaa/config/test_setup_environment_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/config/test_setup_environment_2_11_2.py
@@ -1,0 +1,267 @@
+# test_setup_environment.py
+import pytest
+import json
+import os
+from unittest.mock import patch, mock_open, MagicMock
+from datetime import timedelta
+from mwaa.config.setup_environment import (
+    setup_environment_variables,
+    _execute_startup_script,
+    _export_env_variables,
+    _is_protected_os_environ,
+)
+from mwaa.subprocess.subprocess import Subprocess  # Add this import
+
+
+@pytest.fixture
+def mock_environ(monkeypatch):
+    """Fixture for mocking os.environ"""
+    test_environ = {
+        "AIRFLOW_ENV_ID": "test-env-id",
+        "AIRFLOW_ENV_NAME": "test-env",
+        "AIRFLOW_HOME": "/usr/local/airflow",
+        "AWS_DEFAULT_REGION": "us-east-1",
+        "PYTHONPATH": "/usr/local/airflow/dags",
+        "MWAA__CORE__TEST": "test-value",
+        "MWAA__CORE__STARTUP_SCRIPT_PATH": "../../2.11.2/startup/startup.sh",
+        "MWAA__CORE__TESTING_MODE": "true"
+    }
+    monkeypatch.setattr(os, "environ", test_environ)
+    return test_environ
+
+
+@pytest.fixture
+def mock_config_functions(monkeypatch):
+    """Fixture for mocking all configuration related functions"""
+    mock_functions = {
+        "get_essential_airflow_config": MagicMock(return_value={"ESSENTIAL_CONFIG": "value1"}),
+        "get_opinionated_airflow_config": MagicMock(return_value={"OP_CONFIG": "value2"}),
+        "get_essential_environ": MagicMock(return_value={"ESSENTIAL_ENV": "value3"}),
+        "get_opinionated_environ": MagicMock(return_value={"OP_ENV": "value4"}),
+        "get_user_airflow_config": MagicMock(return_value={"USER_CONFIG": "value5"})
+    }
+
+    for func_name, mock_func in mock_functions.items():
+        monkeypatch.setattr(f"mwaa.config.setup_environment.{func_name}", mock_func)
+
+    return mock_functions
+
+
+@pytest.fixture
+def temp_home_dir(tmp_path):
+    """Fixture for creating temporary home directory with .bashrc and .bash_profile"""
+    bashrc = tmp_path / ".bashrc"
+    bash_profile = tmp_path / ".bash_profile"
+    bashrc.touch()
+    bash_profile.touch()
+    return tmp_path
+
+
+# ------------------------
+# Environment Configuration Tests
+# ------------------------
+
+@pytest.mark.parametrize(
+    "key,expected",
+    [
+        ("MWAA__CORE__TEST", True),
+        ("AIRFLOW_ENV_ID", True),
+        ("AWS_DEFAULT_REGION", True),
+        ("CUSTOM_VAR", False),
+        ("PYTHONPATH", True),
+        ("RANDOM_VAR", False),
+        ("MWAA__CUSTOM__VAR", True),
+    ]
+)
+def test_is_protected_os_environ(key, expected):
+    """Test protected environment variable checking"""
+    assert _is_protected_os_environ(key) == expected
+
+
+def test_export_env_variables(temp_home_dir):
+    """Test environment variable export to shell files"""
+    test_environ = {
+        "TEST_VAR1": "value1",
+        "TEST_VAR2": "value2 with space",
+        "TEST_VAR3": "value3!@#$"
+    }
+
+    with patch("os.path.expanduser", return_value=str(temp_home_dir)):
+        _export_env_variables(test_environ)
+
+    # Verify both files
+    for filename in [".bashrc", ".bash_profile"]:
+        file_path = temp_home_dir / filename
+        content = file_path.read_text()
+
+        assert 'export TEST_VAR1=value1\n' in content
+        assert "export TEST_VAR2='value2 with space'\n" in content
+        assert "export TEST_VAR3='value3!@#$'\n" in content
+
+
+def test_setup_environment_variables(mock_environ, mock_config_functions):
+    """Test complete environment variable setup"""
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script, \
+            patch("mwaa.config.setup_environment._export_env_variables") as mock_export:
+        mock_execute_script.return_value = {"STARTUP_VAR": "value6"}
+
+        result = setup_environment_variables("worker", "Local")
+
+        # Verify all configurations are present and correctly merged
+        assert result["ESSENTIAL_CONFIG"] == "value1"
+        assert result["OP_CONFIG"] == "value2"
+        assert result["ESSENTIAL_ENV"] == "value3"
+        assert result["OP_ENV"] == "value4"
+        assert result["USER_CONFIG"] == "value5"
+        assert result["STARTUP_VAR"] == "value6"
+
+        # Verify protected variables are preserved
+        assert result["AIRFLOW_ENV_ID"] == "test-env-id"
+        assert result["AIRFLOW_HOME"] == "/usr/local/airflow"
+        assert result["AWS_DEFAULT_REGION"] == "us-east-1"
+
+        # Verify export was called
+        mock_export.assert_called_once_with(result)
+
+
+# ------------------------
+# Startup Script Tests
+# ------------------------
+
+def test_no_startup_script_path():
+    """Test when MWAA__CORE__STARTUP_SCRIPT_PATH is not set"""
+    with patch.dict(os.environ, {}, clear=True):
+        result = _execute_startup_script("worker", {})
+        assert result == {}
+
+
+def test_startup_script_not_found():
+    """Test when startup script file doesn't exist"""
+    with patch.dict(os.environ, {"MWAA__CORE__STARTUP_SCRIPT_PATH": "/nonexistent/path"}), \
+            patch('os.path.isfile', return_value=False):
+        result = _execute_startup_script("worker", {})
+        assert result == {}
+
+
+def test_uses_mocked_env(mock_environ):
+    """Ensure environment variables are correctly set"""
+    assert mock_environ["MWAA__CORE__TESTING_MODE"] == "true"
+
+
+@pytest.mark.parametrize("cmd,expected_logger", [
+    ("worker", "worker_startup"),
+    ("scheduler", "scheduler_startup"),
+    ("hybrid", "worker_startup")
+])
+def test_startup_script_execution(cmd, expected_logger, mock_environ):
+    """Test successful startup script execution with different commands"""
+    customer_env = {"CUSTOM_VAR": "value"}
+
+    with patch('os.path.isfile', return_value=True), \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess:
+        # Configure mock subprocess
+        mock_process = MagicMock()
+        mock_process.start.return_value = 0
+        MockSubprocess.return_value = mock_process
+
+        with patch('builtins.open', mock_open(read_data='{"CUSTOM_VAR": "value"}')):
+            result = _execute_startup_script(cmd, mock_environ)
+
+            assert result == customer_env
+            # Verify Subprocess was instantiated twice (for script and verification)
+            assert MockSubprocess.call_count == 2
+            # Verify start was called on each instance
+            assert mock_process.start.call_count == 2
+
+
+def test_failed_env_vars_reading(mock_environ):
+    """Test when reading customer environment variables fails"""
+    with patch('os.path.isfile', return_value=True), \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess, \
+            patch('builtins.open') as mock_file:
+        # Configure mock subprocess
+        mock_process = MagicMock()
+        mock_process.start.return_value = 0
+        MockSubprocess.return_value = mock_process
+
+        # Configure file mock to raise exception
+        mock_file.side_effect = Exception("Failed to read file")
+
+        with pytest.raises(Exception) as exc_info:
+            _execute_startup_script("worker", mock_environ)
+
+        assert ("Failed to read customer's environment variables from startup script: "
+                "Failed to read file") in str(exc_info.value)
+
+
+
+def test_missing_customer_env_vars_file(mock_environ):
+    """Test when customer environment variables file is not created"""
+    with patch('os.path.isfile') as mock_isfile, \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess:
+        # Configure mock subprocess
+        mock_process = MagicMock()
+        mock_process.start.return_value = 0
+        MockSubprocess.return_value = mock_process
+
+        # First True for startup script, second False for env vars file
+        mock_isfile.side_effect = [True, False]
+
+        with pytest.raises(Exception) as exc_info:
+            _execute_startup_script("worker", mock_environ)
+
+        assert ("Failed to access customer environment variables file: Service was unable "
+                "to create or locate /tmp/customer_env_vars.json") in str(exc_info.value)
+        assert MockSubprocess.call_count == 2
+
+
+@pytest.mark.parametrize("subprocess_error", [
+    Exception("Process failed"),
+    TimeoutError("Process timed out")
+])
+def test_subprocess_execution_errors(subprocess_error, mock_environ):
+    """Test handling of subprocess execution errors"""
+    with patch('os.path.isfile', return_value=True), \
+            patch('mwaa.config.setup_environment.Subprocess') as MockSubprocess:
+        # Configure mock subprocess to raise error
+        mock_process = MagicMock()
+        mock_process.start.side_effect = subprocess_error
+        MockSubprocess.return_value = mock_process
+
+        with pytest.raises(type(subprocess_error)) as exc_info:
+            _execute_startup_script("worker", mock_environ)
+
+        assert str(subprocess_error) == str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "command,executor_type",
+    [
+        ("worker", "Local"),
+        ("scheduler", "Celery"),
+        ("webserver", "Local"),
+        ("hybrid", "Celery")
+    ]
+)
+def test_setup_environment_variables_different_commands(
+        command,
+        executor_type,
+        mock_environ,
+        mock_config_functions
+):
+    """Test environment setup with different commands and executor types"""
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script:
+        mock_execute_script.return_value = {}
+
+        result = setup_environment_variables(command, executor_type)
+
+        # Verify essential configurations are present
+        assert "ESSENTIAL_CONFIG" in result
+        assert "ESSENTIAL_ENV" in result
+
+        # Verify the execute_startup_script was called correctly
+        mock_execute_script.assert_called_once()
+        args, _ = mock_execute_script.call_args
+        assert args[0] == command
+        # Verify the environment dict was passed (without checking exact contents)
+        assert isinstance(args[1], dict)

--- a/tests/images/airflow/2.11.2/python/mwaa/logging/test_cloudwatch_handler_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/logging/test_cloudwatch_handler_2_11_2.py
@@ -1,0 +1,322 @@
+import logging
+import pytest
+import os
+import importlib
+import types
+from unittest.mock import patch, Mock, MagicMock, ANY
+from airflow.models.taskinstance import TaskInstance
+from mwaa.config.setup_environment import (
+    setup_environment_variables,
+    _execute_startup_script,
+    _export_env_variables,
+    _is_protected_os_environ,
+)
+from mwaa.subprocess.subprocess import Subprocess
+from mwaa.logging.cloudwatch_handlers import (
+    BaseLogHandler,
+    TaskLogHandler,
+    SubprocessLogHandler,
+    DagProcessorManagerLogHandler,
+    DagProcessingLogHandler
+)
+
+print(BaseLogHandler.__init__.__code__.co_varnames)
+
+@pytest.fixture
+def mock_handler():
+    return Mock()
+
+@pytest.fixture
+def mock_boto3_client():
+    with patch('boto3.client') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_watchtower():
+    with patch('mwaa.logging.cloudwatch_handlers.watchtower.CloudWatchLogHandler') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_fluent():
+    with patch('mwaa.logging.fork_safe_handler.ForkSafeFluentHandler') as mock:
+        yield mock
+
+@pytest.fixture(autouse=True)
+def reload_module():
+    import importlib
+    import mwaa.logging.cloudwatch_handlers
+    importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+@pytest.fixture
+def base_logger(mock_handler):
+    logger = BaseLogHandler(
+        log_group_arn="arn:aws:logs:region:account:log-group:test",
+        kms_key_arn="arn:aws:kms:region:account:key/test",
+        enabled=True
+    )
+    logger.handler = mock_handler
+    logger.stats = Mock()
+    return logger
+
+
+
+def test_emit_skips_deprecated_metric_message(base_logger):  # updated parameter name
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="The basic metric validator will be deprecated",
+        args=(),
+        exc_info=None
+    )
+
+    base_logger.emit(record)
+    base_logger.handler.emit.assert_not_called()
+
+
+def test_emit_handles_normal_message(base_logger):  # updated parameter name
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="Normal message",
+        args=(),
+        exc_info=None
+    )
+
+    with patch.dict(os.environ, {'MWAA__LOGGING__AIRFLOW_TEST_LOG_LEVEL': 'INFO'}):
+        base_logger.emit(record)
+        base_logger.handler.emit.assert_called_once_with(record)
+
+
+def test_emit_respects_log_level(base_logger):
+    record = logging.LogRecord(
+        name="test",
+        level=logging.DEBUG,
+        pathname="",
+        lineno=0,
+        msg="Debug message",
+        args=(),
+        exc_info=None
+    )
+
+    with patch.dict(os.environ, {'MWAA__LOGGING__AIRFLOW_TEST_LOG_LEVEL': 'INFO'}):
+        base_logger.emit(record)
+        base_logger.handler.emit.assert_not_called()
+
+
+def test_emit_with_no_handler():
+    logger = BaseLogHandler(
+        log_group_arn="arn:aws:logs:region:account:log-group:test",
+        kms_key_arn="arn:aws:kms:region:account:key/test",
+        enabled=True
+    )
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="Test message",
+        args=(),
+        exc_info=None
+    )
+
+    try:
+        logger.emit(record)
+        assert True  # Test passes if no exception is raised
+    except Exception as e:
+        assert False, f"emit() raised an exception {e} when handler is not set"
+
+def test_emit_handles_exception(base_logger):
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="Test message",
+        args=(),
+        exc_info=None
+    )
+
+    base_logger.handler.emit.side_effect = Exception("Simulated error")
+
+    base_logger.logs_source = "TEST"  # Make sure this is set
+
+    with patch.object(BaseLogHandler, '_report_logging_error') as mock_report_error:
+        base_logger.emit(record)
+
+        # Verify that stats.incr was called with the correct error metric
+        base_logger.stats.incr.assert_called_once_with("mwaa.logging.TEST.emit_error", 1)
+
+        # Verify that _report_logging_error was called with the correct message
+        mock_report_error.assert_called_once_with("Failed to emit log record.")
+
+@pytest.fixture(autouse=True)
+def reload_module():
+    import importlib
+    import mwaa.logging.cloudwatch_handlers
+    importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+@pytest.mark.parametrize("use_non_critical_logging, expected_handler, unexpected_handler", [
+    ('false', 'watchtower', 'fluent'),
+    ('true', 'fluent', 'watchtower')
+])
+def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, use_non_critical_logging, expected_handler, unexpected_handler):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': use_non_critical_logging}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'test_source')
+
+        assert handler.handler is not None, "No handler was created"
+
+        if expected_handler == 'watchtower':
+            assert isinstance(handler.handler, mock_watchtower.return_value.__class__), "Created handler should be a Watchtower handler"
+            assert mock_watchtower.called, f"{expected_handler} handler should be created"
+            assert not mock_fluent.called, f"{unexpected_handler} handler should not be created"
+            mock_watchtower.assert_called_once_with(
+                log_group_name=handler.log_group_name,
+                log_stream_name='test_stream',
+                boto3_client=mock_boto3_client.return_value,
+                use_queues=True,
+                send_interval=10,
+                create_log_group=False
+            )
+        else:
+            assert isinstance(handler.handler, mock_fluent.return_value.__class__), "Created handler should be a Fluent handler"
+            assert mock_fluent.called, f"{expected_handler} handler should be created"
+            assert not mock_watchtower.called, f"{unexpected_handler} handler should not be created"
+            mock_fluent.assert_called_once_with(
+                'customer.logs',
+                host=ANY,
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
+            )
+
+def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = TaskLogHandler('', 'arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+
+        ti = MagicMock(spec=TaskInstance)
+        ti.try_number = 1
+        ti.dag_id = 'test_dag'
+        ti.task_id = 'test_task'
+        ti.execution_date = '2023-01-01'
+
+        handler.set_context(ti)
+
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.task.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
+        }
+
+def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = SubprocessLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_prefix',
+            'test_source',
+            True,
+            log_formatter=logging.Formatter('%(message)s')
+        )
+
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
+        }
+
+def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = DagProcessorManagerLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_stream',
+            True
+        )
+
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
+        }
+
+def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        # Force reload of the module
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        handler = DagProcessingLogHandler(
+            'arn:aws:logs:us-west-2:123456789012:log-group:test',
+            None,
+            'test_stream_template',
+            True
+        )
+
+        handler.set_context('test_dag.py')
+        
+        assert mock_fluent.called
+        assert mock_fluent.call_args.args[0] == 'customer.logs'
+        assert mock_fluent.call_args.kwargs == {
+            'host': ANY,
+            'port': 24224,
+            'queue_maxsize': 50000,
+            'queue_circular': True,
+        }
+
+def test_task_log_handler_io_override_exception_is_caught(mocker):
+    # Create a fake module WITHOUT CloudWatchRemoteLogIO
+    fake_module = types.ModuleType(
+        "airflow.providers.amazon.aws.log.cloudwatch_task_handler"
+    )
+
+    mocker.patch.dict(
+        "sys.modules",
+        {
+            "airflow.providers.amazon.aws.log.cloudwatch_task_handler": fake_module
+        },
+    )
+    mock_warning = mocker.patch("logging.getLogger")
+    TaskLogHandler(
+        base_log_folder="",
+        log_group_arn="arn:aws:logs:us-west-2:123:log-group:test",
+        kms_key_arn=None,
+        enabled=True,
+    )
+
+    # Assert warning logged
+    mock_warning.return_value.warning.assert_called_once()

--- a/tests/images/airflow/2.11.2/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -1,0 +1,229 @@
+"""Tests for ForkSafeFluentSender and ForkSafeFluentHandler.
+
+These tests verify that the fork-safety mechanism works correctly:
+- After os.register_at_fork fires _reinit_after_fork in a child process,
+  all thread-unsafe state (locks, queue, socket) is reset so the child
+  doesn't deadlock on inherited locked mutexes.
+"""
+
+import gc
+import os
+import signal
+import threading
+import time
+import weakref
+from unittest.mock import Mock
+
+import pytest
+
+# Note: ForkSafeFluentHandler and ForkSafeFluentSender are imported inside
+# fixtures and test methods rather than at module level. This is because the
+# test suite uses an autouse fixture that reloads the cloudwatch_handlers module,
+# which creates new class objects. Top-level imports would hold references to
+# the original (pre-reload) classes, causing `is` and `isinstance` checks to fail.
+
+
+@pytest.fixture
+def sender():
+    """Create a ForkSafeFluentSender and ensure cleanup (stops background thread)."""
+    from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
+    s = ForkSafeFluentSender('test', host='localhost', port=24224)
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def handler():
+    """Create a ForkSafeFluentHandler and ensure cleanup."""
+    from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
+    h = ForkSafeFluentHandler('test', host='localhost', port=24224)
+    yield h
+    h.close()
+
+
+class TestForkSafeFluentSender:
+    """Tests for ForkSafeFluentSender fork-safety behavior.
+
+    Each test simulates what happens in a child process after fork by
+    calling _reinit_after_fork() directly, then verifying the sender
+    is in a safe, non-deadlocking state.
+    """
+
+    def test_reinit_after_fork_resets_lock(self, sender):
+        """Verify that a locked lock becomes acquirable after reinit.
+
+        Simulates the scenario where fork() happened while a thread held
+        sender.lock. In the child, _reinit_after_fork replaces it with a
+        fresh unlocked Lock so subsequent code won't deadlock.
+        """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
+        sender.lock.acquire()
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender.lock.acquire(blocking=False), "Lock should be acquirable after reinit"
+        sender.lock.release()
+
+    def test_reinit_after_fork_marks_closed(self, sender):
+        """Verify sender is marked closed so _send() becomes a no-op.
+
+        The _send_loop thread doesn't survive fork, so the sender can never
+        deliver anything. _closed=True makes _send() return False immediately.
+        """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._closed is True
+
+    def test_reinit_after_fork_replaces_queue(self, sender):
+        """Verify the queue is replaced with a fresh empty one.
+
+        Python's Queue uses threading.Lock internally (Queue.mutex).
+        If the _send_loop thread held Queue.mutex at fork time, the child
+        inherits it locked. Replacing the Queue avoids this.
+        """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
+        sender._queue.put(b'test data', block=False)
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._queue.empty(), "Queue should be empty after reinit"
+
+    def test_reinit_after_fork_closes_socket(self, sender):
+        """Verify the inherited TCP socket is closed.
+
+        Prevents the child from sharing a TCP connection with the parent,
+        which would corrupt data on the wire (interleaved writes).
+        """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
+        sender.socket = Mock()
+
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender.socket is None
+
+    def test_send_returns_false_after_reinit(self, sender):
+        """Verify _send() is a no-op after reinit (returns False).
+
+        Confirms that if any code in the child accidentally calls emit()
+        on the inherited handler before set_context() replaces it, the
+        message is silently dropped instead of accumulating in a dead queue.
+        """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        assert sender._send(b'test') is False
+
+    def test_reinit_with_dead_weakref(self):
+        """Verify reinit is a no-op when the sender has been garbage collected.
+
+        os.register_at_fork callbacks are never unregistered, so the callback
+        may fire after the sender is GC'd. Using weakref ensures this case
+        is handled gracefully (no crash, no action).
+        """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
+        sender = ForkSafeFluentSender('test', host='localhost', port=24224)
+        ref = weakref.ref(sender)
+        sender.close()
+        del sender
+        gc.collect()
+
+        # Should not raise
+        ForkSafeFluentSender._reinit_after_fork(ref)
+
+    def test_close_after_reinit_does_not_deadlock(self, sender):
+        """Verify close() completes after reinit (no deadlock on lock).
+
+        asyncsender.close() does 'with self.lock:' - if the lock were still
+        in its inherited locked state, this would deadlock. After reinit,
+        the lock is fresh and unlocked, so close() completes normally.
+        """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
+        ForkSafeFluentSender._reinit_after_fork(weakref.ref(sender))
+
+        completed = []
+
+        def try_close():
+            sender.close()
+            completed.append(True)
+
+        t = threading.Thread(target=try_close)
+        t.start()
+        t.join(timeout=2)
+
+        assert completed, "close() deadlocked after fork reinit"
+
+
+class TestForkSafeFluentHandler:
+    """Tests for ForkSafeFluentHandler wiring."""
+
+    def test_uses_fork_safe_sender_class(self, handler):
+        """Verify getSenderClass() returns ForkSafeFluentSender.
+
+        This is the extension point that makes the handler create our
+        fork-safe sender instead of the default asyncsender.FluentSender.
+        """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
+        assert handler.getSenderClass() is ForkSafeFluentSender
+
+    def test_sender_is_fork_safe_instance(self, handler):
+        """Verify the lazily-created sender is a ForkSafeFluentSender."""
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentSender
+        assert isinstance(handler.sender, ForkSafeFluentSender)
+
+
+class TestForkSafetyIntegration:
+    """Integration test using actual fork()."""
+
+    def test_child_can_close_inherited_handler(self):
+        """Verify a forked child can close an inherited handler without deadlocking.
+
+        This is a smoke test. The real deadlock only occurs when a thread holds
+        the sender lock at the exact moment of fork (a race condition that is not
+        deterministically reproducible). This test verifies the basic machinery:
+        os.register_at_fork fires, _reinit_after_fork runs, and close() completes.
+        """
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
+        handler = ForkSafeFluentHandler('test', host='localhost', port=24224)
+        # Access sender to ensure it is fully initialized (thread + lock + queue)
+        _ = handler.sender
+
+        pid = os.fork()
+        if pid == 0:
+            # Child: close the inherited handler. Without the fix, this could
+            # deadlock if the sender lock was held at fork time.
+            try:
+                handler.close()
+                os._exit(0)
+            except Exception:
+                os._exit(1)
+        else:
+            # Parent: wait for child with timeout to detect deadlock
+            start = time.time()
+            while time.time() - start < 5:
+                result = os.waitpid(pid, os.WNOHANG)
+                if result[0] != 0:
+                    break
+                time.sleep(0.1)
+            else:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+                pytest.fail("Child process deadlocked on close() after fork")
+
+            assert os.WIFEXITED(result[1]) and os.WEXITSTATUS(result[1]) == 0, \
+                "Child process exited with error"
+
+        handler.close()
+
+
+class TestQueueCircularConfiguration:
+    """Test that queue_circular parameter is correctly wired through the handler."""
+
+    def test_handler_passes_queue_circular_to_sender(self):
+        """Verify queue_circular=True is propagated to the underlying sender."""
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
+        h = ForkSafeFluentHandler('test', host='localhost', port=24224,
+                                  queue_maxsize=50000, queue_circular=True)
+        assert h.sender.queue_circular is True
+        assert h.sender.queue_maxsize == 50000
+        h.close()

--- a/tests/images/airflow/2.11.2/python/mwaa/logging/test_subprocess.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/logging/test_subprocess.py
@@ -1,0 +1,149 @@
+import pytest
+from unittest.mock import patch, Mock, call
+import os
+from io import BytesIO
+from subprocess import Popen
+from mwaa.subprocess.subprocess import Subprocess, _SUBPROCESS_LOG_POLL_IDLE_SLEEP_INTERVAL
+import time
+
+@pytest.fixture
+def subprocess_instance():
+    """Fixture to create a Subprocess instance with mock command"""
+    return Subprocess(cmd="test_command")
+
+@pytest.fixture
+def mock_process(mocker):
+    """Fixture to create a mock process"""
+    process = mocker.Mock(spec=Popen)
+    process.poll.side_effect = [None, None, 0]  # Process runs for 2 iterations then ends
+    process.stdout = mocker.Mock()
+    process.stdout.readline.return_value = b'test output\n'
+    return process
+
+@pytest.fixture
+def mock_logger(mocker):
+    """Fixture to create a mock logger"""
+    return mocker.Mock()
+
+
+def test_read_subprocess_log_stream_empty_stream(subprocess_instance):
+    """Test behavior when stream is None"""
+    # Create mock process with None stdout
+    mock_process = Mock(spec=Popen)
+    mock_process.stdout = None
+
+    subprocess_instance.process_logger = Mock()
+    subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    # Assert no logging calls were made
+    subprocess_instance.process_logger.info.assert_not_called()
+    subprocess_instance.process_logger.error.assert_not_called()
+    subprocess_instance.process_logger.warning.assert_not_called()
+
+
+def test_read_subprocess_log_stream_process_running(mocker, subprocess_instance, mock_process, mock_logger):
+    """Test that read_subprocess_log_stream correctly handles a running process"""
+    # Setup
+    subprocess_instance.process_logger = mock_logger
+    mock_process.stdout.closed = False
+
+    # Simulate the following sequence:
+    # 1. Read output line, process running
+    # 2. Read empty line, process running (triggers sleep)
+    # 3. Read empty line, process finished (breaks loop)
+    mock_process.poll.side_effect = [None, None, 0]
+    mock_process.stdout.readline.side_effect = [
+        b'test output\n',
+        b'',
+        b'',
+        b''
+    ]
+
+    # Act
+    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'INFO'}):
+        subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    # Assert
+    assert mock_process.poll.call_count == 3
+    mock_logger.info.assert_called_once_with('test output\n')
+
+
+def test_read_subprocess_log_stream_closed_stream(subprocess_instance):
+    """Test behavior when stream is closed"""
+    # Create and configure mock process
+    mock_process = Mock(spec=Popen)
+    mock_process.stdout = Mock()
+    mock_process.stdout.closed = True
+
+    subprocess_instance.process_logger = Mock()
+    subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    subprocess_instance.process_logger.info.assert_not_called()
+
+
+def test_read_subprocess_log_stream_process_terminated(subprocess_instance):
+    """Test behavior when process has terminated"""
+    # Create and configure mock process
+    mock_process = Mock(spec=Popen)
+    mock_process.stdout = BytesIO(b"final message\n")
+    mock_process.poll.return_value = 0
+
+    subprocess_instance.process_logger = Mock()
+
+    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'INFO'}):
+        subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    subprocess_instance.process_logger.info.assert_called_once_with("final message\n")
+
+
+def test_read_subprocess_log_stream_process_error(mocker, subprocess_instance, mock_process, mock_logger):
+    """Test that read_subprocess_log_stream correctly handles a running process"""
+    # Setup
+    subprocess_instance.process_logger = mock_logger
+    mock_process.stdout.closed = False
+
+    # Simulate the following sequence:
+    # 1. Read output line, process running
+    # 2. Read empty line, process running (triggers sleep)
+    # 3. Read empty line, process finished (breaks loop)
+    mock_process.poll.side_effect = [None, None, 0]
+    mock_process.stdout.readline.side_effect = [
+        b'test output\n',
+        b'',
+        b'',
+        b''
+    ]
+
+    # Act
+    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'ERROR'}):
+        subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    # Assert
+    assert mock_process.poll.call_count == 3
+    mock_logger.error.assert_called_once_with('test output\n')
+
+def test_read_subprocess_log_stream_process_warning(mocker, subprocess_instance, mock_process, mock_logger):
+    """Test that read_subprocess_log_stream correctly handles a running process"""
+    # Setup
+    subprocess_instance.process_logger = mock_logger
+    mock_process.stdout.closed = False
+
+    # Simulate the following sequence:
+    # 1. Read output line, process running
+    # 2. Read empty line, process running (triggers sleep)
+    # 3. Read empty line, process finished (breaks loop)
+    mock_process.poll.side_effect = [None, None, 0]
+    mock_process.stdout.readline.side_effect = [
+        b'test output\n',
+        b'',
+        b'',
+        b''
+    ]
+
+    # Act
+    with patch.dict(os.environ, {'AIRFLOW_CONSOLE_LOG_LEVEL': 'WARNING'}):
+        subprocess_instance._read_subprocess_log_stream(mock_process)
+
+    # Assert
+    assert mock_process.poll.call_count == 3
+    mock_logger.warning.assert_called_once_with('test output\n')

--- a/tests/images/airflow/2.11.2/python/mwaa/subprocess/test_conditions_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/subprocess/test_conditions_2_11_2.py
@@ -1,0 +1,96 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from mwaa.subprocess.conditions import AirflowDbReachableCondition, ProcessStatus, ProcessConditionResponse
+
+
+# ------------------------
+# Fixtures
+# ------------------------
+@pytest.fixture
+def mock_db_connection():
+    """Mock database connection and engine"""
+    mock_connection = MagicMock()
+    mock_engine = MagicMock()
+    mock_engine.connect.return_value.__enter__.return_value = mock_connection
+    return mock_connection, mock_engine
+
+
+@pytest.fixture
+def airflow_db_condition():
+    """Fixture to create AirflowDbReachableCondition instance"""
+    return AirflowDbReachableCondition("scheduler")
+
+
+# ------------------------
+# Test Cases
+# ------------------------
+def test_airflow_db_reachable_condition_success(airflow_db_condition, mock_db_connection):
+    """Test successful database connection with current_user query"""
+    mock_connection, mock_engine = mock_db_connection
+    
+    # Mock the SELECT 1 query
+    mock_connection.execute.side_effect = [
+        MagicMock(),  # SELECT 1 result
+        MagicMock(scalar=lambda: "test_user")  # SELECT current_user result
+    ]
+    
+    airflow_db_condition.engine = mock_engine
+    
+    with patch('mwaa.subprocess.conditions.logger') as mock_logger:
+        response = airflow_db_condition._check(ProcessStatus.RUNNING)
+    
+    # Verify both queries were executed
+    assert mock_connection.execute.call_count == 2
+    mock_connection.execute.assert_any_call("SELECT 1")
+    mock_connection.execute.assert_any_call("SELECT current_user;")
+    
+    # Verify response
+    assert response.successful is True
+    assert "Successfully connected to database as user: test_user" in response.message
+    
+    # Verify logging
+    mock_logger.info.assert_called_with("Successfully connected to database as user: test_user")
+
+
+def test_airflow_db_reachable_condition_failure(airflow_db_condition, mock_db_connection):
+    """Test database connection failure"""
+    mock_connection, mock_engine = mock_db_connection
+    
+    # Mock connection failure
+    mock_engine.connect.side_effect = Exception("Connection failed")
+    airflow_db_condition.engine = mock_engine
+    
+    with patch('mwaa.subprocess.conditions.logger') as mock_logger:
+        response = airflow_db_condition._check(ProcessStatus.RUNNING)
+    
+    # Verify response
+    assert response.successful is True  # Condition is informational only
+    assert "Couldn't connect to database. Error: Connection failed" in response.message
+    
+    # Verify logging
+    mock_logger.error.assert_called_with("Couldn't connect to database. Error: Connection failed")
+
+
+def test_airflow_db_condition_health_plog_generation(airflow_db_condition, mock_db_connection):
+    """Test health plog generation for database condition"""
+    mock_connection, mock_engine = mock_db_connection
+    mock_connection.execute.side_effect = [
+        MagicMock(),
+        MagicMock(scalar=lambda: "test_user")
+    ]
+    
+    airflow_db_condition.engine = mock_engine
+    airflow_db_condition.healthy = False  # Previous state was unhealthy
+    
+    with patch('mwaa.subprocess.conditions.generate_plog') as mock_generate_plog, \
+         patch('builtins.print') as mock_print:
+        
+        mock_generate_plog.return_value = "test_plog_message"
+        airflow_db_condition._check(ProcessStatus.RUNNING)
+        
+        # Verify plog generation for health change
+        mock_generate_plog.assert_called_once_with(
+            "RDSHealthLogsProcessor",
+            "[scheduler] connection with RDS Meta DB is CONNECTION_BECAME_HEALTHY."
+        )
+        mock_print.assert_called_once_with("test_plog_message")

--- a/tests/images/airflow/2.11.2/python/mwaa/test_entrypoint_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/test_entrypoint_2_11_2.py
@@ -1,0 +1,312 @@
+# test_entrypoint.py
+import pytest
+import os
+import sys
+from unittest.mock import patch, MagicMock, mock_open
+from botocore.exceptions import ClientError
+
+import mwaa.entrypoint as entrypoint
+from mwaa.entrypoint import (
+    _setup_console_log_level,
+    _configure_root_logger,
+    airflow_db_migrate,
+    create_airflow_user,
+    create_queue,
+    main
+)
+
+
+# ------------------------
+# Fixtures
+# ------------------------
+@pytest.fixture
+def mock_environ(monkeypatch):
+    """Basic environment variables fixture"""
+    env_vars = {
+        "MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL": "INFO",
+        "MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL": "INFO",
+        "MWAA__LOGGING__AIRFLOW_WEBSERVER_LOG_LEVEL": "INFO",
+        "MWAA__CORE__EXECUTOR_TYPE": "CeleryExecutor",
+        "MWAA__CORE__AUTH_TYPE": "testing",
+        "MWAA__CORE__CREATED_AT": "Mon Sep 11 00:00:00 UTC 2024",
+        "MWAA__CORE__TESTING_MODE": "true",
+        # Database configuration
+        "MWAA__DB__POSTGRES_HOST": "localhost",
+        "MWAA__DB__POSTGRES_PORT": "5432",
+        "MWAA__DB__POSTGRES_DB": "airflow",
+        "MWAA__DB__POSTGRES_USER": "airflow",
+        "MWAA__DB__POSTGRES_PASSWORD": "airflow",
+        "MWAA__DB__POSTGRES_SSLMODE": "disable",
+        "PYTHONPATH": os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    }
+    monkeypatch.setattr(os, "environ", env_vars)
+    return env_vars
+
+
+@pytest.fixture
+def mock_boto3_client():
+    """Mock boto3 client for SQS operations"""
+    with patch('boto3.client') as mock_client:
+        yield mock_client
+
+
+@pytest.fixture
+def mock_db_utils():
+    """Mock database utilities"""
+    with patch('mwaa.utils.dblock.create_engine') as mock_engine, \
+            patch('mwaa.utils.dblock.get_db_connection_string', return_value='postgresql://localhost/airflow'):
+        engine = MagicMock()
+        mock_engine.return_value = engine
+        yield engine
+
+
+# ------------------------
+# Test Cases
+# ------------------------
+
+@pytest.mark.parametrize("command,expected_level", [
+    ("scheduler", "INFO"),
+    ("worker", "INFO"),
+    ("webserver", "INFO"),
+    ("unknown", "INFO"),
+])
+def test_setup_console_log_level(command, expected_level, mock_environ):
+    """Test console log level setup"""
+    with patch.dict(os.environ, mock_environ, clear=True):
+        _setup_console_log_level(command)
+        assert os.environ['AIRFLOW_CONSOLE_LOG_LEVEL'] == expected_level
+
+
+def test_configure_root_logger(mock_environ):
+    """Test root logger configuration"""
+    with patch('logging.config.dictConfig') as mock_dict_config, \
+            patch.dict(os.environ, mock_environ, clear=True):
+        _configure_root_logger("scheduler")
+        mock_dict_config.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_airflow_db_migrate(mock_db_utils):
+    """Test Airflow database initialization"""
+    environ = {"PYTHONPATH": os.environ.get("PYTHONPATH", "")}
+
+    async def mock_run_command(cmd, env=None):
+        return 0
+
+    with patch('mwaa.entrypoint.run_command', side_effect=mock_run_command) as mock_cmd:
+        await airflow_db_migrate(environ)
+        mock_cmd.assert_called_once_with(
+            "python3 -m mwaa.database.migrate_with_downgrade",
+            env=environ
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_airflow_user(mock_db_utils, mock_environ):
+    """Test Airflow user creation"""
+
+    async def mock_run_command(cmd, env=None):
+        return 0
+
+    with patch('mwaa.entrypoint.run_command', side_effect=mock_run_command) as mock_cmd:
+        await create_airflow_user(mock_environ)
+        assert mock_cmd.called
+        assert "airflow users create" in mock_cmd.call_args[0][0]
+
+
+def test_create_queue_when_not_required(mock_environ, mock_db_utils):
+    """Test queue creation when not required"""
+    with patch('mwaa.entrypoint.should_create_queue', return_value=False):
+        create_queue()
+
+
+def test_create_existing_queue(mock_environ, mock_db_utils, mock_boto3_client):
+    """Test handling of existing queue"""
+    with patch('mwaa.entrypoint.should_create_queue', return_value=True), \
+            patch('mwaa.entrypoint.get_sqs_queue_name', return_value='test-queue'):
+        mock_sqs = MagicMock()
+        mock_boto3_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.return_value = {"QueueUrl": "test-url"}
+
+        create_queue()
+
+        mock_sqs.get_queue_url.assert_called_once_with(QueueName='test-queue')
+        mock_sqs.create_queue.assert_not_called()
+
+
+def test_create_new_queue(mock_environ, mock_db_utils, mock_boto3_client):
+    """Test creation of new queue"""
+    with patch('mwaa.entrypoint.should_create_queue', return_value=True), \
+            patch('mwaa.entrypoint.get_sqs_queue_name', return_value='test-queue'):
+        mock_sqs = MagicMock()
+        mock_boto3_client.return_value = mock_sqs
+        mock_sqs.get_queue_url.side_effect = ClientError(
+            {'Error': {'Message': 'The specified queue does not exist.'}},
+            'GetQueueUrl'
+        )
+
+        create_queue()
+
+        mock_sqs.create_queue.assert_called_once_with(QueueName='test-queue')
+
+
+@pytest.mark.asyncio
+async def test_main_valid_command(mock_environ, mock_db_utils):
+    """Test main function with valid command"""
+    test_args = ['script.py', 'scheduler']
+
+    async def mock_run_command(cmd, env=None):
+        return 0
+
+    with patch.dict(os.environ, mock_environ), \
+            patch.object(sys, 'argv', test_args), \
+            patch('mwaa.entrypoint.run_command', side_effect=mock_run_command), \
+            patch('mwaa.entrypoint.setup_environment_variables') as mock_setup_env, \
+            patch('mwaa.entrypoint.install_user_requirements') as mock_install_req, \
+            patch('mwaa.entrypoint.create_queue') as mock_create_queue, \
+            patch('mwaa.entrypoint.execute_command') as mock_execute:
+        mock_setup_env.return_value = mock_environ
+        mock_install_req.return_value = None
+
+        await main()
+
+        mock_setup_env.assert_called_once()
+        mock_install_req.assert_called_once()
+        mock_create_queue.assert_called_once()
+        mock_execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_main_invalid_command():
+    """Test main function with invalid command"""
+    test_args = ['script.py', 'invalid']
+    with patch.object(sys, 'argv', test_args):
+        with pytest.raises(SystemExit):
+            await main()
+
+
+@pytest.mark.asyncio
+async def test_main_test_requirements(mock_environ, mock_db_utils):
+    """Test main function with test-requirements command"""
+    test_args = ['script.py', 'test-requirements']
+    with patch.dict(os.environ, mock_environ), \
+            patch.object(sys, 'argv', test_args), \
+            patch('mwaa.entrypoint.setup_environment_variables') as mock_setup_env, \
+            patch('mwaa.entrypoint.install_user_requirements') as mock_install_req:
+        mock_setup_env.return_value = mock_environ
+
+        await main()
+
+        mock_setup_env.assert_called_once()
+        mock_install_req.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_main_migrate_db(mock_environ, mock_db_utils):
+    """Test main function with migrate-db command"""
+    test_args = ['script.py', 'migrate-db']
+    with patch.dict(os.environ, mock_environ), \
+            patch.object(sys, 'argv', test_args), \
+            patch('mwaa.entrypoint.setup_environment_variables') as mock_setup_env, \
+            patch('mwaa.entrypoint.airflow_db_migrate') as mock_db_migrate:
+        mock_setup_env.return_value = mock_environ
+
+        await main()
+
+        mock_setup_env.assert_called_once()
+        mock_db_migrate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_main_missing_arguments():
+    """Test main function with missing arguments"""
+    test_args = ['script.py']
+    with patch.object(sys, 'argv', test_args):
+        with pytest.raises(SystemExit):
+            await main()
+
+
+def test_import_guard():
+    """Test import guard functionality"""
+    with patch.dict(os.environ, {'MWAA__CORE__TESTING_MODE': 'false'}, clear=True), \
+            patch('sys.exit') as mock_exit:
+        import importlib
+        importlib.reload(entrypoint)
+        mock_exit.assert_called_once_with(1)
+
+
+def test_mark_as_unhealthy(mock_environ):
+    """Test basic functionality of _mark_as_unhealthy"""
+    with patch('os.makedirs') as mock_makedirs, \
+         patch('builtins.open', mock_open()) as mock_file, \
+         patch('time.sleep') as mock_sleep:
+        
+        entrypoint._mark_as_unhealthy()
+
+        # Verify directory creation
+        mock_makedirs.assert_called_once_with('/tmp/mwaa', exist_ok=True)
+        
+        # Verify file creation
+        mock_file.assert_called_once_with('/tmp/mwaa/container_unhealthy', 'w')
+        
+        # Verify sleep was called (assuming new container)
+        mock_sleep.assert_called_once_with(1100)
+
+
+def test_mark_as_unhealthy_error(mock_environ):
+    """Test error handling in _mark_as_unhealthy"""
+    with patch('os.makedirs', side_effect=Exception("Directory creation failed")), \
+         patch('time.sleep') as mock_sleep:
+        
+        entrypoint._mark_as_unhealthy()
+        
+        # Verify sleep was still called
+        mock_sleep.assert_called_once_with(1100)
+
+
+def test_fix_shared_log_volume_permissions_on_mount(mock_environ):
+    """Test _fix_shared_log_volume_permissions runs chown when path is a mount point."""
+    with patch('os.path.ismount', return_value=True) as mock_ismount, \
+         patch('subprocess.run') as mock_run, \
+         patch('os.makedirs') as mock_makedirs:
+        entrypoint._fix_shared_log_volume_permissions()
+
+        mock_ismount.assert_called_once_with('/usr/local/airflow/logs')
+        mock_run.assert_called_once_with(
+            ['sudo', 'chown', '-R', 'airflow:', '/usr/local/airflow/logs'],
+            check=True,
+        )
+        mock_makedirs.assert_called_once_with(
+            '/usr/local/airflow/logs/dag_processor', exist_ok=True
+        )
+
+
+def test_fix_shared_log_volume_permissions_not_mount(mock_environ):
+    """Test _fix_shared_log_volume_permissions skips chown when path is not a mount."""
+    with patch('os.path.ismount', return_value=False) as mock_ismount, \
+         patch('subprocess.run') as mock_run:
+        entrypoint._fix_shared_log_volume_permissions()
+
+        mock_ismount.assert_called_once_with('/usr/local/airflow/logs')
+        mock_run.assert_not_called()
+
+
+def test_fix_shared_log_volume_permissions_chown_failure(mock_environ):
+    """Test _fix_shared_log_volume_permissions handles chown failure gracefully."""
+    with patch('os.path.ismount', return_value=True), \
+         patch('subprocess.run', side_effect=Exception('Permission denied')), \
+         patch('os.makedirs') as mock_makedirs:
+        # Should not raise — just prints a warning
+        entrypoint._fix_shared_log_volume_permissions()
+        # dag_processor dir creation should still be attempted after chown failure
+        mock_makedirs.assert_called_once_with(
+            '/usr/local/airflow/logs/dag_processor', exist_ok=True
+        )
+
+
+def test_fix_shared_log_volume_permissions_dag_processor_dir_failure(mock_environ):
+    """Test _fix_shared_log_volume_permissions handles dag_processor mkdir failure gracefully."""
+    with patch('os.path.ismount', return_value=True), \
+         patch('subprocess.run'), \
+         patch('os.makedirs', side_effect=OSError('Read-only file system')):
+        # Should not raise — just prints a warning
+        entrypoint._fix_shared_log_volume_permissions()

--- a/tests/images/airflow/2.11.2/python/mwaa/test_execute_command_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/test_execute_command_2_11_2.py
@@ -1,0 +1,148 @@
+import pytest
+import os
+from unittest.mock import patch, MagicMock, mock_open
+
+# Set CONTAINER_START_TIME before importing the module
+TEST_CONTAINER_START_TIME = 1234567890.0
+with patch.dict('os.environ', {'CONTAINER_START_TIME': str(TEST_CONTAINER_START_TIME)}):
+    from mwaa.execute_command import (
+        execute_command,
+        HYBRID_WORKER_SIGTERM_PATIENCE_INTERVAL_DEFAULT
+    )
+
+
+# ------------------------
+# Fixtures
+# ------------------------
+@pytest.fixture
+def mock_environ():
+    """Basic environment variables fixture"""
+    return {
+        "AIRFLOW_HOME": "/usr/local/airflow",
+        "MWAA__CORE__TASK_MONITORING_ENABLED": "false",
+        "MWAA__CORE__TERMINATE_IF_IDLE": "false",
+        "MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED": "false",
+        "MWAA__HEALTH_MONITORING__ENABLE_SIDECAR_HEALTH_MONITORING": "false",
+        "MWAA__HYBRID_CONTAINER__SIGTERM_PATIENCE_INTERVAL": "150",
+        "MWAA__DB__POSTGRES_HOST": "localhost",
+        "MWAA__DB__POSTGRES_PORT": "5432",
+        "MWAA__DB__POSTGRES_DB": "airflow",
+        "MWAA__DB__POSTGRES_SSLMODE": "disable"
+    }
+
+
+@pytest.fixture
+def mock_subprocess():
+    """Mock Subprocess"""
+    process = MagicMock()
+    process.start.return_value = 0
+    process.process = MagicMock()
+    process.process.returncode = 0
+
+    with patch('mwaa.subprocess.subprocess.Subprocess', return_value=process) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_run_subprocesses():
+    """Mock run_subprocesses"""
+    with patch('mwaa.execute_command.run_subprocesses') as mock:
+        yield mock
+
+def remove_celery_state():
+    try:
+        os.remove("/celery_state_")
+    except FileNotFoundError:
+        pass
+
+
+@pytest.fixture
+def mock_file_operations():
+    """Mock file-related operations"""
+    with patch("os.path.exists", return_value=False), \
+         patch("builtins.open", mock_open()), \
+         patch("os.remove"):
+        yield
+
+
+# ------------------------
+# Test Cases
+# ------------------------
+
+def test_execute_command_shell(mock_environ):
+    """Test shell command execution"""
+    with patch('os.execlpe') as mock_exec:
+        execute_command("shell", mock_environ, TEST_CONTAINER_START_TIME)
+        mock_exec.assert_called_once_with("/bin/bash", "/bin/bash", mock_environ)
+
+
+def test_execute_command_spy(mock_environ):
+    """Test spy command execution"""
+    with patch('time.sleep', side_effect=KeyboardInterrupt) as mock_sleep:
+        with pytest.raises(KeyboardInterrupt):
+            execute_command("spy", mock_environ, TEST_CONTAINER_START_TIME)
+        mock_sleep.assert_called_once_with(1)
+
+
+@pytest.mark.parametrize("command,expected_subprocesses", [
+    ("scheduler", 3),  # scheduler, dag-processor, triggerer
+    ("worker", 1),  # celery worker
+    ("webserver", 1),  # webserver
+    ("hybrid", 4),  # scheduler, dag-processor, triggerer, worker
+])
+def test_execute_command_airflow_components(command, expected_subprocesses, mock_environ, mock_run_subprocesses):
+    """Test execution of different Airflow components"""
+    execute_command(command, mock_environ, TEST_CONTAINER_START_TIME)
+    assert mock_run_subprocesses.called
+    subprocess_calls = mock_run_subprocesses.call_args[0][0]
+    assert len(subprocess_calls) == expected_subprocesses
+
+
+def test_execute_command_invalid(mock_environ):
+    """Test invalid command execution"""
+    with pytest.raises(ValueError, match="Invalid command"):
+        execute_command("invalid", mock_environ, TEST_CONTAINER_START_TIME)
+
+
+def test_execute_command_worker_idle_termination(mock_environ, mock_run_subprocesses):
+    """Test worker with idle termination enabled"""
+    with patch.dict(os.environ, {"MWAA__CORE__TERMINATE_IF_IDLE": "true"}):
+        execute_command("worker", mock_environ, TEST_CONTAINER_START_TIME)
+    mock_run_subprocesses.assert_called()
+
+
+def test_execute_command_worker_signal_handling(mock_environ, mock_run_subprocesses):
+    """Test worker with signal handling enabled"""
+    with patch.dict(os.environ, {"MWAA__CORE__MWAA_SIGNAL_HANDLING_ENABLED": "true"}):
+        execute_command("worker", mock_environ, TEST_CONTAINER_START_TIME)
+    mock_run_subprocesses.assert_called()
+
+
+def test_execute_command_container_start_time(mock_environ, mock_run_subprocesses):
+    """Test container start time is properly set"""
+    test_time = 9876543210.0
+    execute_command("scheduler", mock_environ, test_time)
+    from mwaa.execute_command import CONTAINER_START_TIME
+    assert CONTAINER_START_TIME == test_time
+
+
+@patch('mwaa.celery.task_monitor.WorkerTaskMonitor')
+@patch('multiprocessing.shared_memory.SharedMemory')
+def test_execute_command_task_monitoring_enabled(mock_shared_memory, mock_worker_monitor, mock_environ,
+                                                 mock_run_subprocesses):
+    """Test execute_command when task monitoring is enabled in environment variables"""
+    # Setup the mocks
+    mock_worker_instance = MagicMock()
+    mock_worker_monitor.return_value = mock_worker_instance
+
+    mock_shared_memory_instance = MagicMock()
+    mock_shared_memory.return_value = mock_shared_memory_instance
+
+    with patch.dict(os.environ, {"MWAA__CORE__TASK_MONITORING_ENABLED": "true"}, clear=True):
+        execute_command("worker", mock_environ, TEST_CONTAINER_START_TIME)
+
+    # Verify run_subprocesses was called
+    mock_run_subprocesses.assert_called()
+
+
+

--- a/tests/images/airflow/2.11.2/python/mwaa/utils/test_dblock_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/utils/test_dblock_2_11_2.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def test_connect_with_retry_uses_static_credentials_when_iam_disabled():
+    """Test that _connect_with_retry uses get_db_connection_string when IAM is disabled."""
+    from mwaa.utils.dblock import _connect_with_retry
+
+    with patch('mwaa.config.airflow_rds_iam_patch.use_iam_credentials', return_value=False), \
+         patch('mwaa.utils.dblock.create_engine') as mock_create_engine, \
+         patch('mwaa.utils.dblock.get_db_connection_string', return_value='postgresql://static/airflow'):
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        result = _connect_with_retry()
+
+        mock_create_engine.assert_called_once()
+        call_args = mock_create_engine.call_args
+        assert call_args[0][0] == 'postgresql://static/airflow'
+        assert result == mock_conn
+
+
+def test_connect_with_retry_uses_iam_credentials_when_enabled():
+    """Test that _connect_with_retry uses RDSIAMCredentialProvider when IAM is enabled."""
+    from mwaa.utils.dblock import _connect_with_retry
+
+    with patch('mwaa.config.airflow_rds_iam_patch.use_iam_credentials', return_value=True), \
+         patch('mwaa.utils.get_rds_iam_credentials.RDSIAMCredentialProvider') as mock_provider, \
+         patch('mwaa.utils.dblock.create_engine') as mock_create_engine, \
+         patch('mwaa.utils.dblock.get_db_connection_string', return_value='postgresql://static/airflow'):
+        mock_provider.get_token.return_value = 'iam-token-123'
+        mock_provider.create_db_connection_url.return_value = 'postgresql://airflow_user:iam-token-123@host/db'
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        result = _connect_with_retry()
+
+        mock_provider.get_token.assert_called_once()
+        mock_provider.create_db_connection_url.assert_called_once_with('iam-token-123')
+        mock_create_engine.assert_called_once()
+        call_args = mock_create_engine.call_args
+        assert call_args[0][0] == 'postgresql://airflow_user:iam-token-123@host/db'
+        assert result == mock_conn

--- a/tests/images/airflow/2.11.2/python/mwaa/utils/test_get_rds_iam_credentials_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/utils/test_get_rds_iam_credentials_2_11_2.py
@@ -1,0 +1,267 @@
+import pytest
+import json
+import time
+from unittest.mock import patch, MagicMock
+
+
+def test_get_ecs_credentials_success():
+    """Test successful ECS credentials retrieval"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    mock_credentials = {
+        'AccessKeyId': 'test_key',
+        'SecretAccessKey': 'test_secret',
+        'Token': 'test_token'
+    }
+    
+    with patch.dict('os.environ', {
+        'AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI': '/v2/credentials/test',
+        'ECS_CONTAINER_METADATA_URI': 'http://169.254.170.2/v3/containers/test'
+    }), \
+    patch('urllib.request.build_opener') as mock_build_opener:
+        
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = json.dumps(mock_credentials).encode('utf-8')
+        
+        mock_opener = MagicMock()
+        mock_opener.open.return_value.__enter__.return_value = mock_response
+        mock_build_opener.return_value = mock_opener
+        
+        result = RDSIAMCredentialProvider.get_ecs_credentials()
+        assert result == mock_credentials
+
+
+def test_get_ecs_credentials_missing_env():
+    """Test ECS credentials with missing environment variables"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    with patch.dict('os.environ', {}, clear=True):
+        with pytest.raises(ValueError, match="AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI not set"):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+
+
+def test_get_ecs_credentials_missing_metadata_uri():
+    """Test ECS credentials with missing ECS_CONTAINER_METADATA_URI"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    with patch.dict('os.environ', {'AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI': '/v2/credentials/test'}, clear=True):
+        with pytest.raises(ValueError, match="ECS_CONTAINER_METADATA_URI not set"):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+
+
+def test_get_ecs_credentials_http_error():
+    """Test ECS credentials with HTTP error response"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    with patch.dict('os.environ', {
+        'AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI': '/v2/credentials/test',
+        'ECS_CONTAINER_METADATA_URI': 'http://169.254.170.2/v3/containers/test'
+    }), \
+    patch('urllib.request.build_opener') as mock_build_opener:
+        
+        mock_response = MagicMock()
+        mock_response.status = 404
+        
+        mock_opener = MagicMock()
+        mock_opener.open.return_value.__enter__.return_value = mock_response
+        mock_build_opener.return_value = mock_opener
+        
+        with pytest.raises(Exception, match="Failed to fetch ECS credentials: 404"):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+
+
+def test_get_ecs_credentials_ignores_proxy_env_vars():
+    """Test that proxy environment variables don't affect ECS metadata requests"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    mock_credentials = {
+        'AccessKeyId': 'test_key',
+        'SecretAccessKey': 'test_secret', 
+        'Token': 'test_token'
+    }
+    
+    with patch.dict('os.environ', {
+        'AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI': '/v2/credentials/test',
+        'ECS_CONTAINER_METADATA_URI': 'http://169.254.170.2/v3/containers/test',
+        'HTTP_PROXY': 'http://should-not-be-used:8080',
+        'HTTPS_PROXY': 'http://should-not-be-used:8080',
+        'http_proxy': 'http://should-not-be-used:8080',
+        'https_proxy': 'http://should-not-be-used:8080'
+    }), \
+    patch('urllib.request.build_opener') as mock_build_opener, \
+    patch('urllib.request.ProxyHandler') as mock_proxy_handler:
+        
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = json.dumps(mock_credentials).encode('utf-8')
+        
+        mock_opener = MagicMock()
+        mock_opener.open.return_value.__enter__.return_value = mock_response
+        mock_build_opener.return_value = mock_opener
+        
+        result = RDSIAMCredentialProvider.get_ecs_credentials()
+        
+        # Verify that ProxyHandler was instantiated with empty dict
+        mock_proxy_handler.assert_called_once_with({})
+        # Verify build_opener was called with the no-proxy handler
+        mock_build_opener.assert_called_once()
+        
+        assert result == mock_credentials
+
+
+def test_get_rds_iam_token_hostname_success():
+    """Test successful RDS IAM token hostname retrieval"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    with patch.dict('os.environ', {'RDS_IAM_TOKEN_HOSTNAME': 'test.rds.amazonaws.com'}):
+        result = RDSIAMCredentialProvider.get_rds_iam_token_hostname()
+        assert result == 'test.rds.amazonaws.com'
+
+
+def test_get_rds_iam_token_hostname_missing():
+    """Test RDS IAM token hostname with missing environment variable"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    with patch.dict('os.environ', {}, clear=True), \
+         patch('mwaa.utils.get_rds_iam_credentials.logger') as mock_logger:
+        
+        with pytest.raises(ValueError, match="RDS_IAM_TOKEN_HOSTNAME environment variable is required"):
+            RDSIAMCredentialProvider.get_rds_iam_token_hostname()
+
+
+def test_generate_rds_auth_token():
+    """Test RDS auth token generation"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    mock_credentials = {
+        'AccessKeyId': 'test_key',
+        'SecretAccessKey': 'test_secret',
+        'Token': 'test_token'
+    }
+    
+    with patch('boto3.client') as mock_boto3:
+        mock_rds_client = MagicMock()
+        mock_rds_client.generate_db_auth_token.return_value = 'test_auth_token'
+        mock_boto3.return_value = mock_rds_client
+        
+        result = RDSIAMCredentialProvider.generate_rds_auth_token(
+            mock_credentials, 'test.rds.amazonaws.com', 5432, 'airflow_user'
+        )
+        
+        assert result == 'test_auth_token'
+        mock_rds_client.generate_db_auth_token.assert_called_once()
+
+
+def test_generate_rds_auth_token_failure():
+    """Test RDS auth token generation failure"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    mock_credentials = {
+        'AccessKeyId': 'test_key',
+        'SecretAccessKey': 'test_secret',
+        'Token': 'test_token'
+    }
+    
+    with patch('boto3.client') as mock_boto3, \
+         patch('mwaa.utils.get_rds_iam_credentials.logger') as mock_logger:
+        
+        mock_rds_client = MagicMock()
+        mock_rds_client.generate_db_auth_token.side_effect = Exception("Token generation failed")
+        mock_boto3.return_value = mock_rds_client
+        
+        with pytest.raises(Exception, match="Token generation failed"):
+            RDSIAMCredentialProvider.generate_rds_auth_token(
+                mock_credentials, 'test.rds.amazonaws.com', 5432, 'airflow_user'
+            )
+        
+        mock_logger.error.assert_called_once_with("Failed to generate RDS auth token: Token generation failed")
+
+
+def test_get_token_cached():
+    """Test cached token retrieval"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    RDSIAMCredentialProvider._token = 'cached_token'
+    RDSIAMCredentialProvider._expires_at = time.time() + 600
+    
+    result = RDSIAMCredentialProvider.get_token()
+    assert result == 'cached_token'
+
+
+def test_get_token_refresh_needed():
+    """Test token refresh when expired"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    RDSIAMCredentialProvider._token = 'old_token'
+    RDSIAMCredentialProvider._expires_at = time.time() - 100
+    
+    with patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value='new_token'):
+        result = RDSIAMCredentialProvider.get_token()
+        assert result == 'new_token'
+        assert RDSIAMCredentialProvider._token == 'new_token'
+
+
+def test_generate_credentials_success():
+    """Test successful credential generation"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    mock_credentials = {'AccessKeyId': 'key', 'SecretAccessKey': 'secret', 'Token': 'token'}
+    
+    with patch.object(RDSIAMCredentialProvider, 'get_ecs_credentials', return_value=mock_credentials), \
+         patch.object(RDSIAMCredentialProvider, 'get_rds_iam_token_hostname', return_value='test.rds.amazonaws.com'), \
+         patch.object(RDSIAMCredentialProvider, 'generate_rds_auth_token', return_value='auth_token'):
+        
+        result = RDSIAMCredentialProvider.generate_credentials()
+        assert result == 'auth_token'
+
+
+def test_generate_credentials_failure():
+    """Test credential generation failure"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    with patch.object(RDSIAMCredentialProvider, 'get_ecs_credentials', side_effect=Exception("ECS error")), \
+         patch('mwaa.utils.get_rds_iam_credentials.logger') as mock_logger:
+        
+        result = RDSIAMCredentialProvider.generate_credentials()
+        assert result is None
+        mock_logger.error.assert_called_with("Failed to update credentials: ECS error")
+
+
+def test_create_db_connection_url():
+    """Test database connection URL creation"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    with patch.dict('os.environ', {
+        'POSTGRES_HOST': 'test.rds.amazonaws.com',
+        'POSTGRES_PORT': '5432',
+        'POSTGRES_DB': 'airflow',
+        'SSL_MODE': 'require'
+    }):
+        result = RDSIAMCredentialProvider.create_db_connection_url('test_token')
+        assert 'postgresql+psycopg2://airflow_user:test_token@test.rds.amazonaws.com:5432/airflow?sslmode=require' in result
+
+
+def test_create_db_connection_url_generate_token():
+    """Test database connection URL creation with token generation"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    with patch.dict('os.environ', {
+        'POSTGRES_HOST': 'test.rds.amazonaws.com',
+        'POSTGRES_PORT': '5432',
+        'POSTGRES_DB': 'airflow',
+        'SSL_MODE': 'require'
+    }), \
+    patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value='generated_token'):
+        
+        result = RDSIAMCredentialProvider.create_db_connection_url()
+        assert 'postgresql+psycopg2://airflow_user:generated_token@test.rds.amazonaws.com:5432/airflow?sslmode=require' in result
+
+
+def test_create_db_connection_url_generation_failure():
+    """Test database connection URL creation when token generation fails"""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+    
+    with patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value=None):
+        with pytest.raises(Exception, match="Failed to generate RDS auth token"):
+            RDSIAMCredentialProvider.create_db_connection_url()

--- a/tests/images/airflow/2.11.2/python/mwaa/utils/test_user_requirements_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/utils/test_user_requirements_2_11_2.py
@@ -1,0 +1,198 @@
+# test_user_requirements.py
+import pytest
+import os
+from unittest.mock import patch, mock_open, MagicMock
+from datetime import timedelta
+
+from mwaa.utils.user_requirements import (
+    install_user_requirements,
+    _read_requirements_file,
+    _requirements_has_constraints,
+    USER_REQUIREMENTS_MAX_INSTALL_TIME
+)
+
+
+# ------------------------
+# Fixtures
+# ------------------------
+@pytest.fixture
+def mock_environ():
+    """Basic environment variables fixture"""
+    return {
+        "MWAA__CORE__REQUIREMENTS_PATH": "/path/to/requirements.txt",
+        "AIRFLOW_CONSTRAINTS_FILE": "/path/to/constraints.txt",
+        "MWAA__LOGGING__AIRFLOW_WORKER_LOG_LEVEL": "INFO",
+        "MWAA__LOGGING__AIRFLOW_SCHEDULER_LOG_LEVEL": "INFO",
+    }
+
+
+@pytest.fixture
+def mock_subprocess():
+    """Mock Subprocess class"""
+    subprocess_instance = MagicMock()
+    subprocess_instance.process = MagicMock()
+    subprocess_instance.process.returncode = 0
+    subprocess_instance.start = MagicMock(return_value=0)
+
+    with patch('mwaa.utils.user_requirements.Subprocess', return_value=subprocess_instance) as mock:
+        yield mock, subprocess_instance
+
+
+@pytest.fixture
+def mock_composite_logger():
+    """Mock CompositeLogger"""
+    logger_instance = MagicMock()
+    with patch('mwaa.utils.user_requirements.CompositeLogger', return_value=logger_instance) as mock:
+        yield mock, logger_instance
+
+
+# ------------------------
+# Test Cases
+# ------------------------
+
+def test_read_requirements_file():
+    """Test reading requirements file"""
+    content = "package1==1.0.0\npackage2>=2.0.0"
+    with patch('builtins.open', mock_open(read_data=content.encode())):
+        result = _read_requirements_file("requirements.txt")
+        assert result == content
+
+
+@pytest.mark.parametrize("content,expected", [
+    ("package1==1.0.0\n-c constraints.txt", True),
+    ("package1==1.0.0\npackage2>=2.0.0", False),
+    ("# -c constraints.txt\npackage1==1.0.0", True),
+])
+def test_requirements_has_constraints(content, expected):
+    """Test constraint detection in requirements file"""
+    with patch('mwaa.utils.user_requirements._read_requirements_file', return_value=content):
+        assert _requirements_has_constraints("requirements.txt") == expected
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_no_file(mock_environ):
+    """Test when no requirements file is specified"""
+    with patch.dict(os.environ, {}, clear=True):
+        await install_user_requirements("worker", {})
+        # Should complete without error
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_with_constraints(mock_environ):
+    """Test installation with constraints"""
+    requirements_content = "package1==1.0.0\n-c constraints.txt"
+
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value=requirements_content), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+        mock_process = MagicMock()
+        mock_process.process = MagicMock()
+        mock_subprocess.return_value = mock_process
+
+        await install_user_requirements("worker", mock_environ)
+
+        mock_subprocess.assert_called_once()
+        call_args = mock_subprocess.call_args[1]
+        assert call_args['cmd'] == ['safe-pip-install', '-r', mock_environ['MWAA__CORE__REQUIREMENTS_PATH']]
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_without_constraints(mock_environ):
+    """Test installation without constraints"""
+    requirements_content = "package1==1.0.0"
+
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value=requirements_content), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+        mock_process = MagicMock()
+        mock_process.process = MagicMock()
+        mock_subprocess.return_value = mock_process
+
+        await install_user_requirements("worker", mock_environ)
+
+        mock_subprocess.assert_called_once()
+        call_args = mock_subprocess.call_args[1]
+        assert '-c' in call_args['cmd']
+        assert mock_environ['AIRFLOW_CONSTRAINTS_FILE'] in call_args['cmd']
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_installation_error(mock_environ):
+    """Test handling of installation errors"""
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value="package1==1.0.0"), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess, \
+            patch('mwaa.utils.user_requirements.CompositeLogger') as mock_logger:
+        mock_process = MagicMock()
+        mock_process.process = MagicMock()
+        mock_process.process.returncode = 1
+        mock_subprocess.return_value = mock_process
+
+        logger_instance = MagicMock()
+        mock_logger.return_value = logger_instance
+
+        await install_user_requirements("worker", mock_environ)
+        logger_instance.error.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_hybrid_mode(mock_environ):
+    """Test installation in hybrid mode"""
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value="package1==1.0.0"), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+        mock_process = MagicMock()
+        mock_subprocess.return_value = mock_process
+
+        await install_user_requirements("hybrid", mock_environ)
+
+        assert mock_subprocess.call_args[1]['friendly_name'] == "worker_requirements"
+
+
+@pytest.mark.asyncio
+async def test_subprocess_timeout_configuration(mock_environ):
+    """Test subprocess timeout configuration"""
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', return_value="package1==1.0.0"), \
+            patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+        await install_user_requirements("worker", mock_environ)
+
+        conditions = mock_subprocess.call_args[1]['conditions']
+        timeout_condition = next(c for c in conditions if hasattr(c, 'timeout'))
+        assert timeout_condition.timeout == USER_REQUIREMENTS_MAX_INSTALL_TIME
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_file_read_error(mock_environ):
+    """Test handling of file read errors"""
+    with patch.dict(os.environ, mock_environ, clear=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('mwaa.utils.user_requirements._read_requirements_file', side_effect=Exception("Read error")), \
+            patch('mwaa.utils.user_requirements.CompositeLogger') as mock_logger:
+        logger_instance = MagicMock()
+        mock_logger.return_value = logger_instance
+
+        await install_user_requirements("worker", mock_environ)
+        logger_instance.warning.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_install_user_requirements_command_types(mock_environ):
+    """Test different command types"""
+    commands = ["worker", "scheduler", "webserver"]
+    for cmd in commands:
+        with patch.dict(os.environ, mock_environ, clear=True), \
+                patch('os.path.isfile', return_value=True), \
+                patch('mwaa.utils.user_requirements._read_requirements_file', return_value="package1==1.0.0"), \
+                patch('mwaa.utils.user_requirements.Subprocess') as mock_subprocess:
+            mock_process = MagicMock()
+            mock_subprocess.return_value = mock_process
+
+            await install_user_requirements(cmd, mock_environ)
+
+            assert mock_subprocess.call_args[1]['friendly_name'] == f"{cmd}_requirements"

--- a/tests/images/airflow/2.11.2/requirements.txt
+++ b/tests/images/airflow/2.11.2/requirements.txt
@@ -1,0 +1,25 @@
+# This requirements file is used when creating a virtual environment for
+# building and developing the Airflow image. It is not to be confused with
+# the requirements of Airflow within the image. Still, they are largely similar
+# apart from some additional requirements for type checking, e.g. boto3-stubs
+# or similar stuff for aiding build and development, e.g. pydocstyle.
+--constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.11.2/constraints-3.12.txt
+# Main Airflow packages.
+# NOTE: We always specify the version here.
+apache-airflow[celery,statsd]==2.11.2
+# Additional packages for MWAA Airflow.
+# NOTE: We don't specify the version here since the constraints file take care
+# of this, making it easier to port the code to other versions.
+apache-airflow-providers-amazon[aiobotocore]
+celery[sqs]
+pycurl
+watchtower
+fluent-logger
+# Additional packages for development
+# NOTE: Like above, we don't specify the version here.
+boto3-stubs[logs]
+boto3-stubs[sqs]
+jinja2
+pydocstyle
+ruff
+sqlalchemy-stubs

--- a/tests/images/airflow/2.11.2/startup/startup.sh
+++ b/tests/images/airflow/2.11.2/startup/startup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+export CUSTOM_VAR="value"

--- a/tests/images/airflow/2.11.2/test_airflow_local_settings_2_11_2.py
+++ b/tests/images/airflow/2.11.2/test_airflow_local_settings_2_11_2.py
@@ -1,0 +1,123 @@
+import pytest
+import sys
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+def test_import_all_modules():
+    """Test that imports all modules to ensure coverage tracking"""
+    # Mock dependencies to avoid errors
+    with patch('mwaa.config.database.get_db_connection_string', return_value='postgresql://test:test@localhost/test'), \
+         patch.dict('os.environ', {'MWAA_AIRFLOW_COMPONENT': 'scheduler', 'SSL_MODE': 'require'}, clear=False):
+        
+        # Import the modules directly to get them in coverage
+        import mwaa.config.airflow_rds_iam_patch  # noqa: F401
+        import mwaa.utils.get_rds_iam_credentials  # noqa: F401
+        
+        # Also test airflow_local_settings
+        airflow_local_settings_path = Path(__file__).parent.parent.parent.parent.parent / "images/airflow/2.11.2/airflow_local_settings.py"
+        spec = importlib.util.spec_from_file_location("airflow_local_settings", airflow_local_settings_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+def test_rds_iam_patch_import_failure():
+    """Test RDS IAM patch import failure handling"""
+    with patch.dict('sys.modules', {'mwaa.config.airflow_rds_iam_patch': None}):
+        with pytest.raises(ModuleNotFoundError):
+            airflow_local_settings_path = Path(__file__).parent.parent.parent.parent.parent / "images/airflow/2.11.2/airflow_local_settings.py"
+            spec = importlib.util.spec_from_file_location("airflow_local_settings", airflow_local_settings_path)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+
+def test_load_dags_airflow_local_settings_success():
+    """Test successful loading of dags/airflow_local_settings.py"""
+    import tempfile
+    import os
+    
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create the dags directory and a dummy airflow_local_settings.py
+        dags_dir = os.path.join(temp_dir, 'dags')
+        os.makedirs(dags_dir)
+        dags_file = os.path.join(dags_dir, 'airflow_local_settings.py')
+        
+        # Write a simple Python file
+        with open(dags_file, 'w') as f:
+            f.write('# Test dags airflow_local_settings\ntest_var = "dags_loaded"\n')
+        
+        # Set AIRFLOW_HOME to our temp directory
+        with patch.dict('os.environ', {'AIRFLOW_HOME': temp_dir}):
+            # Import and execute the module
+            airflow_local_settings_path = Path(__file__).parent.parent.parent.parent.parent / "images/airflow/2.11.2/airflow_local_settings.py"
+            spec = importlib.util.spec_from_file_location("airflow_local_settings", airflow_local_settings_path)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+
+def test_load_dags_airflow_local_settings_failure():
+    """Test error handling when loading dags/airflow_local_settings.py fails"""
+    import tempfile
+    import os
+    
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create the dags directory and a bad Python file
+        dags_dir = os.path.join(temp_dir, 'dags')
+        os.makedirs(dags_dir)
+        dags_file = os.path.join(dags_dir, 'airflow_local_settings.py')
+        
+        # Write invalid Python code that will cause an import error
+        with open(dags_file, 'w') as f:
+            f.write('invalid python syntax !!!')
+        
+        # Set AIRFLOW_HOME to our temp directory
+        with patch.dict('os.environ', {'AIRFLOW_HOME': temp_dir}):
+            with pytest.raises(Exception):
+                airflow_local_settings_path = Path(__file__).parent.parent.parent.parent.parent / "images/airflow/2.11.2/airflow_local_settings.py"
+                spec = importlib.util.spec_from_file_location("airflow_local_settings", airflow_local_settings_path)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+
+def test_load_plugins_airflow_local_settings_success():
+    """Test successful loading of plugins/airflow_local_settings.py"""
+    import tempfile
+    import os
+    
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create the plugins directory and a dummy airflow_local_settings.py
+        plugins_dir = os.path.join(temp_dir, 'plugins')
+        os.makedirs(plugins_dir)
+        plugins_file = os.path.join(plugins_dir, 'airflow_local_settings.py')
+        
+        # Write a simple Python file
+        with open(plugins_file, 'w') as f:
+            f.write('# Test plugins airflow_local_settings\ntest_var = "plugins_loaded"\n')
+        
+        # Set AIRFLOW_HOME to our temp directory
+        with patch.dict('os.environ', {'AIRFLOW_HOME': temp_dir}):
+            # Import and execute the module
+            airflow_local_settings_path = Path(__file__).parent.parent.parent.parent.parent / "images/airflow/2.11.2/airflow_local_settings.py"
+            spec = importlib.util.spec_from_file_location("airflow_local_settings", airflow_local_settings_path)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+
+def test_load_plugins_airflow_local_settings_failure():
+    """Test error handling when loading plugins/airflow_local_settings.py fails"""
+    import tempfile
+    import os
+    
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create the plugins directory and a bad Python file
+        plugins_dir = os.path.join(temp_dir, 'plugins')
+        os.makedirs(plugins_dir)
+        plugins_file = os.path.join(plugins_dir, 'airflow_local_settings.py')
+        
+        # Write invalid Python code that will cause an import error
+        with open(plugins_file, 'w') as f:
+            f.write('invalid python syntax !!!')
+        
+        # Set AIRFLOW_HOME to our temp directory
+        with patch.dict('os.environ', {'AIRFLOW_HOME': temp_dir}):
+            with pytest.raises(Exception):
+                airflow_local_settings_path = Path(__file__).parent.parent.parent.parent.parent / "images/airflow/2.11.2/airflow_local_settings.py"
+                spec = importlib.util.spec_from_file_location("airflow_local_settings", airflow_local_settings_path)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)

--- a/tests/images/airflow/2.11.2/test_healthcheck.py
+++ b/tests/images/airflow/2.11.2/test_healthcheck.py
@@ -1,0 +1,119 @@
+import os
+import sys
+import pytest
+from unittest.mock import patch
+
+# Add the directory containing healthcheck.py to the Python path
+AIRFLOW_VERSION = "2.11.2"
+HEALTHCHECK_DIR = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "..",
+        "images",
+        "airflow",
+        AIRFLOW_VERSION
+    )
+)
+sys.path.insert(0, HEALTHCHECK_DIR)
+
+from healthcheck import main, ExitStatus
+
+# Simple mock process outputs
+MOCK_PS_OUTPUT_WITH_SCHEDULER = "airflow    123   0.0  0.2 /usr/local/airflow/.local/bin/airflow scheduler"
+MOCK_PS_OUTPUT_WITH_WEBSERVER = "airflow    124   0.0  0.2 /usr/local/airflow/.local/bin/airflow webserver"
+MOCK_PS_OUTPUT_WITH_WORKER = "airflow     36  4.1  2.2 506068 176924 ?       Ss   09:51   0:09 [celeryd: celery@9011bf25155e:MainProcess] -active- (celery worker)"
+MOCK_PS_OUTPUT_WITH_WORKER_FALLBACK_TITLE = "airflow     53 68.6  2.1 506084 176492 ?       Ss   09:58   0:05 /usr/local/bin/python3.11 /usr/local/airflow/.local/bin/airflow celery worker"
+MOCK_PS_OUTPUT_EMPTY = "root       456   0.0  0.1 /usr/sbin/sshd"
+
+def test_main_success_scheduler():
+    """Test main function success path for scheduler"""
+    with patch('sys.argv', ['healthcheck.py', 'SCHEDULER']), \
+         patch('os.path.exists', return_value=False), \
+         patch('subprocess.check_output', return_value=MOCK_PS_OUTPUT_WITH_SCHEDULER.encode()), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.SUCCESS.value
+
+@pytest.mark.parametrize("webserver_component", [
+    "WEB_SERVER",
+    "ADDITIONAL_WEBSERVER"
+])
+def test_main_success_webserver(webserver_component):
+    """Test main function success path for webserver components"""
+    with patch('sys.argv', ['healthcheck.py', webserver_component]), \
+         patch('os.path.exists', return_value=False), \
+         patch('subprocess.check_output', return_value=MOCK_PS_OUTPUT_WITH_WEBSERVER.encode()), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.SUCCESS.value
+
+@pytest.mark.parametrize("worker_component", [
+    "WORKER",
+    "STATIC_ADDITIONAL_WORKER",
+    "DYNAMIC_ADDITIONAL_WORKER"
+])
+def test_main_success_worker_with_mainprocess(worker_component):
+    """Test main function success path for worker with MainProcess string"""
+    with patch('sys.argv', ['healthcheck.py', worker_component]), \
+         patch('os.path.exists', return_value=False), \
+         patch('subprocess.check_output', return_value=MOCK_PS_OUTPUT_WITH_WORKER.encode()), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.SUCCESS.value
+
+@pytest.mark.parametrize("worker_component", [
+    "WORKER",
+    "STATIC_ADDITIONAL_WORKER",
+    "DYNAMIC_ADDITIONAL_WORKER"
+])
+def test_main_success_worker_with_fallback_title(worker_component):
+    """Test main function success path for worker with fallback title"""
+    with patch('sys.argv', ['healthcheck.py', worker_component]), \
+         patch('os.path.exists', return_value=False), \
+         patch('subprocess.check_output', return_value=MOCK_PS_OUTPUT_WITH_WORKER_FALLBACK_TITLE.encode()), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.SUCCESS.value
+
+def test_main_unhealthy_container():
+    """Test when container is marked unhealthy"""
+    with patch('sys.argv', ['healthcheck.py', 'SCHEDULER']), \
+         patch('os.path.exists', return_value=True), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY.value
+
+@pytest.mark.parametrize("component", [
+    "SCHEDULER",
+    "WORKER",
+    "STATIC_ADDITIONAL_WORKER",
+    "DYNAMIC_ADDITIONAL_WORKER",
+    "WEB_SERVER",
+    "ADDITIONAL_WEBSERVER"
+])
+def test_main_process_not_found(component):
+    """Test when process is not found"""
+    with patch('sys.argv', ['healthcheck.py', component]), \
+         patch('os.path.exists', return_value=False), \
+         patch('subprocess.check_output', return_value=MOCK_PS_OUTPUT_EMPTY.encode()), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.AIRFLOW_COMPONENT_UNHEALTHY.value
+
+def test_main_invalid_args():
+    """Test with invalid number of arguments"""
+    with patch('sys.argv', ['healthcheck.py']), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.INSUFFICIENT_ARGUMENTS.value
+
+def test_main_invalid_component():
+    """Test with invalid component name"""
+    with patch('sys.argv', ['healthcheck.py', 'INVALID']), \
+         patch('os.path.exists', return_value=False), \
+         pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == ExitStatus.INVALID_AIRFLOW_COMPONENT.value


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Copy tests from 2.11.0 and update version references to 2.11.2. Includes tests for: celery (SQS broker, task monitor), config, logging, subprocess, entrypoint, healthcheck, RDS IAM credentials, user requirements, dblock, and airflow local settings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
