### PR TITLE
Fix CloudWatch task log ordering for NCL (Fluent Bit) logging

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -139,6 +139,8 @@ class BaseLogHandler(logging.Handler):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
             if self.formatter:
                 # Wrap the existing formatter to add routing fields
@@ -317,6 +319,8 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
 
             original_formatter = self.formatter

--- a/images/airflow/2.10.1/python/mwaa/logging/fork_safe_handler.py
+++ b/images/airflow/2.10.1/python/mwaa/logging/fork_safe_handler.py
@@ -65,8 +65,32 @@ class ForkSafeFluentSender(asyncsender.FluentSender):
 
 
 class ForkSafeFluentHandler(fluent_handler.FluentHandler):
-    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety.
+
+    Also enforces strictly increasing millisecond timestamps per handler:
+    CloudWatch does not guarantee display order for same-millisecond events,
+    so tied timestamps are nudged forward to make ordering deterministic.
+    """
 
     def getSenderClass(self):
         """Return the ForkSafeFluentSender class for fork-safe logging."""
         return ForkSafeFluentSender
+
+    def emit(self, record):
+        """Emit a record, enforcing a strictly increasing ms timestamp."""
+        # Compute ms with the same arithmetic as the wire encoding: fluent's
+        # EventTime packs seconds plus the fractional second as nanoseconds
+        # (int((created % 1) * 1e9)), which Fluent Bit floors to milliseconds
+        # for CloudWatch. A plain int(record.created * 1000) can disagree with
+        # that by 1ms near boundaries, letting same-millisecond ties through
+        # the check below.
+        ms = int(record.created) * 1000 + int((record.created % 1) * 1e9) // 1_000_000
+        last_ms = getattr(self, "_last_emitted_ms", 0)
+        if ms <= last_ms:
+            ms = last_ms + 1
+            # Mid-ms bias: a bare ms/1000.0 can floor back into the previous
+            # millisecond after EventTime float reconstruction.
+            record.created = (ms + 0.5) / 1000.0
+            record.msecs = (record.created - int(record.created)) * 1000
+        self._last_emitted_ms = ms
+        return super().emit(record)

--- a/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
@@ -138,6 +138,8 @@ class BaseLogHandler(logging.Handler):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
             if self.formatter:
                 # Wrap the existing formatter to add routing fields
@@ -316,6 +318,8 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
 
             original_formatter = self.formatter

--- a/images/airflow/2.10.3/python/mwaa/logging/fork_safe_handler.py
+++ b/images/airflow/2.10.3/python/mwaa/logging/fork_safe_handler.py
@@ -65,9 +65,32 @@ class ForkSafeFluentSender(asyncsender.FluentSender):
 
 
 class ForkSafeFluentHandler(fluent_handler.FluentHandler):
-    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety.
+
+    Also enforces strictly increasing millisecond timestamps per handler:
+    CloudWatch does not guarantee display order for same-millisecond events,
+    so tied timestamps are nudged forward to make ordering deterministic.
+    """
 
     def getSenderClass(self):
         """Return the ForkSafeFluentSender class for fork-safe logging."""
         return ForkSafeFluentSender
 
+    def emit(self, record):
+        """Emit a record, enforcing a strictly increasing ms timestamp."""
+        # Compute ms with the same arithmetic as the wire encoding: fluent's
+        # EventTime packs seconds plus the fractional second as nanoseconds
+        # (int((created % 1) * 1e9)), which Fluent Bit floors to milliseconds
+        # for CloudWatch. A plain int(record.created * 1000) can disagree with
+        # that by 1ms near boundaries, letting same-millisecond ties through
+        # the check below.
+        ms = int(record.created) * 1000 + int((record.created % 1) * 1e9) // 1_000_000
+        last_ms = getattr(self, "_last_emitted_ms", 0)
+        if ms <= last_ms:
+            ms = last_ms + 1
+            # Mid-ms bias: a bare ms/1000.0 can floor back into the previous
+            # millisecond after EventTime float reconstruction.
+            record.created = (ms + 0.5) / 1000.0
+            record.msecs = (record.created - int(record.created)) * 1000
+        self._last_emitted_ms = ms
+        return super().emit(record)

--- a/images/airflow/2.11.0/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.11.0/python/mwaa/logging/cloudwatch_handlers.py
@@ -139,6 +139,8 @@ class BaseLogHandler(logging.Handler):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
             if self.formatter:
                 # Wrap the existing formatter to add routing fields
@@ -334,6 +336,8 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
 
             original_formatter = self.formatter

--- a/images/airflow/2.11.0/python/mwaa/logging/fork_safe_handler.py
+++ b/images/airflow/2.11.0/python/mwaa/logging/fork_safe_handler.py
@@ -65,8 +65,32 @@ class ForkSafeFluentSender(asyncsender.FluentSender):
 
 
 class ForkSafeFluentHandler(fluent_handler.FluentHandler):
-    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety.
+
+    Also enforces strictly increasing millisecond timestamps per handler:
+    CloudWatch does not guarantee display order for same-millisecond events,
+    so tied timestamps are nudged forward to make ordering deterministic.
+    """
 
     def getSenderClass(self):
         """Return the ForkSafeFluentSender class for fork-safe logging."""
         return ForkSafeFluentSender
+
+    def emit(self, record):
+        """Emit a record, enforcing a strictly increasing ms timestamp."""
+        # Compute ms with the same arithmetic as the wire encoding: fluent's
+        # EventTime packs seconds plus the fractional second as nanoseconds
+        # (int((created % 1) * 1e9)), which Fluent Bit floors to milliseconds
+        # for CloudWatch. A plain int(record.created * 1000) can disagree with
+        # that by 1ms near boundaries, letting same-millisecond ties through
+        # the check below.
+        ms = int(record.created) * 1000 + int((record.created % 1) * 1e9) // 1_000_000
+        last_ms = getattr(self, "_last_emitted_ms", 0)
+        if ms <= last_ms:
+            ms = last_ms + 1
+            # Mid-ms bias: a bare ms/1000.0 can floor back into the previous
+            # millisecond after EventTime float reconstruction.
+            record.created = (ms + 0.5) / 1000.0
+            record.msecs = (record.created - int(record.created)) * 1000
+        self._last_emitted_ms = ms
+        return super().emit(record)

--- a/images/airflow/2.11.2/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.11.2/python/mwaa/logging/cloudwatch_handlers.py
@@ -139,6 +139,8 @@ class BaseLogHandler(logging.Handler):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
             if self.formatter:
                 # Wrap the existing formatter to add routing fields
@@ -334,6 +336,8 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
 
             original_formatter = self.formatter

--- a/images/airflow/2.11.2/python/mwaa/logging/fork_safe_handler.py
+++ b/images/airflow/2.11.2/python/mwaa/logging/fork_safe_handler.py
@@ -65,8 +65,32 @@ class ForkSafeFluentSender(asyncsender.FluentSender):
 
 
 class ForkSafeFluentHandler(fluent_handler.FluentHandler):
-    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety.
+
+    Also enforces strictly increasing millisecond timestamps per handler:
+    CloudWatch does not guarantee display order for same-millisecond events,
+    so tied timestamps are nudged forward to make ordering deterministic.
+    """
 
     def getSenderClass(self):
         """Return the ForkSafeFluentSender class for fork-safe logging."""
         return ForkSafeFluentSender
+
+    def emit(self, record):
+        """Emit a record, enforcing a strictly increasing ms timestamp."""
+        # Compute ms with the same arithmetic as the wire encoding: fluent's
+        # EventTime packs seconds plus the fractional second as nanoseconds
+        # (int((created % 1) * 1e9)), which Fluent Bit floors to milliseconds
+        # for CloudWatch. A plain int(record.created * 1000) can disagree with
+        # that by 1ms near boundaries, letting same-millisecond ties through
+        # the check below.
+        ms = int(record.created) * 1000 + int((record.created % 1) * 1e9) // 1_000_000
+        last_ms = getattr(self, "_last_emitted_ms", 0)
+        if ms <= last_ms:
+            ms = last_ms + 1
+            # Mid-ms bias: a bare ms/1000.0 can floor back into the previous
+            # millisecond after EventTime float reconstruction.
+            record.created = (ms + 0.5) / 1000.0
+            record.msecs = (record.created - int(record.created)) * 1000
+        self._last_emitted_ms = ms
+        return super().emit(record)

--- a/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
@@ -139,6 +139,8 @@ class BaseLogHandler(logging.Handler):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
             if self.formatter:
                 # Wrap the existing formatter to add routing fields
@@ -317,6 +319,8 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
 
             original_formatter = self.formatter

--- a/images/airflow/2.9.2/python/mwaa/logging/fork_safe_handler.py
+++ b/images/airflow/2.9.2/python/mwaa/logging/fork_safe_handler.py
@@ -65,8 +65,32 @@ class ForkSafeFluentSender(asyncsender.FluentSender):
 
 
 class ForkSafeFluentHandler(fluent_handler.FluentHandler):
-    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety.
+
+    Also enforces strictly increasing millisecond timestamps per handler:
+    CloudWatch does not guarantee display order for same-millisecond events,
+    so tied timestamps are nudged forward to make ordering deterministic.
+    """
 
     def getSenderClass(self):
         """Return the ForkSafeFluentSender class for fork-safe logging."""
         return ForkSafeFluentSender
+
+    def emit(self, record):
+        """Emit a record, enforcing a strictly increasing ms timestamp."""
+        # Compute ms with the same arithmetic as the wire encoding: fluent's
+        # EventTime packs seconds plus the fractional second as nanoseconds
+        # (int((created % 1) * 1e9)), which Fluent Bit floors to milliseconds
+        # for CloudWatch. A plain int(record.created * 1000) can disagree with
+        # that by 1ms near boundaries, letting same-millisecond ties through
+        # the check below.
+        ms = int(record.created) * 1000 + int((record.created % 1) * 1e9) // 1_000_000
+        last_ms = getattr(self, "_last_emitted_ms", 0)
+        if ms <= last_ms:
+            ms = last_ms + 1
+            # Mid-ms bias: a bare ms/1000.0 can floor back into the previous
+            # millisecond after EventTime float reconstruction.
+            record.created = (ms + 0.5) / 1000.0
+            record.msecs = (record.created - int(record.created)) * 1000
+        self._last_emitted_ms = ms
+        return super().emit(record)

--- a/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
@@ -152,6 +152,8 @@ class BaseLogHandler(logging.Handler):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
             if self.formatter:
                 # Wrap the existing formatter to add routing fields
@@ -489,6 +491,8 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
             log_group = self.log_group_name
             # Stash log_stream on the handler so the formatter can access it per-call

--- a/images/airflow/3.0.6/python/mwaa/logging/fork_safe_handler.py
+++ b/images/airflow/3.0.6/python/mwaa/logging/fork_safe_handler.py
@@ -65,8 +65,32 @@ class ForkSafeFluentSender(asyncsender.FluentSender):
 
 
 class ForkSafeFluentHandler(fluent_handler.FluentHandler):
-    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety.
+
+    Also enforces strictly increasing millisecond timestamps per handler:
+    CloudWatch does not guarantee display order for same-millisecond events,
+    so tied timestamps are nudged forward to make ordering deterministic.
+    """
 
     def getSenderClass(self):
         """Return the ForkSafeFluentSender class for fork-safe logging."""
         return ForkSafeFluentSender
+
+    def emit(self, record):
+        """Emit a record, enforcing a strictly increasing ms timestamp."""
+        # Compute ms with the same arithmetic as the wire encoding: fluent's
+        # EventTime packs seconds plus the fractional second as nanoseconds
+        # (int((created % 1) * 1e9)), which Fluent Bit floors to milliseconds
+        # for CloudWatch. A plain int(record.created * 1000) can disagree with
+        # that by 1ms near boundaries, letting same-millisecond ties through
+        # the check below.
+        ms = int(record.created) * 1000 + int((record.created % 1) * 1e9) // 1_000_000
+        last_ms = getattr(self, "_last_emitted_ms", 0)
+        if ms <= last_ms:
+            ms = last_ms + 1
+            # Mid-ms bias: a bare ms/1000.0 can floor back into the previous
+            # millisecond after EventTime float reconstruction.
+            record.created = (ms + 0.5) / 1000.0
+            record.msecs = (record.created - int(record.created)) * 1000
+        self._last_emitted_ms = ms
+        return super().emit(record)

--- a/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -152,6 +152,8 @@ class BaseLogHandler(logging.Handler):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
             if self.formatter:
                 # Wrap the existing formatter to add routing fields
@@ -338,6 +340,8 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
             log_group = self.log_group_name
             # Stash log_stream on the handler so the formatter can access it per-call

--- a/images/airflow/3.2.1/python/mwaa/logging/fork_safe_handler.py
+++ b/images/airflow/3.2.1/python/mwaa/logging/fork_safe_handler.py
@@ -65,8 +65,32 @@ class ForkSafeFluentSender(asyncsender.FluentSender):
 
 
 class ForkSafeFluentHandler(fluent_handler.FluentHandler):
-    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety.
+
+    Also enforces strictly increasing millisecond timestamps per handler:
+    CloudWatch does not guarantee display order for same-millisecond events,
+    so tied timestamps are nudged forward to make ordering deterministic.
+    """
 
     def getSenderClass(self):
         """Return the ForkSafeFluentSender class for fork-safe logging."""
         return ForkSafeFluentSender
+
+    def emit(self, record):
+        """Emit a record, enforcing a strictly increasing ms timestamp."""
+        # Compute ms with the same arithmetic as the wire encoding: fluent's
+        # EventTime packs seconds plus the fractional second as nanoseconds
+        # (int((created % 1) * 1e9)), which Fluent Bit floors to milliseconds
+        # for CloudWatch. A plain int(record.created * 1000) can disagree with
+        # that by 1ms near boundaries, letting same-millisecond ties through
+        # the check below.
+        ms = int(record.created) * 1000 + int((record.created % 1) * 1e9) // 1_000_000
+        last_ms = getattr(self, "_last_emitted_ms", 0)
+        if ms <= last_ms:
+            ms = last_ms + 1
+            # Mid-ms bias: a bare ms/1000.0 can floor back into the previous
+            # millisecond after EventTime float reconstruction.
+            record.created = (ms + 0.5) / 1000.0
+            record.msecs = (record.created - int(record.created)) * 1000
+        self._last_emitted_ms = ms
+        return super().emit(record)

--- a/images/airflow/3.3.0/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.3.0/python/mwaa/logging/cloudwatch_handlers.py
@@ -152,6 +152,8 @@ class BaseLogHandler(logging.Handler):
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
             if self.formatter:
                 # Wrap the existing formatter to add routing fields

--- a/images/airflow/3.3.0/python/mwaa/logging/fork_safe_handler.py
+++ b/images/airflow/3.3.0/python/mwaa/logging/fork_safe_handler.py
@@ -65,8 +65,32 @@ class ForkSafeFluentSender(asyncsender.FluentSender):
 
 
 class ForkSafeFluentHandler(fluent_handler.FluentHandler):
-    """A FluentHandler that uses ForkSafeFluentSender for fork-safety."""
+    """A FluentHandler that uses ForkSafeFluentSender for fork-safety.
+
+    Also enforces strictly increasing millisecond timestamps per handler:
+    CloudWatch does not guarantee display order for same-millisecond events,
+    so tied timestamps are nudged forward to make ordering deterministic.
+    """
 
     def getSenderClass(self):
         """Return the ForkSafeFluentSender class for fork-safe logging."""
         return ForkSafeFluentSender
+
+    def emit(self, record):
+        """Emit a record, enforcing a strictly increasing ms timestamp."""
+        # Compute ms with the same arithmetic as the wire encoding: fluent's
+        # EventTime packs seconds plus the fractional second as nanoseconds
+        # (int((created % 1) * 1e9)), which Fluent Bit floors to milliseconds
+        # for CloudWatch. A plain int(record.created * 1000) can disagree with
+        # that by 1ms near boundaries, letting same-millisecond ties through
+        # the check below.
+        ms = int(record.created) * 1000 + int((record.created % 1) * 1e9) // 1_000_000
+        last_ms = getattr(self, "_last_emitted_ms", 0)
+        if ms <= last_ms:
+            ms = last_ms + 1
+            # Mid-ms bias: a bare ms/1000.0 can floor back into the previous
+            # millisecond after EventTime float reconstruction.
+            record.created = (ms + 0.5) / 1000.0
+            record.msecs = (record.created - int(record.created)) * 1000
+        self._last_emitted_ms = ms
+        return super().emit(record)

--- a/tests/images/airflow/2.10.1/python/mwaa/logging/test_cloudwatch_handler_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/logging/test_cloudwatch_handler_2_10_1.py
@@ -190,6 +190,7 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                nanosecond_precision=True,
             )
 
 def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -216,6 +217,7 @@ def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -241,6 +243,7 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -264,6 +267,7 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -289,4 +293,5 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }

--- a/tests/images/airflow/2.10.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -227,3 +227,135 @@ class TestQueueCircularConfiguration:
         assert h.sender.queue_circular is True
         assert h.sender.queue_maxsize == 50000
         h.close()
+
+
+class TestMonotonicTimestampNudge:
+    """Tests for the strictly-increasing millisecond timestamp enforcement.
+
+    CloudWatch Logs timestamps have millisecond resolution and CloudWatch does
+    not guarantee display order for same-timestamp events (they sort by
+    ingestion time, then message index — nondeterministic across PutLogEvents
+    batches). ForkSafeFluentHandler.emit() therefore nudges each record's
+    timestamp to be at least 1ms after the previous one.
+
+    IMPORTANT: these tests assert on the WIRE encoding — the millisecond value
+    CloudWatch will actually store after fluent EventTime packing
+    (seconds + int((created % 1) * 1e9) nanoseconds) and Fluent Bit's floor to
+    milliseconds — NOT on record.created directly. Two float-arithmetic bugs
+    shipped in earlier iterations of the nudge precisely because tests
+    asserted on Python-side values:
+      1. record.created = ms / 1000.0 floors back down 1ms for ~50% of values
+         through the EventTime reconstruction (fixed with mid-ms bias).
+      2. int(created * 1000) can round UP across a ms boundary while the wire
+         value stays below it, letting a same-source tie through un-nudged
+         (fixed by computing the check with wire-identical arithmetic).
+    """
+
+    @staticmethod
+    def _make_record(created):
+        import logging
+        r = logging.LogRecord('t', 20, '', 0, 'msg', (), None)
+        r.created = created
+        r.msecs = (created - int(created)) * 1000  # as real records have
+        return r
+
+    @staticmethod
+    def _cw_ms(created):
+        """The millisecond timestamp CloudWatch stores for this record.
+
+        Reproduces fluent sender.EventTime packing (seconds uint32 +
+        nanoseconds uint32) followed by Fluent Bit's floor to milliseconds.
+        """
+        import struct
+        from fluent import sender as fluent_sender
+        et = fluent_sender.EventTime(created)
+        secs, nanos = struct.unpack('>II', et.data)
+        return secs * 1000 + nanos // 1_000_000
+
+    def _emit_and_capture_cw_ms(self, handler, created_values):
+        """Emit records through the real handler, capture wire ms values."""
+        from unittest.mock import patch
+        captured = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: captured.append(self._cw_ms(rec.created))):
+            for created in created_values:
+                handler.emit(self._make_record(created))
+        return captured
+
+    def test_same_millisecond_burst_gets_unique_increasing_ms(self, handler):
+        """A burst of records in the same millisecond must land on strictly
+        increasing, unique CloudWatch milliseconds."""
+        base = 1784526643.000100
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base + i * 0.00001 for i in range(50)])
+
+        assert len(set(cw)) == 50, f"CW ms collisions: {sorted(cw)}"
+        assert cw == sorted(cw), "CW ms values must be strictly increasing"
+
+    def test_records_in_distinct_ms_are_not_modified(self, handler):
+        """Records already >=1ms apart must pass through with their natural
+        timestamps (the nudge only activates on ties)."""
+        base = 1784526643.0
+        values = [base + i * 0.005 for i in range(10)]  # 5ms apart
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert cw == [self._cw_ms(v) for v in values]
+
+    def test_backwards_clock_sample_is_nudged_forward(self, handler):
+        """A record whose clock reads earlier than the previous one (clock
+        adjustment) must still land strictly after it."""
+        base = 1784526643.500
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base, base + 0.0001, base - 1.0])
+
+        assert len(set(cw)) == 3
+        assert cw == sorted(cw)
+
+    def test_boundary_straddling_floats_cannot_tie(self, handler):
+        """Values within sub-microsecond of millisecond boundaries — the class
+        that defeated both earlier nudge implementations — must never produce
+        a tied or decreasing wire millisecond."""
+        base_ms = 1784526643000
+        values = []
+        t = base_ms
+        for k in range(500):
+            t += 1
+            for eps in (-2e-7, -1e-7, 0.0, 1e-7):
+                values.append(t / 1000.0 + eps)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == len(cw), "wire ms collision from boundary floats"
+        assert cw == sorted(cw), "wire ms regression from boundary floats"
+
+    def test_dense_stress_profile_all_unique(self, handler):
+        """Stress-test-shaped emission (bursts up to ~11 lines/ms with gaps)
+        must produce all-unique, strictly increasing wire milliseconds."""
+        import random
+        rng = random.Random(42)
+        t = 1784526643.0
+        values = []
+        for i in range(5000):
+            if i % 6 == 0:
+                t += rng.choice([0.0, 0.001, 0.002])
+            values.append(t)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == 5000
+        assert cw == sorted(cw)
+
+    def test_msecs_kept_consistent_for_formatters(self, handler):
+        """When a record is nudged, record.msecs must match record.created so
+        %(asctime)s in formatted messages agrees with the CW timestamp."""
+        from unittest.mock import patch
+        records = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: records.append(rec)):
+            base = 1784526643.000100
+            for i in range(5):
+                handler.emit(self._make_record(base))  # all identical -> nudged
+
+        for rec in records:
+            expected_msecs = (rec.created - int(rec.created)) * 1000
+            assert abs(rec.msecs - expected_msecs) < 1e-6

--- a/tests/images/airflow/2.10.3/python/mwaa/logging/test_cloudwatch_handler_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/logging/test_cloudwatch_handler_2_10_3.py
@@ -196,6 +196,7 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                nanosecond_precision=True,
             )
 
 def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -222,6 +223,7 @@ def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -247,6 +249,7 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -270,6 +273,7 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -295,4 +299,5 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }

--- a/tests/images/airflow/2.10.3/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -228,3 +228,135 @@ class TestQueueCircularConfiguration:
         assert h.sender.queue_circular is True
         assert h.sender.queue_maxsize == 50000
         h.close()
+
+
+class TestMonotonicTimestampNudge:
+    """Tests for the strictly-increasing millisecond timestamp enforcement.
+
+    CloudWatch Logs timestamps have millisecond resolution and CloudWatch does
+    not guarantee display order for same-timestamp events (they sort by
+    ingestion time, then message index — nondeterministic across PutLogEvents
+    batches). ForkSafeFluentHandler.emit() therefore nudges each record's
+    timestamp to be at least 1ms after the previous one.
+
+    IMPORTANT: these tests assert on the WIRE encoding — the millisecond value
+    CloudWatch will actually store after fluent EventTime packing
+    (seconds + int((created % 1) * 1e9) nanoseconds) and Fluent Bit's floor to
+    milliseconds — NOT on record.created directly. Two float-arithmetic bugs
+    shipped in earlier iterations of the nudge precisely because tests
+    asserted on Python-side values:
+      1. record.created = ms / 1000.0 floors back down 1ms for ~50% of values
+         through the EventTime reconstruction (fixed with mid-ms bias).
+      2. int(created * 1000) can round UP across a ms boundary while the wire
+         value stays below it, letting a same-source tie through un-nudged
+         (fixed by computing the check with wire-identical arithmetic).
+    """
+
+    @staticmethod
+    def _make_record(created):
+        import logging
+        r = logging.LogRecord('t', 20, '', 0, 'msg', (), None)
+        r.created = created
+        r.msecs = (created - int(created)) * 1000  # as real records have
+        return r
+
+    @staticmethod
+    def _cw_ms(created):
+        """The millisecond timestamp CloudWatch stores for this record.
+
+        Reproduces fluent sender.EventTime packing (seconds uint32 +
+        nanoseconds uint32) followed by Fluent Bit's floor to milliseconds.
+        """
+        import struct
+        from fluent import sender as fluent_sender
+        et = fluent_sender.EventTime(created)
+        secs, nanos = struct.unpack('>II', et.data)
+        return secs * 1000 + nanos // 1_000_000
+
+    def _emit_and_capture_cw_ms(self, handler, created_values):
+        """Emit records through the real handler, capture wire ms values."""
+        from unittest.mock import patch
+        captured = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: captured.append(self._cw_ms(rec.created))):
+            for created in created_values:
+                handler.emit(self._make_record(created))
+        return captured
+
+    def test_same_millisecond_burst_gets_unique_increasing_ms(self, handler):
+        """A burst of records in the same millisecond must land on strictly
+        increasing, unique CloudWatch milliseconds."""
+        base = 1784526643.000100
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base + i * 0.00001 for i in range(50)])
+
+        assert len(set(cw)) == 50, f"CW ms collisions: {sorted(cw)}"
+        assert cw == sorted(cw), "CW ms values must be strictly increasing"
+
+    def test_records_in_distinct_ms_are_not_modified(self, handler):
+        """Records already >=1ms apart must pass through with their natural
+        timestamps (the nudge only activates on ties)."""
+        base = 1784526643.0
+        values = [base + i * 0.005 for i in range(10)]  # 5ms apart
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert cw == [self._cw_ms(v) for v in values]
+
+    def test_backwards_clock_sample_is_nudged_forward(self, handler):
+        """A record whose clock reads earlier than the previous one (clock
+        adjustment) must still land strictly after it."""
+        base = 1784526643.500
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base, base + 0.0001, base - 1.0])
+
+        assert len(set(cw)) == 3
+        assert cw == sorted(cw)
+
+    def test_boundary_straddling_floats_cannot_tie(self, handler):
+        """Values within sub-microsecond of millisecond boundaries — the class
+        that defeated both earlier nudge implementations — must never produce
+        a tied or decreasing wire millisecond."""
+        base_ms = 1784526643000
+        values = []
+        t = base_ms
+        for k in range(500):
+            t += 1
+            for eps in (-2e-7, -1e-7, 0.0, 1e-7):
+                values.append(t / 1000.0 + eps)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == len(cw), "wire ms collision from boundary floats"
+        assert cw == sorted(cw), "wire ms regression from boundary floats"
+
+    def test_dense_stress_profile_all_unique(self, handler):
+        """Stress-test-shaped emission (bursts up to ~11 lines/ms with gaps)
+        must produce all-unique, strictly increasing wire milliseconds."""
+        import random
+        rng = random.Random(42)
+        t = 1784526643.0
+        values = []
+        for i in range(5000):
+            if i % 6 == 0:
+                t += rng.choice([0.0, 0.001, 0.002])
+            values.append(t)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == 5000
+        assert cw == sorted(cw)
+
+    def test_msecs_kept_consistent_for_formatters(self, handler):
+        """When a record is nudged, record.msecs must match record.created so
+        %(asctime)s in formatted messages agrees with the CW timestamp."""
+        from unittest.mock import patch
+        records = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: records.append(rec)):
+            base = 1784526643.000100
+            for i in range(5):
+                handler.emit(self._make_record(base))  # all identical -> nudged
+
+        for rec in records:
+            expected_msecs = (rec.created - int(rec.created)) * 1000
+            assert abs(rec.msecs - expected_msecs) < 1e-6

--- a/tests/images/airflow/2.11.0/python/mwaa/logging/test_cloudwatch_handler_2_11_0.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/logging/test_cloudwatch_handler_2_11_0.py
@@ -197,6 +197,7 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                nanosecond_precision=True,
             )
 
 def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -223,6 +224,7 @@ def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -248,6 +250,7 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -271,6 +274,7 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -296,6 +300,7 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_task_log_handler_io_override_exception_is_caught(mocker):

--- a/tests/images/airflow/2.11.0/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -227,3 +227,135 @@ class TestQueueCircularConfiguration:
         assert h.sender.queue_circular is True
         assert h.sender.queue_maxsize == 50000
         h.close()
+
+
+class TestMonotonicTimestampNudge:
+    """Tests for the strictly-increasing millisecond timestamp enforcement.
+
+    CloudWatch Logs timestamps have millisecond resolution and CloudWatch does
+    not guarantee display order for same-timestamp events (they sort by
+    ingestion time, then message index — nondeterministic across PutLogEvents
+    batches). ForkSafeFluentHandler.emit() therefore nudges each record's
+    timestamp to be at least 1ms after the previous one.
+
+    IMPORTANT: these tests assert on the WIRE encoding — the millisecond value
+    CloudWatch will actually store after fluent EventTime packing
+    (seconds + int((created % 1) * 1e9) nanoseconds) and Fluent Bit's floor to
+    milliseconds — NOT on record.created directly. Two float-arithmetic bugs
+    shipped in earlier iterations of the nudge precisely because tests
+    asserted on Python-side values:
+      1. record.created = ms / 1000.0 floors back down 1ms for ~50% of values
+         through the EventTime reconstruction (fixed with mid-ms bias).
+      2. int(created * 1000) can round UP across a ms boundary while the wire
+         value stays below it, letting a same-source tie through un-nudged
+         (fixed by computing the check with wire-identical arithmetic).
+    """
+
+    @staticmethod
+    def _make_record(created):
+        import logging
+        r = logging.LogRecord('t', 20, '', 0, 'msg', (), None)
+        r.created = created
+        r.msecs = (created - int(created)) * 1000  # as real records have
+        return r
+
+    @staticmethod
+    def _cw_ms(created):
+        """The millisecond timestamp CloudWatch stores for this record.
+
+        Reproduces fluent sender.EventTime packing (seconds uint32 +
+        nanoseconds uint32) followed by Fluent Bit's floor to milliseconds.
+        """
+        import struct
+        from fluent import sender as fluent_sender
+        et = fluent_sender.EventTime(created)
+        secs, nanos = struct.unpack('>II', et.data)
+        return secs * 1000 + nanos // 1_000_000
+
+    def _emit_and_capture_cw_ms(self, handler, created_values):
+        """Emit records through the real handler, capture wire ms values."""
+        from unittest.mock import patch
+        captured = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: captured.append(self._cw_ms(rec.created))):
+            for created in created_values:
+                handler.emit(self._make_record(created))
+        return captured
+
+    def test_same_millisecond_burst_gets_unique_increasing_ms(self, handler):
+        """A burst of records in the same millisecond must land on strictly
+        increasing, unique CloudWatch milliseconds."""
+        base = 1784526643.000100
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base + i * 0.00001 for i in range(50)])
+
+        assert len(set(cw)) == 50, f"CW ms collisions: {sorted(cw)}"
+        assert cw == sorted(cw), "CW ms values must be strictly increasing"
+
+    def test_records_in_distinct_ms_are_not_modified(self, handler):
+        """Records already >=1ms apart must pass through with their natural
+        timestamps (the nudge only activates on ties)."""
+        base = 1784526643.0
+        values = [base + i * 0.005 for i in range(10)]  # 5ms apart
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert cw == [self._cw_ms(v) for v in values]
+
+    def test_backwards_clock_sample_is_nudged_forward(self, handler):
+        """A record whose clock reads earlier than the previous one (clock
+        adjustment) must still land strictly after it."""
+        base = 1784526643.500
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base, base + 0.0001, base - 1.0])
+
+        assert len(set(cw)) == 3
+        assert cw == sorted(cw)
+
+    def test_boundary_straddling_floats_cannot_tie(self, handler):
+        """Values within sub-microsecond of millisecond boundaries — the class
+        that defeated both earlier nudge implementations — must never produce
+        a tied or decreasing wire millisecond."""
+        base_ms = 1784526643000
+        values = []
+        t = base_ms
+        for k in range(500):
+            t += 1
+            for eps in (-2e-7, -1e-7, 0.0, 1e-7):
+                values.append(t / 1000.0 + eps)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == len(cw), "wire ms collision from boundary floats"
+        assert cw == sorted(cw), "wire ms regression from boundary floats"
+
+    def test_dense_stress_profile_all_unique(self, handler):
+        """Stress-test-shaped emission (bursts up to ~11 lines/ms with gaps)
+        must produce all-unique, strictly increasing wire milliseconds."""
+        import random
+        rng = random.Random(42)
+        t = 1784526643.0
+        values = []
+        for i in range(5000):
+            if i % 6 == 0:
+                t += rng.choice([0.0, 0.001, 0.002])
+            values.append(t)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == 5000
+        assert cw == sorted(cw)
+
+    def test_msecs_kept_consistent_for_formatters(self, handler):
+        """When a record is nudged, record.msecs must match record.created so
+        %(asctime)s in formatted messages agrees with the CW timestamp."""
+        from unittest.mock import patch
+        records = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: records.append(rec)):
+            base = 1784526643.000100
+            for i in range(5):
+                handler.emit(self._make_record(base))  # all identical -> nudged
+
+        for rec in records:
+            expected_msecs = (rec.created - int(rec.created)) * 1000
+            assert abs(rec.msecs - expected_msecs) < 1e-6

--- a/tests/images/airflow/2.11.2/python/mwaa/logging/test_cloudwatch_handler_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/logging/test_cloudwatch_handler_2_11_2.py
@@ -197,6 +197,7 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                nanosecond_precision=True,
             )
 
 def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -223,6 +224,7 @@ def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -248,6 +250,7 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -271,6 +274,7 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -296,6 +300,7 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_task_log_handler_io_override_exception_is_caught(mocker):

--- a/tests/images/airflow/2.11.2/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -227,3 +227,135 @@ class TestQueueCircularConfiguration:
         assert h.sender.queue_circular is True
         assert h.sender.queue_maxsize == 50000
         h.close()
+
+
+class TestMonotonicTimestampNudge:
+    """Tests for the strictly-increasing millisecond timestamp enforcement.
+
+    CloudWatch Logs timestamps have millisecond resolution and CloudWatch does
+    not guarantee display order for same-timestamp events (they sort by
+    ingestion time, then message index — nondeterministic across PutLogEvents
+    batches). ForkSafeFluentHandler.emit() therefore nudges each record's
+    timestamp to be at least 1ms after the previous one.
+
+    IMPORTANT: these tests assert on the WIRE encoding — the millisecond value
+    CloudWatch will actually store after fluent EventTime packing
+    (seconds + int((created % 1) * 1e9) nanoseconds) and Fluent Bit's floor to
+    milliseconds — NOT on record.created directly. Two float-arithmetic bugs
+    shipped in earlier iterations of the nudge precisely because tests
+    asserted on Python-side values:
+      1. record.created = ms / 1000.0 floors back down 1ms for ~50% of values
+         through the EventTime reconstruction (fixed with mid-ms bias).
+      2. int(created * 1000) can round UP across a ms boundary while the wire
+         value stays below it, letting a same-source tie through un-nudged
+         (fixed by computing the check with wire-identical arithmetic).
+    """
+
+    @staticmethod
+    def _make_record(created):
+        import logging
+        r = logging.LogRecord('t', 20, '', 0, 'msg', (), None)
+        r.created = created
+        r.msecs = (created - int(created)) * 1000  # as real records have
+        return r
+
+    @staticmethod
+    def _cw_ms(created):
+        """The millisecond timestamp CloudWatch stores for this record.
+
+        Reproduces fluent sender.EventTime packing (seconds uint32 +
+        nanoseconds uint32) followed by Fluent Bit's floor to milliseconds.
+        """
+        import struct
+        from fluent import sender as fluent_sender
+        et = fluent_sender.EventTime(created)
+        secs, nanos = struct.unpack('>II', et.data)
+        return secs * 1000 + nanos // 1_000_000
+
+    def _emit_and_capture_cw_ms(self, handler, created_values):
+        """Emit records through the real handler, capture wire ms values."""
+        from unittest.mock import patch
+        captured = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: captured.append(self._cw_ms(rec.created))):
+            for created in created_values:
+                handler.emit(self._make_record(created))
+        return captured
+
+    def test_same_millisecond_burst_gets_unique_increasing_ms(self, handler):
+        """A burst of records in the same millisecond must land on strictly
+        increasing, unique CloudWatch milliseconds."""
+        base = 1784526643.000100
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base + i * 0.00001 for i in range(50)])
+
+        assert len(set(cw)) == 50, f"CW ms collisions: {sorted(cw)}"
+        assert cw == sorted(cw), "CW ms values must be strictly increasing"
+
+    def test_records_in_distinct_ms_are_not_modified(self, handler):
+        """Records already >=1ms apart must pass through with their natural
+        timestamps (the nudge only activates on ties)."""
+        base = 1784526643.0
+        values = [base + i * 0.005 for i in range(10)]  # 5ms apart
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert cw == [self._cw_ms(v) for v in values]
+
+    def test_backwards_clock_sample_is_nudged_forward(self, handler):
+        """A record whose clock reads earlier than the previous one (clock
+        adjustment) must still land strictly after it."""
+        base = 1784526643.500
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base, base + 0.0001, base - 1.0])
+
+        assert len(set(cw)) == 3
+        assert cw == sorted(cw)
+
+    def test_boundary_straddling_floats_cannot_tie(self, handler):
+        """Values within sub-microsecond of millisecond boundaries — the class
+        that defeated both earlier nudge implementations — must never produce
+        a tied or decreasing wire millisecond."""
+        base_ms = 1784526643000
+        values = []
+        t = base_ms
+        for k in range(500):
+            t += 1
+            for eps in (-2e-7, -1e-7, 0.0, 1e-7):
+                values.append(t / 1000.0 + eps)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == len(cw), "wire ms collision from boundary floats"
+        assert cw == sorted(cw), "wire ms regression from boundary floats"
+
+    def test_dense_stress_profile_all_unique(self, handler):
+        """Stress-test-shaped emission (bursts up to ~11 lines/ms with gaps)
+        must produce all-unique, strictly increasing wire milliseconds."""
+        import random
+        rng = random.Random(42)
+        t = 1784526643.0
+        values = []
+        for i in range(5000):
+            if i % 6 == 0:
+                t += rng.choice([0.0, 0.001, 0.002])
+            values.append(t)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == 5000
+        assert cw == sorted(cw)
+
+    def test_msecs_kept_consistent_for_formatters(self, handler):
+        """When a record is nudged, record.msecs must match record.created so
+        %(asctime)s in formatted messages agrees with the CW timestamp."""
+        from unittest.mock import patch
+        records = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: records.append(rec)):
+            base = 1784526643.000100
+            for i in range(5):
+                handler.emit(self._make_record(base))  # all identical -> nudged
+
+        for rec in records:
+            expected_msecs = (rec.created - int(rec.created)) * 1000
+            assert abs(rec.msecs - expected_msecs) < 1e-6

--- a/tests/images/airflow/2.9.2/python/mwaa/logging/test_cloudwatch_handler_2_9_2.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/logging/test_cloudwatch_handler_2_9_2.py
@@ -191,6 +191,7 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                nanosecond_precision=True,
             )
 
 def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -217,6 +218,7 @@ def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
@@ -242,6 +244,7 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -265,6 +268,7 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -290,4 +294,5 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }

--- a/tests/images/airflow/2.9.2/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -227,3 +227,135 @@ class TestQueueCircularConfiguration:
         assert h.sender.queue_circular is True
         assert h.sender.queue_maxsize == 50000
         h.close()
+
+
+class TestMonotonicTimestampNudge:
+    """Tests for the strictly-increasing millisecond timestamp enforcement.
+
+    CloudWatch Logs timestamps have millisecond resolution and CloudWatch does
+    not guarantee display order for same-timestamp events (they sort by
+    ingestion time, then message index — nondeterministic across PutLogEvents
+    batches). ForkSafeFluentHandler.emit() therefore nudges each record's
+    timestamp to be at least 1ms after the previous one.
+
+    IMPORTANT: these tests assert on the WIRE encoding — the millisecond value
+    CloudWatch will actually store after fluent EventTime packing
+    (seconds + int((created % 1) * 1e9) nanoseconds) and Fluent Bit's floor to
+    milliseconds — NOT on record.created directly. Two float-arithmetic bugs
+    shipped in earlier iterations of the nudge precisely because tests
+    asserted on Python-side values:
+      1. record.created = ms / 1000.0 floors back down 1ms for ~50% of values
+         through the EventTime reconstruction (fixed with mid-ms bias).
+      2. int(created * 1000) can round UP across a ms boundary while the wire
+         value stays below it, letting a same-source tie through un-nudged
+         (fixed by computing the check with wire-identical arithmetic).
+    """
+
+    @staticmethod
+    def _make_record(created):
+        import logging
+        r = logging.LogRecord('t', 20, '', 0, 'msg', (), None)
+        r.created = created
+        r.msecs = (created - int(created)) * 1000  # as real records have
+        return r
+
+    @staticmethod
+    def _cw_ms(created):
+        """The millisecond timestamp CloudWatch stores for this record.
+
+        Reproduces fluent sender.EventTime packing (seconds uint32 +
+        nanoseconds uint32) followed by Fluent Bit's floor to milliseconds.
+        """
+        import struct
+        from fluent import sender as fluent_sender
+        et = fluent_sender.EventTime(created)
+        secs, nanos = struct.unpack('>II', et.data)
+        return secs * 1000 + nanos // 1_000_000
+
+    def _emit_and_capture_cw_ms(self, handler, created_values):
+        """Emit records through the real handler, capture wire ms values."""
+        from unittest.mock import patch
+        captured = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: captured.append(self._cw_ms(rec.created))):
+            for created in created_values:
+                handler.emit(self._make_record(created))
+        return captured
+
+    def test_same_millisecond_burst_gets_unique_increasing_ms(self, handler):
+        """A burst of records in the same millisecond must land on strictly
+        increasing, unique CloudWatch milliseconds."""
+        base = 1784526643.000100
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base + i * 0.00001 for i in range(50)])
+
+        assert len(set(cw)) == 50, f"CW ms collisions: {sorted(cw)}"
+        assert cw == sorted(cw), "CW ms values must be strictly increasing"
+
+    def test_records_in_distinct_ms_are_not_modified(self, handler):
+        """Records already >=1ms apart must pass through with their natural
+        timestamps (the nudge only activates on ties)."""
+        base = 1784526643.0
+        values = [base + i * 0.005 for i in range(10)]  # 5ms apart
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert cw == [self._cw_ms(v) for v in values]
+
+    def test_backwards_clock_sample_is_nudged_forward(self, handler):
+        """A record whose clock reads earlier than the previous one (clock
+        adjustment) must still land strictly after it."""
+        base = 1784526643.500
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base, base + 0.0001, base - 1.0])
+
+        assert len(set(cw)) == 3
+        assert cw == sorted(cw)
+
+    def test_boundary_straddling_floats_cannot_tie(self, handler):
+        """Values within sub-microsecond of millisecond boundaries — the class
+        that defeated both earlier nudge implementations — must never produce
+        a tied or decreasing wire millisecond."""
+        base_ms = 1784526643000
+        values = []
+        t = base_ms
+        for k in range(500):
+            t += 1
+            for eps in (-2e-7, -1e-7, 0.0, 1e-7):
+                values.append(t / 1000.0 + eps)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == len(cw), "wire ms collision from boundary floats"
+        assert cw == sorted(cw), "wire ms regression from boundary floats"
+
+    def test_dense_stress_profile_all_unique(self, handler):
+        """Stress-test-shaped emission (bursts up to ~11 lines/ms with gaps)
+        must produce all-unique, strictly increasing wire milliseconds."""
+        import random
+        rng = random.Random(42)
+        t = 1784526643.0
+        values = []
+        for i in range(5000):
+            if i % 6 == 0:
+                t += rng.choice([0.0, 0.001, 0.002])
+            values.append(t)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == 5000
+        assert cw == sorted(cw)
+
+    def test_msecs_kept_consistent_for_formatters(self, handler):
+        """When a record is nudged, record.msecs must match record.created so
+        %(asctime)s in formatted messages agrees with the CW timestamp."""
+        from unittest.mock import patch
+        records = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: records.append(rec)):
+            base = 1784526643.000100
+            for i in range(5):
+                handler.emit(self._make_record(base))  # all identical -> nudged
+
+        for rec in records:
+            expected_msecs = (rec.created - int(rec.created)) * 1000
+            assert abs(rec.msecs - expected_msecs) < 1e-6

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -193,6 +193,7 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                nanosecond_precision=True,
             )
 
 def test_cloudwatch_remote_task_logger_initialization(mock_boto3_client):
@@ -420,6 +421,7 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -443,6 +445,7 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -468,6 +471,7 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 
@@ -497,6 +501,7 @@ def test_cloudwatch_remote_task_logger_uses_fluent_when_non_critical(mock_boto3_
             port=24224,
             queue_maxsize=50000,
             queue_circular=True,
+            nanosecond_precision=True,
         )
         assert not mock_watchtower.called, (
             "CloudWatchRemoteTaskLogger must NOT use watchtower "

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -227,3 +227,135 @@ class TestQueueCircularConfiguration:
         assert h.sender.queue_circular is True
         assert h.sender.queue_maxsize == 50000
         h.close()
+
+
+class TestMonotonicTimestampNudge:
+    """Tests for the strictly-increasing millisecond timestamp enforcement.
+
+    CloudWatch Logs timestamps have millisecond resolution and CloudWatch does
+    not guarantee display order for same-timestamp events (they sort by
+    ingestion time, then message index — nondeterministic across PutLogEvents
+    batches). ForkSafeFluentHandler.emit() therefore nudges each record's
+    timestamp to be at least 1ms after the previous one.
+
+    IMPORTANT: these tests assert on the WIRE encoding — the millisecond value
+    CloudWatch will actually store after fluent EventTime packing
+    (seconds + int((created % 1) * 1e9) nanoseconds) and Fluent Bit's floor to
+    milliseconds — NOT on record.created directly. Two float-arithmetic bugs
+    shipped in earlier iterations of the nudge precisely because tests
+    asserted on Python-side values:
+      1. record.created = ms / 1000.0 floors back down 1ms for ~50% of values
+         through the EventTime reconstruction (fixed with mid-ms bias).
+      2. int(created * 1000) can round UP across a ms boundary while the wire
+         value stays below it, letting a same-source tie through un-nudged
+         (fixed by computing the check with wire-identical arithmetic).
+    """
+
+    @staticmethod
+    def _make_record(created):
+        import logging
+        r = logging.LogRecord('t', 20, '', 0, 'msg', (), None)
+        r.created = created
+        r.msecs = (created - int(created)) * 1000  # as real records have
+        return r
+
+    @staticmethod
+    def _cw_ms(created):
+        """The millisecond timestamp CloudWatch stores for this record.
+
+        Reproduces fluent sender.EventTime packing (seconds uint32 +
+        nanoseconds uint32) followed by Fluent Bit's floor to milliseconds.
+        """
+        import struct
+        from fluent import sender as fluent_sender
+        et = fluent_sender.EventTime(created)
+        secs, nanos = struct.unpack('>II', et.data)
+        return secs * 1000 + nanos // 1_000_000
+
+    def _emit_and_capture_cw_ms(self, handler, created_values):
+        """Emit records through the real handler, capture wire ms values."""
+        from unittest.mock import patch
+        captured = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: captured.append(self._cw_ms(rec.created))):
+            for created in created_values:
+                handler.emit(self._make_record(created))
+        return captured
+
+    def test_same_millisecond_burst_gets_unique_increasing_ms(self, handler):
+        """A burst of records in the same millisecond must land on strictly
+        increasing, unique CloudWatch milliseconds."""
+        base = 1784526643.000100
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base + i * 0.00001 for i in range(50)])
+
+        assert len(set(cw)) == 50, f"CW ms collisions: {sorted(cw)}"
+        assert cw == sorted(cw), "CW ms values must be strictly increasing"
+
+    def test_records_in_distinct_ms_are_not_modified(self, handler):
+        """Records already >=1ms apart must pass through with their natural
+        timestamps (the nudge only activates on ties)."""
+        base = 1784526643.0
+        values = [base + i * 0.005 for i in range(10)]  # 5ms apart
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert cw == [self._cw_ms(v) for v in values]
+
+    def test_backwards_clock_sample_is_nudged_forward(self, handler):
+        """A record whose clock reads earlier than the previous one (clock
+        adjustment) must still land strictly after it."""
+        base = 1784526643.500
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base, base + 0.0001, base - 1.0])
+
+        assert len(set(cw)) == 3
+        assert cw == sorted(cw)
+
+    def test_boundary_straddling_floats_cannot_tie(self, handler):
+        """Values within sub-microsecond of millisecond boundaries — the class
+        that defeated both earlier nudge implementations — must never produce
+        a tied or decreasing wire millisecond."""
+        base_ms = 1784526643000
+        values = []
+        t = base_ms
+        for k in range(500):
+            t += 1
+            for eps in (-2e-7, -1e-7, 0.0, 1e-7):
+                values.append(t / 1000.0 + eps)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == len(cw), "wire ms collision from boundary floats"
+        assert cw == sorted(cw), "wire ms regression from boundary floats"
+
+    def test_dense_stress_profile_all_unique(self, handler):
+        """Stress-test-shaped emission (bursts up to ~11 lines/ms with gaps)
+        must produce all-unique, strictly increasing wire milliseconds."""
+        import random
+        rng = random.Random(42)
+        t = 1784526643.0
+        values = []
+        for i in range(5000):
+            if i % 6 == 0:
+                t += rng.choice([0.0, 0.001, 0.002])
+            values.append(t)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == 5000
+        assert cw == sorted(cw)
+
+    def test_msecs_kept_consistent_for_formatters(self, handler):
+        """When a record is nudged, record.msecs must match record.created so
+        %(asctime)s in formatted messages agrees with the CW timestamp."""
+        from unittest.mock import patch
+        records = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: records.append(rec)):
+            base = 1784526643.000100
+            for i in range(5):
+                handler.emit(self._make_record(base))  # all identical -> nudged
+
+        for rec in records:
+            expected_msecs = (rec.created - int(rec.created)) * 1000
+            assert abs(rec.msecs - expected_msecs) < 1e-6

--- a/tests/images/airflow/3.2.1/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/logging/test_cloudwatch_handler.py
@@ -190,6 +190,7 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                nanosecond_precision=True,
             )
 
 def test_cloudwatch_remote_task_logger_initialization(mock_boto3_client):
@@ -498,6 +499,7 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -520,6 +522,7 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -544,6 +547,7 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_cloudwatch_remote_task_logger_uses_fluent_when_non_critical(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -572,6 +576,7 @@ def test_cloudwatch_remote_task_logger_uses_fluent_when_non_critical(mock_boto3_
             port=24224,
             queue_maxsize=50000,
             queue_circular=True,
+            nanosecond_precision=True,
         )
         assert not mock_watchtower.called, (
             "CloudWatchRemoteTaskLogger must NOT use watchtower "

--- a/tests/images/airflow/3.2.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -227,3 +227,135 @@ class TestQueueCircularConfiguration:
         assert h.sender.queue_circular is True
         assert h.sender.queue_maxsize == 50000
         h.close()
+
+
+class TestMonotonicTimestampNudge:
+    """Tests for the strictly-increasing millisecond timestamp enforcement.
+
+    CloudWatch Logs timestamps have millisecond resolution and CloudWatch does
+    not guarantee display order for same-timestamp events (they sort by
+    ingestion time, then message index — nondeterministic across PutLogEvents
+    batches). ForkSafeFluentHandler.emit() therefore nudges each record's
+    timestamp to be at least 1ms after the previous one.
+
+    IMPORTANT: these tests assert on the WIRE encoding — the millisecond value
+    CloudWatch will actually store after fluent EventTime packing
+    (seconds + int((created % 1) * 1e9) nanoseconds) and Fluent Bit's floor to
+    milliseconds — NOT on record.created directly. Two float-arithmetic bugs
+    shipped in earlier iterations of the nudge precisely because tests
+    asserted on Python-side values:
+      1. record.created = ms / 1000.0 floors back down 1ms for ~50% of values
+         through the EventTime reconstruction (fixed with mid-ms bias).
+      2. int(created * 1000) can round UP across a ms boundary while the wire
+         value stays below it, letting a same-source tie through un-nudged
+         (fixed by computing the check with wire-identical arithmetic).
+    """
+
+    @staticmethod
+    def _make_record(created):
+        import logging
+        r = logging.LogRecord('t', 20, '', 0, 'msg', (), None)
+        r.created = created
+        r.msecs = (created - int(created)) * 1000  # as real records have
+        return r
+
+    @staticmethod
+    def _cw_ms(created):
+        """The millisecond timestamp CloudWatch stores for this record.
+
+        Reproduces fluent sender.EventTime packing (seconds uint32 +
+        nanoseconds uint32) followed by Fluent Bit's floor to milliseconds.
+        """
+        import struct
+        from fluent import sender as fluent_sender
+        et = fluent_sender.EventTime(created)
+        secs, nanos = struct.unpack('>II', et.data)
+        return secs * 1000 + nanos // 1_000_000
+
+    def _emit_and_capture_cw_ms(self, handler, created_values):
+        """Emit records through the real handler, capture wire ms values."""
+        from unittest.mock import patch
+        captured = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: captured.append(self._cw_ms(rec.created))):
+            for created in created_values:
+                handler.emit(self._make_record(created))
+        return captured
+
+    def test_same_millisecond_burst_gets_unique_increasing_ms(self, handler):
+        """A burst of records in the same millisecond must land on strictly
+        increasing, unique CloudWatch milliseconds."""
+        base = 1784526643.000100
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base + i * 0.00001 for i in range(50)])
+
+        assert len(set(cw)) == 50, f"CW ms collisions: {sorted(cw)}"
+        assert cw == sorted(cw), "CW ms values must be strictly increasing"
+
+    def test_records_in_distinct_ms_are_not_modified(self, handler):
+        """Records already >=1ms apart must pass through with their natural
+        timestamps (the nudge only activates on ties)."""
+        base = 1784526643.0
+        values = [base + i * 0.005 for i in range(10)]  # 5ms apart
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert cw == [self._cw_ms(v) for v in values]
+
+    def test_backwards_clock_sample_is_nudged_forward(self, handler):
+        """A record whose clock reads earlier than the previous one (clock
+        adjustment) must still land strictly after it."""
+        base = 1784526643.500
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base, base + 0.0001, base - 1.0])
+
+        assert len(set(cw)) == 3
+        assert cw == sorted(cw)
+
+    def test_boundary_straddling_floats_cannot_tie(self, handler):
+        """Values within sub-microsecond of millisecond boundaries — the class
+        that defeated both earlier nudge implementations — must never produce
+        a tied or decreasing wire millisecond."""
+        base_ms = 1784526643000
+        values = []
+        t = base_ms
+        for k in range(500):
+            t += 1
+            for eps in (-2e-7, -1e-7, 0.0, 1e-7):
+                values.append(t / 1000.0 + eps)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == len(cw), "wire ms collision from boundary floats"
+        assert cw == sorted(cw), "wire ms regression from boundary floats"
+
+    def test_dense_stress_profile_all_unique(self, handler):
+        """Stress-test-shaped emission (bursts up to ~11 lines/ms with gaps)
+        must produce all-unique, strictly increasing wire milliseconds."""
+        import random
+        rng = random.Random(42)
+        t = 1784526643.0
+        values = []
+        for i in range(5000):
+            if i % 6 == 0:
+                t += rng.choice([0.0, 0.001, 0.002])
+            values.append(t)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == 5000
+        assert cw == sorted(cw)
+
+    def test_msecs_kept_consistent_for_formatters(self, handler):
+        """When a record is nudged, record.msecs must match record.created so
+        %(asctime)s in formatted messages agrees with the CW timestamp."""
+        from unittest.mock import patch
+        records = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: records.append(rec)):
+            base = 1784526643.000100
+            for i in range(5):
+                handler.emit(self._make_record(base))  # all identical -> nudged
+
+        for rec in records:
+            expected_msecs = (rec.created - int(rec.created)) * 1000
+            assert abs(rec.msecs - expected_msecs) < 1e-6

--- a/tests/images/airflow/3.3.0/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/logging/test_cloudwatch_handler.py
@@ -190,6 +190,7 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                nanosecond_precision=True,
             )
 
 def test_cloudwatch_remote_task_logger_initialization(mock_boto3_client):
@@ -498,6 +499,7 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -520,6 +522,7 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchtower):
@@ -544,6 +547,7 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'nanosecond_precision': True,
         }
 
 def test_cloudwatch_remote_task_logger_always_uses_watchtower_not_fluent(mock_boto3_client, mock_fluent, mock_watchtower):

--- a/tests/images/airflow/3.3.0/python/mwaa/logging/test_fork_safe_fluent_handler.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/logging/test_fork_safe_fluent_handler.py
@@ -214,3 +214,135 @@ class TestForkSafetyIntegration:
                 "Child process exited with error"
 
         handler.close()
+
+
+class TestMonotonicTimestampNudge:
+    """Tests for the strictly-increasing millisecond timestamp enforcement.
+
+    CloudWatch Logs timestamps have millisecond resolution and CloudWatch does
+    not guarantee display order for same-timestamp events (they sort by
+    ingestion time, then message index — nondeterministic across PutLogEvents
+    batches). ForkSafeFluentHandler.emit() therefore nudges each record's
+    timestamp to be at least 1ms after the previous one.
+
+    IMPORTANT: these tests assert on the WIRE encoding — the millisecond value
+    CloudWatch will actually store after fluent EventTime packing
+    (seconds + int((created % 1) * 1e9) nanoseconds) and Fluent Bit's floor to
+    milliseconds — NOT on record.created directly. Two float-arithmetic bugs
+    shipped in earlier iterations of the nudge precisely because tests
+    asserted on Python-side values:
+      1. record.created = ms / 1000.0 floors back down 1ms for ~50% of values
+         through the EventTime reconstruction (fixed with mid-ms bias).
+      2. int(created * 1000) can round UP across a ms boundary while the wire
+         value stays below it, letting a same-source tie through un-nudged
+         (fixed by computing the check with wire-identical arithmetic).
+    """
+
+    @staticmethod
+    def _make_record(created):
+        import logging
+        r = logging.LogRecord('t', 20, '', 0, 'msg', (), None)
+        r.created = created
+        r.msecs = (created - int(created)) * 1000  # as real records have
+        return r
+
+    @staticmethod
+    def _cw_ms(created):
+        """The millisecond timestamp CloudWatch stores for this record.
+
+        Reproduces fluent sender.EventTime packing (seconds uint32 +
+        nanoseconds uint32) followed by Fluent Bit's floor to milliseconds.
+        """
+        import struct
+        from fluent import sender as fluent_sender
+        et = fluent_sender.EventTime(created)
+        secs, nanos = struct.unpack('>II', et.data)
+        return secs * 1000 + nanos // 1_000_000
+
+    def _emit_and_capture_cw_ms(self, handler, created_values):
+        """Emit records through the real handler, capture wire ms values."""
+        from unittest.mock import patch
+        captured = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: captured.append(self._cw_ms(rec.created))):
+            for created in created_values:
+                handler.emit(self._make_record(created))
+        return captured
+
+    def test_same_millisecond_burst_gets_unique_increasing_ms(self, handler):
+        """A burst of records in the same millisecond must land on strictly
+        increasing, unique CloudWatch milliseconds."""
+        base = 1784526643.000100
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base + i * 0.00001 for i in range(50)])
+
+        assert len(set(cw)) == 50, f"CW ms collisions: {sorted(cw)}"
+        assert cw == sorted(cw), "CW ms values must be strictly increasing"
+
+    def test_records_in_distinct_ms_are_not_modified(self, handler):
+        """Records already >=1ms apart must pass through with their natural
+        timestamps (the nudge only activates on ties)."""
+        base = 1784526643.0
+        values = [base + i * 0.005 for i in range(10)]  # 5ms apart
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert cw == [self._cw_ms(v) for v in values]
+
+    def test_backwards_clock_sample_is_nudged_forward(self, handler):
+        """A record whose clock reads earlier than the previous one (clock
+        adjustment) must still land strictly after it."""
+        base = 1784526643.500
+        cw = self._emit_and_capture_cw_ms(
+            handler, [base, base + 0.0001, base - 1.0])
+
+        assert len(set(cw)) == 3
+        assert cw == sorted(cw)
+
+    def test_boundary_straddling_floats_cannot_tie(self, handler):
+        """Values within sub-microsecond of millisecond boundaries — the class
+        that defeated both earlier nudge implementations — must never produce
+        a tied or decreasing wire millisecond."""
+        base_ms = 1784526643000
+        values = []
+        t = base_ms
+        for k in range(500):
+            t += 1
+            for eps in (-2e-7, -1e-7, 0.0, 1e-7):
+                values.append(t / 1000.0 + eps)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == len(cw), "wire ms collision from boundary floats"
+        assert cw == sorted(cw), "wire ms regression from boundary floats"
+
+    def test_dense_stress_profile_all_unique(self, handler):
+        """Stress-test-shaped emission (bursts up to ~11 lines/ms with gaps)
+        must produce all-unique, strictly increasing wire milliseconds."""
+        import random
+        rng = random.Random(42)
+        t = 1784526643.0
+        values = []
+        for i in range(5000):
+            if i % 6 == 0:
+                t += rng.choice([0.0, 0.001, 0.002])
+            values.append(t)
+
+        cw = self._emit_and_capture_cw_ms(handler, values)
+
+        assert len(set(cw)) == 5000
+        assert cw == sorted(cw)
+
+    def test_msecs_kept_consistent_for_formatters(self, handler):
+        """When a record is nudged, record.msecs must match record.created so
+        %(asctime)s in formatted messages agrees with the CW timestamp."""
+        from unittest.mock import patch
+        records = []
+        with patch('fluent.handler.FluentHandler.emit',
+                   side_effect=lambda rec: records.append(rec)):
+            base = 1784526643.000100
+            for i in range(5):
+                handler.emit(self._make_record(base))  # all identical -> nudged
+
+        for rec in records:
+            expected_msecs = (rec.created - int(rec.created)) * 1000
+            assert abs(rec.msecs - expected_msecs) < 1e-6


### PR DESCRIPTION
# Fix CloudWatch task log ordering for NCL (Fluent Bit) logging

  ## Problem

  With `USE_NON_CRITICAL_LOGGING=true`, task logs display **out of order** in the
  CloudWatch console. Under a 50-task × 5000-line stress test on Airflow 2.10.3,
  44/50 log streams were disordered, with whole blocks displaced (e.g., lines
  151–200 + END marker rendered before lines 1–50). A Watchtower-based (non-NCL)
  environment passes the same test 50/50 — this is a regression introduced by the
  Fluent Bit sidecar transport.

  ## Root cause

  Two independent defects:

  1. **Second-truncated timestamps.** `fluent-logger`'s handler sends
     `int(record.created)` — whole seconds — unless `nanosecond_precision=True`
     is set (we didn't). Every log line emitted within the same second carries an
     identical CloudWatch timestamp.

  2. **Fluent Bit's transport doesn't preserve cross-chunk order (by design).**
     Chunks are flushed asynchronously and retried with backoff while newer
     chunks proceed ([documented upstream](https://github.com/grafana/loki/issues/2393),
     [fluent-bit#4757](https://github.com/fluent/fluent-bit/issues/4757)).
     Per [CloudWatch docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html),
     same-timestamp events are processed as **unordered** (tie-broken by ingestion
     time, then message index) — so once timestamps tie, display order is
     whatever order chunks happened to land, which no transport config can fix.

  Watchtower avoided this by accident: strictly serial per-stream submission made
  ingestion order match emission order.

  ## Fix (two parts, all NCL versions)

  1. **`cloudwatch_handlers.py`: `nanosecond_precision=True`** on all
     `ForkSafeFluentHandler` constructions — stops discarding sub-second
     precision (fluent `EventTime` carries it natively).

  2. **`fork_safe_handler.py`: monotonic millisecond nudge** in
     `ForkSafeFluentHandler.emit()` — enforces strictly increasing, unique
     CloudWatch millisecond timestamps per handler. CloudWatch stores
     ms-resolution timestamps, so rapid bursts (>1 line/ms) still tie after fix 1
     alone; the nudge encodes ordering into the resolution CloudWatch actually
     keeps, making display order deterministic regardless of chunk batching,
     races, or retries.

     Two float-arithmetic subtleties are load-bearing (see code comments):
     - nudged values are reconstructed at **mid-millisecond** (`(ms + 0.5)/1000.0`)
       — a bare `ms/1000.0` floors back down 1ms through the EventTime packing for
       ~50% of values, re-creating ties
     - the tie check computes milliseconds with **wire-identical arithmetic**
       (`int(created)*1000 + int((created % 1)*1e9)//1_000_000`) — `int(created*1000)`
       can round up across a boundary the wire value doesn't cross, letting rare
       same-source ties through (~5 per 250k lines, reproduced in production data)

  ## Trade-off

  During sustained bursts faster than **1000 lines/sec per source**, timestamps
  drift ahead of wall clock by the excess (self-correcting during gaps; CloudWatch
  accepts up to 2h future). Inter-line deltas within such bursts read as a
  synthetic 1ms. At realistic rates (≤ hundreds of lines/sec) the nudge is a
  no-op. Ordering guarantee is **per-source**: concurrent writers to one stream
  (task supervisor vs. raw task process) may interleave nondeterministically, but
  each source's own sequence is always preserved.

  ## Validation

  - **Stress test** (50 tasks × 5000 lines, single worker, 2.10.3):
    baseline **6/50** streams ordered → with fix **50/50, three consecutive runs
    (150/150)**; distinct-timestamp checks confirm zero same-source ties.
  - **Also verified on 3.2.1** (26/50 → 50/50).
  - **Unit tests** (`TestMonotonicTimestampNudge`, 6 tests per version): assert on
    the **wire encoding** (real fluent `EventTime` struct packing + Fluent Bit's
    floor-to-ms), not `record.created` — both float bugs above escaped earlier
    verification precisely because it checked Python-side values. Covers same-ms
    bursts, boundary-straddling floats, backwards clock samples, 5000-line stress
    profiles, and formatter (`%(asctime)s`) consistency.
  - All suites pass locally: 17/17 on 2.9.2/2.10.1/2.10.3/2.11.0/3.0.6/3.2.1,
    16/16 on 3.3.0. (2.11.2 suite requires CI — local requirements install
    unavailable.)

  ## Notes for reviewers

  - **3.3.0** currently constructs the fluent handler only for `customer.logs`
    (its task-log path doesn't use it yet). If/when it adopts the 3.2.1
    `CloudWatchRemoteTaskLogger` pattern, that construction **must** include
    `nanosecond_precision=True`, or the ordering bug returns for task logs.
  - The nudge makes chunk retries ordering-safe, which unlocks a follow-up
    `Retry_Limit` increase in the Fluent Bit sidecar config (separate change,
    addresses log loss rather than ordering).
  - No changes to the Watchtower (non-NCL) path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
