### PR TITLE
Change Task logs to use Fluentbit for Airflow 3

### DIFF
--- a/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
@@ -479,51 +479,113 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
             handlers. And only the processor attribute from the remote logging class is loaded into the Structlog
             logger used for task logging.
         """
-        from logging import getLogRecordFactory
-
         import structlog.stdlib
-
-        logRecordFactory = getLogRecordFactory()
-        # The handler MUST be initted here, before the processor is actually used to log anything.
-        # Otherwise, logging that occurs during the creation of the handler can create infinite loops.
-        _handler = self.get_handler()
         from airflow.sdk.log import relative_path_from_logger
 
-        def proc(logger: structlog.typing.WrappedLogger, method_name: str, event: structlog.typing.EventDict):
-            if not logger or not (stream_name := relative_path_from_logger(logger)):
+        if self.NON_CRITICAL_LOGGING_ENABLED:
+            _handler = ForkSafeFluentHandler(
+                'customer.task.logs',
+                host='localhost',
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
+            )
+            log_group = self.log_group_name
+            # Stash log_stream on the handler so the formatter can access it per-call
+            _handler._current_log_stream = ""
+
+            class _TaskRoutingFormatter(logging.Formatter):
+                def format(self, record) -> Dict[str, str]:  # type: ignore[override]
+                    return {
+                        'log_group': log_group,
+                        'log_stream': _handler._current_log_stream,
+                        'message': json.dumps(record.msg, default=str) if isinstance(record.msg, dict) else record.getMessage(),
+                    }
+
+            _handler.setFormatter(_TaskRoutingFormatter())
+            # Assign to self.handler so close() and upload() -> flush() drain the
+            # sender queue at task exit. The sender's send thread is a daemon thread,
+            # so without a proper close() the last log events of a task can be lost.
+            self.handler = _handler
+
+            def proc(logger: structlog.typing.WrappedLogger, method_name: str, event: structlog.typing.EventDict):
+                if not logger or not (stream_name := relative_path_from_logger(logger)):
+                    return event
+                _handler._current_log_stream = stream_name.as_posix().replace(":", "_")
+
+                if self.log_group_name.endswith("-Task") \
+                        and any(re.match(p, _handler._current_log_stream) for p in CloudWatchRemoteTaskLogger.IGNORED_PATTERNS):
+                    return event
+
+                name = event.get("logger_name") or event.get("logger", "")
+                level = structlog.stdlib.NAME_TO_LEVEL.get(method_name.lower(), logging.INFO)
+                if level < self.log_level:
+                    return event
+
+                msg = copy.copy(event)
+                created = None
+                if ts := msg.pop("timestamp", None):
+                    with contextlib.suppress(Exception):
+                        created = datetime.fromisoformat(ts)
+
+                for chunks_msg in self._split_oversize_event(msg):
+                    record = logging.LogRecord(
+                        name=name,
+                        level=level,
+                        pathname="", lineno=0, msg=chunks_msg, args=(), exc_info=None,
+                    )
+                    if created is not None:
+                        ct = created.timestamp()
+                        record.created = ct
+                        record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
+                    try:
+                        _handler.emit(record)
+                    except Exception:
+                        self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.emit_error", 1)
                 return event
-            _handler.log_stream_name = stream_name.as_posix().replace(":", "_")
 
-            if self.log_group_name.endswith("-Task") \
-                    and any(re.match(p, _handler.log_stream_name) for p in CloudWatchRemoteTaskLogger.IGNORED_PATTERNS):
+        else:
+            from logging import getLogRecordFactory
+
+            logRecordFactory = getLogRecordFactory()
+            # The handler MUST be initted here, before the processor is actually used to log anything.
+            # Otherwise, logging that occurs during the creation of the handler can create infinite loops.
+            _handler = self.get_handler()
+
+            def proc(logger: structlog.typing.WrappedLogger, method_name: str, event: structlog.typing.EventDict):
+                if not logger or not (stream_name := relative_path_from_logger(logger)):
+                    return event
+                _handler.log_stream_name = stream_name.as_posix().replace(":", "_")
+
+                if self.log_group_name.endswith("-Task") \
+                        and any(re.match(p, _handler.log_stream_name) for p in CloudWatchRemoteTaskLogger.IGNORED_PATTERNS):
+                    return event
+
+                name = event.get("logger_name") or event.get("logger", "")
+                level = structlog.stdlib.NAME_TO_LEVEL.get(method_name.lower(), logging.INFO)
+                if level < self.log_level:
+                    return event
+
+                msg = copy.copy(event)
+                created = None
+                if ts := msg.pop("timestamp", None):
+                    with contextlib.suppress(Exception):
+                        created = datetime.fromisoformat(ts)
+
+                for chunks_msg in self._split_oversize_event(msg):
+                    record = logRecordFactory(
+                        name, level, pathname="", lineno=0, msg=chunks_msg, args=(), exc_info=None, func=None, sinfo=None
+                    )
+                    if created is not None:
+                        ct = created.timestamp()
+                        record.created = ct
+                        record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
+                    try:
+                        _handler.handle(record)
+                    except Exception as e:
+                        self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.emit_error", 1)
+                        raise e
                 return event
-
-            name = event.get("logger_name") or event.get("logger", "")
-            level = structlog.stdlib.NAME_TO_LEVEL.get(method_name.lower(), logging.INFO)
-            if level < self.log_level:
-                return event
-
-            msg = copy.copy(event)
-            created = None
-            if ts := msg.pop("timestamp", None):
-                with contextlib.suppress(Exception):
-                    created = datetime.fromisoformat(ts)
-
-            for chunks_msg in self._split_oversize_event(msg):
-                record = logRecordFactory(
-                    name, level, pathname="", lineno=0, msg=chunks_msg, args=(), exc_info=None, func=None, sinfo=None
-                )
-                if created is not None:
-                    ct = created.timestamp()
-                    record.created = ct
-                    record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
-                try:
-                    _handler.handle(record)
-                except Exception as e:
-                    self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.emit_error", 1)
-                    # TODO maybe consider removing this if we plan to make logging non-critical
-                    raise e
-            return event
 
         return (proc,)
 

--- a/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -328,55 +328,116 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
             handlers. And only the processor attribute from the remote logging class is loaded into the Structlog
             logger used for task logging.
         """
-        from logging import getLogRecordFactory
-
         import structlog.stdlib
-
-        logRecordFactory = getLogRecordFactory()
-        # The handler MUST be initted here, before the processor is actually used to log anything.
-        # Otherwise, logging that occurs during the creation of the handler can create infinite loops.
-        _handler = self.get_handler()
         from airflow.sdk.log import relative_path_from_logger
 
-        def proc(logger: structlog.typing.WrappedLogger, method_name: str, event: structlog.typing.EventDict):
-            if not logger or not (stream_name := relative_path_from_logger(logger)):
-                return event
-            _handler.log_stream_name = stream_name.as_posix().replace(":", "_")
-
-            if self.log_group_name.endswith("-Task") \
-                    and any(re.match(p, _handler.log_stream_name) for p in CloudWatchRemoteTaskLogger.IGNORED_PATTERNS):
-                return event
-
-            name = event.get("logger_name") or event.get("logger", "")
-            level = structlog.stdlib.NAME_TO_LEVEL.get(method_name.lower(), logging.INFO)
-            if level < self.log_level:
-                return event
-
-            msg = copy.copy(event)
-            created = None
-            if ts := msg.pop("timestamp", None):
-                with contextlib.suppress(Exception):
-                    created = datetime.fromisoformat(ts)
-            record = logRecordFactory(
-                name, level, pathname="", lineno=0, msg=msg, args=(), exc_info=None, func=None, sinfo=None
+        if self.NON_CRITICAL_LOGGING_ENABLED:
+            _handler = ForkSafeFluentHandler(
+                'customer.task.logs',
+                host='localhost',
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
             )
-            if created is not None:
-                ct = created.timestamp()
-                record.created = ct
-                record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
-            try:
-                # In Airflow 3.1+, triggerer_job_runner's _process_log_messages_from_subprocess
-                # calls configure_logging() -> dictConfig() which shuts down all existing
-                # handlers, setting watchtower's shutting_down=True and silently dropping
-                # all subsequent log records. Reset it to keep sending.
-                if getattr(_handler, 'shutting_down', False):
-                    _handler.shutting_down = False
-                _handler.handle(record)
-            except Exception as e:
-                self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.emit_error", 1)
-                # TODO maybe consider removing this if we plan to make logging non-critical
-                raise e
-            return event
+            log_group = self.log_group_name
+            # Stash log_stream on the handler so the formatter can access it per-call
+            _handler._current_log_stream = ""
+
+            class _TaskRoutingFormatter(logging.Formatter):
+                def format(self, record) -> Dict[str, str]:  # type: ignore[override]
+                    return {
+                        'log_group': log_group,
+                        'log_stream': _handler._current_log_stream,
+                        'message': json.dumps(record.msg, default=str) if isinstance(record.msg, dict) else record.getMessage(),
+                    }
+
+            _handler.setFormatter(_TaskRoutingFormatter())
+            # Assign to self.handler so close() and upload() -> flush() drain the
+            # sender queue at task exit. The sender's send thread is a daemon thread,
+            # so without a proper close() the last log events of a task can be lost.
+            self.handler = _handler
+
+            def proc(logger: structlog.typing.WrappedLogger, method_name: str, event: structlog.typing.EventDict):
+                if not logger or not (stream_name := relative_path_from_logger(logger)):
+                    return event
+                _handler._current_log_stream = stream_name.as_posix().replace(":", "_")
+
+                if self.log_group_name.endswith("-Task") \
+                        and any(re.match(p, _handler._current_log_stream) for p in CloudWatchRemoteTaskLogger.IGNORED_PATTERNS):
+                    return event
+
+                name = event.get("logger_name") or event.get("logger", "")
+                level = structlog.stdlib.NAME_TO_LEVEL.get(method_name.lower(), logging.INFO)
+                if level < self.log_level:
+                    return event
+
+                msg = copy.copy(event)
+                created = None
+                if ts := msg.pop("timestamp", None):
+                    with contextlib.suppress(Exception):
+                        created = datetime.fromisoformat(ts)
+
+                record = logging.LogRecord(
+                    name=name,
+                    level=level,
+                    pathname="", lineno=0, msg=msg, args=(), exc_info=None,
+                )
+                if created is not None:
+                    ct = created.timestamp()
+                    record.created = ct
+                    record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
+                try:
+                    _handler.emit(record)
+                except Exception:
+                    self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.emit_error", 1)
+                return event
+
+        else:
+            from logging import getLogRecordFactory
+
+            logRecordFactory = getLogRecordFactory()
+            # The handler MUST be initted here, before the processor is actually used to log anything.
+            # Otherwise, logging that occurs during the creation of the handler can create infinite loops.
+            _handler = self.get_handler()
+
+            def proc(logger: structlog.typing.WrappedLogger, method_name: str, event: structlog.typing.EventDict):
+                if not logger or not (stream_name := relative_path_from_logger(logger)):
+                    return event
+                _handler.log_stream_name = stream_name.as_posix().replace(":", "_")
+
+                if self.log_group_name.endswith("-Task") \
+                        and any(re.match(p, _handler.log_stream_name) for p in CloudWatchRemoteTaskLogger.IGNORED_PATTERNS):
+                    return event
+
+                name = event.get("logger_name") or event.get("logger", "")
+                level = structlog.stdlib.NAME_TO_LEVEL.get(method_name.lower(), logging.INFO)
+                if level < self.log_level:
+                    return event
+
+                msg = copy.copy(event)
+                created = None
+                if ts := msg.pop("timestamp", None):
+                    with contextlib.suppress(Exception):
+                        created = datetime.fromisoformat(ts)
+                record = logRecordFactory(
+                    name, level, pathname="", lineno=0, msg=msg, args=(), exc_info=None, func=None, sinfo=None
+                )
+                if created is not None:
+                    ct = created.timestamp()
+                    record.created = ct
+                    record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
+                try:
+                    # In Airflow 3.1+, triggerer_job_runner's _process_log_messages_from_subprocess
+                    # calls configure_logging() -> dictConfig() which shuts down all existing
+                    # handlers, setting watchtower's shutting_down=True and silently dropping
+                    # all subsequent log records. Reset it to keep sending.
+                    if getattr(_handler, 'shutting_down', False):
+                        _handler.shutting_down = False
+                    _handler.handle(record)
+                except Exception as e:
+                    self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.emit_error", 1)
+                    raise e
+                return event
 
         return (proc,)
 

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -471,7 +471,7 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
         }
 
 
-def test_cloudwatch_remote_task_logger_always_uses_watchtower_not_fluent(mock_boto3_client, mock_fluent, mock_watchtower):
+def test_cloudwatch_remote_task_logger_uses_fluent_when_non_critical(mock_boto3_client, mock_fluent, mock_watchtower):
     with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
         import importlib
         import mwaa.logging.cloudwatch_handlers
@@ -484,14 +484,46 @@ def test_cloudwatch_remote_task_logger_always_uses_watchtower_not_fluent(mock_bo
             log_level='INFO'
         )
 
-        # Trigger handler initialisation (lazy)
-        logger.get_handler()
+        # Access processors to trigger the fluent handler creation
+        _ = logger.processors
 
-        assert logger.handler is not None
-        assert mock_watchtower.called, "CloudWatchRemoteTaskLogger must use watchtower"
+        assert mock_fluent.called, (
+            "CloudWatchRemoteTaskLogger must use Fluent "
+            "when USE_NON_CRITICAL_LOGGING=true"
+        )
+        mock_fluent.assert_called_once_with(
+            'customer.task.logs',
+            host='localhost',
+            port=24224,
+            queue_maxsize=50000,
+            queue_circular=True,
+        )
+        assert not mock_watchtower.called, (
+            "CloudWatchRemoteTaskLogger must NOT use watchtower "
+            "when USE_NON_CRITICAL_LOGGING=true"
+        )
+
+
+def test_cloudwatch_remote_task_logger_uses_watchtower_when_non_critical_disabled(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'false'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        logger = CloudWatchRemoteTaskLogger(
+            log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+            kms_key_arn=None,
+            enabled=True,
+            log_level='INFO'
+        )
+
+        # Access processors to trigger the watchtower handler creation
+        _ = logger.processors
+
+        assert mock_watchtower.called, "CloudWatchRemoteTaskLogger must use watchtower when NON_CRITICAL disabled"
         assert not mock_fluent.called, (
-            "CloudWatchRemoteTaskLogger must NOT use Fluent, "
-            "even with USE_NON_CRITICAL_LOGGING=true"
+            "CloudWatchRemoteTaskLogger must NOT use Fluent "
+            "when USE_NON_CRITICAL_LOGGING=false"
         )
         mock_watchtower.assert_called_once_with(
             log_group_name='test-Task',

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -214,3 +214,16 @@ class TestForkSafetyIntegration:
                 "Child process exited with error"
 
         handler.close()
+
+
+class TestQueueCircularConfiguration:
+    """Test that queue_circular parameter is correctly wired through the handler."""
+
+    def test_handler_passes_queue_circular_to_sender(self):
+        """Verify queue_circular=True is propagated to the underlying sender."""
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
+        h = ForkSafeFluentHandler('test', host='localhost', port=24224,
+                                  queue_maxsize=50000, queue_circular=True)
+        assert h.sender.queue_circular is True
+        assert h.sender.queue_maxsize == 50000
+        h.close()

--- a/tests/images/airflow/3.2.1/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/logging/test_cloudwatch_handler.py
@@ -546,7 +546,7 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'queue_circular': True,
         }
 
-def test_cloudwatch_remote_task_logger_always_uses_watchtower_not_fluent(mock_boto3_client, mock_fluent, mock_watchtower):
+def test_cloudwatch_remote_task_logger_uses_fluent_when_non_critical(mock_boto3_client, mock_fluent, mock_watchtower):
     with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
         import importlib
         import mwaa.logging.cloudwatch_handlers
@@ -559,14 +559,46 @@ def test_cloudwatch_remote_task_logger_always_uses_watchtower_not_fluent(mock_bo
             log_level='INFO'
         )
 
-        # Trigger handler initialisation (lazy)
-        logger.get_handler()
+        # Access processors to trigger the fluent handler creation
+        _ = logger.processors
 
-        assert logger.handler is not None
-        assert mock_watchtower.called, "CloudWatchRemoteTaskLogger must use watchtower"
+        assert mock_fluent.called, (
+            "CloudWatchRemoteTaskLogger must use Fluent "
+            "when USE_NON_CRITICAL_LOGGING=true"
+        )
+        mock_fluent.assert_called_once_with(
+            'customer.task.logs',
+            host='localhost',
+            port=24224,
+            queue_maxsize=50000,
+            queue_circular=True,
+        )
+        assert not mock_watchtower.called, (
+            "CloudWatchRemoteTaskLogger must NOT use watchtower "
+            "when USE_NON_CRITICAL_LOGGING=true"
+        )
+
+
+def test_cloudwatch_remote_task_logger_uses_watchtower_when_non_critical_disabled(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'false'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        logger = CloudWatchRemoteTaskLogger(
+            log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+            kms_key_arn=None,
+            enabled=True,
+            log_level='INFO'
+        )
+
+        # Access processors to trigger the watchtower handler creation
+        _ = logger.processors
+
+        assert mock_watchtower.called, "CloudWatchRemoteTaskLogger must use watchtower when NON_CRITICAL disabled"
         assert not mock_fluent.called, (
-            "CloudWatchRemoteTaskLogger must NOT use Fluent, "
-            "even with USE_NON_CRITICAL_LOGGING=true"
+            "CloudWatchRemoteTaskLogger must NOT use Fluent "
+            "when USE_NON_CRITICAL_LOGGING=false"
         )
         mock_watchtower.assert_called_once_with(
             log_group_name='test-Task',

--- a/tests/images/airflow/3.2.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -214,3 +214,16 @@ class TestForkSafetyIntegration:
                 "Child process exited with error"
 
         handler.close()
+
+
+class TestQueueCircularConfiguration:
+    """Test that queue_circular parameter is correctly wired through the handler."""
+
+    def test_handler_passes_queue_circular_to_sender(self):
+        """Verify queue_circular=True is propagated to the underlying sender."""
+        from mwaa.logging.fork_safe_handler import ForkSafeFluentHandler
+        h = ForkSafeFluentHandler('test', host='localhost', port=24224,
+                                  queue_maxsize=50000, queue_circular=True)
+        assert h.sender.queue_circular is True
+        assert h.sender.queue_maxsize == 50000
+        h.close()


### PR DESCRIPTION
## Summary

  Route Airflow 3 task logs through FluentBit when Non-Critical Logging (NCL) is enabled, completing the NCL migration for all log types in 3.0.6 and 3.2.1.

  ## Problem

  When `USE_NON_CRITICAL_LOGGING=true`, all subprocess-based logs (scheduler, worker, webserver, triggerer) and DAG processing logs are already routed through FluentBit via `BaseLogHandler.create_cloudwatch_handler()`. However, **task logs** — which in Airflow 3 use a separate code path via the `CloudWatchRemoteTaskLogger.processors` property and Structlog — were hardcoded to
  watchtower via `get_handler()`.

  Task logs were the only log type still making direct CloudWatch API calls with NCL enabled, bypassing FluentBit's buffering and the non-critical failure semantics. In Airflow 2.x, task logs already route through FluentBit under NCL (`TaskLogHandler.set_context`); this PR brings Airflow 3 to parity.

  ## Solution

  Branch the `processors` property on `self.NON_CRITICAL_LOGGING_ENABLED`:

  - **NCL enabled**: Create a `ForkSafeFluentHandler` with tag `customer.task.logs` (matching the 2.x task handler), attach a `_TaskRoutingFormatter` that serializes the structlog event dict as JSON and includes `log_group`/`log_stream` routing fields for FluentBit delivery.
  - **NCL disabled**: Preserve the existing watchtower path unchanged (including the 3.2.1 `shutting_down` reset for Airflow 3.1+ triggerer compatibility).

  ### Key design decisions

  1. **Non-blocking under back-pressure**: The handler uses `queue_maxsize=50000, queue_circular=True` — identical to the 2.x task handler and the `BaseLogHandler` NCL path. When FluentBit stalls and the queue fills, the oldest event is dropped instead of blocking the task's log call. Combined with the fork-safe sender, logging can never hang or deadlock an Airflow process.

  2. **Handler lifecycle**: The fluent handler is assigned to `self.handler` so Airflow's end-of-task `upload()` → `flush()` and `close()` drain the sender queue before process exit. The sender's delivery thread is a daemon thread, so without an explicit `close()` the final log events of a task (completion status, fatal errors) could be lost.

  3. **Non-critical error handling**: The FluentBit path swallows emit exceptions (increments `mwaa.logging.task.emit_error` only). The watchtower path continues to re-raise. Logging failures must not fail
  tasks.

  4. **JSON serialization**: `json.dumps(record.msg, default=str)` when the message is a dict, mirroring watchtower's `CloudwatchLogFormatter`, so structured logs render correctly in the CloudWatch console. Falls back to `getMessage()` for plain strings.

  5. **Timestamp preservation**: The structlog `timestamp` field is parsed into `record.created`, which the fluent handler uses as the event time — CloudWatch shows the original event time, not delivery time (consistent with watchtower behavior).

  6. **Oversize splitting (3.0.6)**: The fluent path calls `_split_oversize_event()` to chunk >260KB events, preserving the behavior added in #500. The splitter's `ensure_ascii=True` size accounting matches the formatter's `json.dumps` default.

  ## Known gaps (out of scope, follow-ups)

  - **3.2.1 oversize handling**: 3.2.1 has no `_split_oversize_event` (the #500 chunking was only added to 3.0.6). Oversized events in 3.2.1 are passed through and rejected downstream by CloudWatch — pre-existing gap shared with the watchtower path, to be addressed by porting #500 to 3.2.1 separately.
  - **Delivery-failure observability**: The fluent sender reports failures via return value (not exceptions) and its circular-queue drops are silent, so the `emit_error` metric undercounts. This is pre-existing behavior shared with the 2.x NCL path and watchtower's async delivery; a follow-up will check emit return values and wire a `queue_overflow_handler` drop metric across all versions.

  ## Testing

  - **Unit tests** (3.0.6 and 3.2.1):
    - FluentBit handler used when NCL=true, with exact constructor args (`customer.task.logs`, `queue_maxsize=50000`, `queue_circular=True`); watchtower not called
    - Watchtower used when NCL=false; FluentBit not called
    - `queue_circular` propagation through `ForkSafeFluentHandler` to the underlying sender
  - **Manual testing** (dev environment, NCL=true):
    - Task logs delivered to the CloudWatch `-Task` log group with correct JSON formatting and accurate event timestamps
    - Deferrable/triggerer DAG task logs route correctly
    - `dag_processor/` streams filtered from the Task log group (IGNORED_PATTERNS)
    - Stress test: 50 concurrent tasks × 5000 log lines (250k total) — PENDING

  ## Files Changed

  | File | Change |
  |------|--------|
  | `images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py` | NCL branching in `processors`; fluent handler with circular queue, lifecycle wiring, JSON formatting, oversize splitting |
  | `images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py` | Same, minus oversize splitting (see Known gaps); preserves `shutting_down` reset in watchtower fallback |
  | `tests/images/airflow/{3.0.6,3.2.1}/.../test_cloudwatch_handler.py` | Replace "always watchtower" test with per-path tests for NCL true/false |
  | `tests/images/airflow/{3.0.6,3.2.1}/.../test_fork_safe_fluent_handler.py` | Add `queue_circular` propagation test |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
