### PR TITLE
Add Dependabot configuration for pip dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Root-level dev dependencies (ruff, pytest, etc.) — allow updates
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Airflow version directories are intentionally pinned — suppress all updates
+  - package-ecosystem: "pip"
+    directories:
+      - "/images/airflow/*"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable Dependabot version updates for pip dependencies.
- Root-level dev dependencies (ruff, pytest, etc.) get weekly update PRs.
- Airflow version directories under `images/airflow/*` are intentionally pinned, so updates are suppressed (`open-pull-requests-limit: 0`) while still being scanned weekly.

## Testing
- Validated YAML syntax locally.
- No build/test impact; this is a GitHub configuration file only.
