### PR TITLE
Add 2.11.2 to needs_downgrade_compat_fixes in 3.2.1 downgrade path

### DIFF
--- a/images/airflow/3.2.1/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.2.1/python/mwaa/database/migrate_with_downgrade.py
@@ -317,7 +317,7 @@ def _check_downgrade_db():
     target_version = os.environ.get("MWAA__DB__AIRFLOW_TARGET_VERSION", None)
     current_version = os.environ.get("AIRFLOW_VERSION", None)
     if target_version and current_version and Version(target_version) < Version(current_version):
-        needs_downgrade_compat_fixes = Version(target_version) in (Version("3.0.6"), Version("2.11.0"))
+        needs_downgrade_compat_fixes = Version(target_version) in (Version("3.0.6"), Version("2.11.0"), Version("2.11.2"))
 
         # Re-encode deferred-task serialization BEFORE the schema downgrade, while the
         # 3.2.1 schema is still in place (task_instance.id and trigger.kwargs exist).


### PR DESCRIPTION
*Issue #, if available:*
+ The same fix needs to be applied to 2.11.2 for downgrade from 3.2.1 to 2.11.2.
+ Related PR: https://github.com/aws/amazon-mwaa-docker-images/commit/5f80edf3e86fe0a8b8669ea6214778daf0191b26
+ Related PR2: https://github.com/aws/amazon-mwaa-docker-images/commit/77498107476a0842d9c332abf30e3b29f8f86b78

*Testing*:
Deploy 3.2.1 environments with updated image and perform downgrade to 2.11.2, run long deferred task in one environment and a deferred task with kwargs in another environment,downgrade was successful in both environments and no Errors observed in scheduler logs. Added new DAGs are able to show and execute.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
