### PR TITLE
fix(2.11.2): bump sagemaker_studio 1.0.24 → 1.0.26 to fix image bloat

### DIFF
--- a/images/airflow/2.11.2/etc/airflow_constraints.txt
+++ b/images/airflow/2.11.2/etc/airflow_constraints.txt
@@ -653,7 +653,7 @@ ruamel.yaml==0.19.1
 ruff==0.5.5
 s3fs==2026.2.0
 s3transfer==0.16.0
-sagemaker_studio==1.0.24
+sagemaker_studio==1.0.26
 scikit-learn==1.8.0
 scipy==1.17.1
 scramp==1.4.8


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

sagemaker_studio 1.0.24 added heavyweight data-engineering libraries (duckdb, pyarrow, numpy, pandas, awswrangler, snowflake-sqlalchemy, etc.) as core dependencies, inflating the image by ~1.15 GB uncompressed. This was a one-off mistake corrected in 1.0.25.

Bumping to 1.0.26 restores the uncompressed image to ~3.3 GB (from ~4.5 GB).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
