### PR TITLE
Fix copy-paste errors in package-requirements feature

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/utils/user_requirements.py
+++ b/images/airflow/2.10.1/python/mwaa/utils/user_requirements.py
@@ -135,7 +135,7 @@ def package_user_requirements(environ: dict[str, str]):
         logger.info("No user requirements file found. Nothing to package.")
         return
 
-    airflow_home = os.environ.get("AIRFLOW_HOME", "/usr/local/airflow")
+    airflow_home = environ.get("AIRFLOW_HOME", "/usr/local/airflow")
     plugins_dir = Path(airflow_home) / "plugins"
     requirements_dir = Path(airflow_home) / "requirements"
     downloads_dir = requirements_dir / "downloads"

--- a/images/airflow/2.10.3/python/mwaa/utils/user_requirements.py
+++ b/images/airflow/2.10.3/python/mwaa/utils/user_requirements.py
@@ -135,7 +135,7 @@ def package_user_requirements(environ: dict[str, str]):
         logger.info("No user requirements file found. Nothing to package.")
         return
 
-    airflow_home = os.environ.get("AIRFLOW_HOME", "/usr/local/airflow")
+    airflow_home = environ.get("AIRFLOW_HOME", "/usr/local/airflow")
     plugins_dir = Path(airflow_home) / "plugins"
     requirements_dir = Path(airflow_home) / "requirements"
     downloads_dir = requirements_dir / "downloads"

--- a/images/airflow/2.11.0/python/mwaa/utils/user_requirements.py
+++ b/images/airflow/2.11.0/python/mwaa/utils/user_requirements.py
@@ -135,7 +135,7 @@ def package_user_requirements(environ: dict[str, str]):
         logger.info("No user requirements file found. Nothing to package.")
         return
 
-    airflow_home = os.environ.get("AIRFLOW_HOME", "/usr/local/airflow")
+    airflow_home = environ.get("AIRFLOW_HOME", "/usr/local/airflow")
     plugins_dir = Path(airflow_home) / "plugins"
     requirements_dir = Path(airflow_home) / "requirements"
     downloads_dir = requirements_dir / "downloads"

--- a/images/airflow/2.11.2/docker-compose-test-commands.yaml
+++ b/images/airflow/2.11.2/docker-compose-test-commands.yaml
@@ -53,7 +53,7 @@ services:
   package-requirements:
     <<: *airflow-common
     command: package-requirements
-    container_name: mwaa-320-package-requirements
+    container_name: mwaa-2112-package-requirements
 
 volumes:
   postgres-db-volume:

--- a/images/airflow/2.11.2/python/mwaa/utils/user_requirements.py
+++ b/images/airflow/2.11.2/python/mwaa/utils/user_requirements.py
@@ -135,7 +135,7 @@ def package_user_requirements(environ: dict[str, str]):
         logger.info("No user requirements file found. Nothing to package.")
         return
 
-    airflow_home = os.environ.get("AIRFLOW_HOME", "/usr/local/airflow")
+    airflow_home = environ.get("AIRFLOW_HOME", "/usr/local/airflow")
     plugins_dir = Path(airflow_home) / "plugins"
     requirements_dir = Path(airflow_home) / "requirements"
     downloads_dir = requirements_dir / "downloads"

--- a/images/airflow/2.9.2/python/mwaa/utils/user_requirements.py
+++ b/images/airflow/2.9.2/python/mwaa/utils/user_requirements.py
@@ -136,7 +136,7 @@ def package_user_requirements(environ: dict[str, str]):
         logger.info("No user requirements file found. Nothing to package.")
         return
 
-    airflow_home = os.environ.get("AIRFLOW_HOME", "/usr/local/airflow")
+    airflow_home = environ.get("AIRFLOW_HOME", "/usr/local/airflow")
     plugins_dir = Path(airflow_home) / "plugins"
     requirements_dir = Path(airflow_home) / "requirements"
     downloads_dir = requirements_dir / "downloads"

--- a/images/airflow/3.0.6/python/mwaa/utils/user_requirements.py
+++ b/images/airflow/3.0.6/python/mwaa/utils/user_requirements.py
@@ -135,7 +135,7 @@ def package_user_requirements(environ: dict[str, str]):
         logger.info("No user requirements file found. Nothing to package.")
         return
 
-    airflow_home = os.environ.get("AIRFLOW_HOME", "/usr/local/airflow")
+    airflow_home = environ.get("AIRFLOW_HOME", "/usr/local/airflow")
     plugins_dir = Path(airflow_home) / "plugins"
     requirements_dir = Path(airflow_home) / "requirements"
     downloads_dir = requirements_dir / "downloads"

--- a/images/airflow/3.2.1/docker-compose-test-commands.yaml
+++ b/images/airflow/3.2.1/docker-compose-test-commands.yaml
@@ -43,18 +43,18 @@ services:
   test-requirements:
     <<: *airflow-common
     command: test-requirements
-    container_name: mwaa-320-requirements
+    container_name: mwaa-321-requirements
 
   test-startup-script:
     <<: *airflow-common
     command: test-startup-script
-    container_name: mwaa-320-startup-script
+    container_name: mwaa-321-startup-script
 
   package-requirements:
     <<: *airflow-common
     command: package-requirements
-    container_name: mwaa-320-package-requirements
+    container_name: mwaa-321-package-requirements
 
 volumes:
   postgres-db-volume:
-    name: "mwaa-320-db-volume"
+    name: "mwaa-321-db-volume"

--- a/images/airflow/3.2.1/python/mwaa/utils/user_requirements.py
+++ b/images/airflow/3.2.1/python/mwaa/utils/user_requirements.py
@@ -136,7 +136,7 @@ def package_user_requirements(environ: dict[str, str]):
         logger.info("No user requirements file found. Nothing to package.")
         return
 
-    airflow_home = os.environ.get("AIRFLOW_HOME", "/usr/local/airflow")
+    airflow_home = environ.get("AIRFLOW_HOME", "/usr/local/airflow")
     plugins_dir = Path(airflow_home) / "plugins"
     requirements_dir = Path(airflow_home) / "requirements"
     downloads_dir = requirements_dir / "downloads"


### PR DESCRIPTION
## Summary

Fixes two issues introduced in PR #457 (package-requirements feature):

### 1. Docker Compose container name copy-paste errors

- **2.11.2**: `container_name: mwaa-320-package-requirements` → `mwaa-2112-package-requirements`
- **3.2.1**: All container names and volume name still reference `mwaa-320` instead of `mwaa-321`:
  - `mwaa-320-requirements` → `mwaa-321-requirements`
  - `mwaa-320-startup-script` → `mwaa-321-startup-script`
  - `mwaa-320-package-requirements` → `mwaa-321-package-requirements`
  - `mwaa-320-db-volume` → `mwaa-321-db-volume`

The wrong container names could cause collisions if multiple version compose files are used on the same Docker host.

### 2. Inconsistent environment variable source in `package_user_requirements()`

`MWAA__CORE__REQUIREMENTS_PATH` is correctly read from the `environ` parameter (the constructed environment passed to pip3), but `AIRFLOW_HOME` was incorrectly read from `os.environ`. If the two differ, this would produce incorrect paths.

**Fix**: Read `AIRFLOW_HOME` from `environ` parameter for consistency.

**Affected versions**: 2.9.2, 2.10.1, 2.10.3, 2.11.0, 2.11.2, 3.0.6, 3.2.1

## Testing

These are straightforward copy-paste fixes — verified by grepping all affected files to confirm correctness.