### PR TITLE
Add observability for NCL by emitting python metrics related to logs in CloudWatch_handlers

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -37,6 +37,42 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
 
+# Batch size for the emitted counter: we accumulate locally and flush to StatsD
+# every N records to avoid doubling the UDP packet rate at high throughput.
+_EMITTED_BATCH_SIZE = 100
+# Time-based flush interval (seconds) for the emitted counter: ensures low-volume
+# sources still report metrics regularly for pattern observation.
+_EMITTED_FLUSH_INTERVAL_SECONDS = 60
+
+
+def _make_overflow_handlers(logs_source: str):
+    """
+    Create queue_overflow_handler and buffer_overflow_handler callbacks for a
+    ForkSafeFluentHandler instance.
+
+    These callbacks emit StatsD metrics when the fluent sender drops log records,
+    giving us visibility into log loss from the Python side of the NCL pipeline.
+
+    Args:
+        logs_source: Identifies the log source (e.g. "scheduler", "task") for the
+            metric name: mwaa.logging.{logs_source}.ncl_queue_evicted_records, etc.
+
+    Returns:
+        (queue_overflow_handler, buffer_overflow_handler) tuple of callables.
+    """
+    stats = get_statsd()
+
+    def queue_overflow_handler(discarded_bytes):
+        """Called once per eviction when the circular queue is full."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_queue_evicted_records", 1)
+
+    def buffer_overflow_handler(pendings):
+        """Called when the TCP send buffer exceeds bufmax after a socket failure."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow", 1)
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow_bytes", len(pendings))
+
+    return queue_overflow_handler, buffer_overflow_handler
+
 
 # fmt: off
 # IMPORTANT NOTE: The time complexity of log inspection is O(M*N) where M is the number
@@ -107,6 +143,12 @@ class BaseLogHandler(logging.Handler):
         logging.Handler.__init__(self)
 
         self.stats = get_statsd()
+        # Batched emitted counter: accumulate locally, flush to StatsD every
+        # _EMITTED_BATCH_SIZE records or _EMITTED_FLUSH_INTERVAL_SECONDS,
+        # whichever comes first. Avoids excessive UDP packet rate at high
+        # throughput while still providing regular data points for low-volume sources.
+        self._emitted_count = 0
+        self._last_emitted_flush = time.time()
 
     def create_cloudwatch_handler(
         self,
@@ -133,12 +175,15 @@ class BaseLogHandler(logging.Handler):
         self.log_stream = stream_name
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers(logs_source)
             self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -188,6 +233,10 @@ class BaseLogHandler(logging.Handler):
     def close(self):
         """Close the log handler (by closing the underlying log handler)."""
         if self.handler is not None:
+            # Flush any remaining emitted count before closing.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.close()
             self.handler = None
 
@@ -231,6 +280,14 @@ class BaseLogHandler(logging.Handler):
                 try:
                     self.handler.emit(record)  # type: ignore
                     self.sniff_errors(record)
+                    # Batch the emitted metric to avoid flooding StatsD with per-record packets.
+                    # Flush on count threshold OR time interval, whichever comes first.
+                    self._emitted_count += 1
+                    if self._emitted_count >= _EMITTED_BATCH_SIZE or \
+                            (time.time() - self._last_emitted_flush) >= _EMITTED_FLUSH_INTERVAL_SECONDS:
+                        self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                        self._emitted_count = 0
+                        self._last_emitted_flush = time.time()
                 except Exception:
                     self.stats.incr(f"mwaa.logging.{self.logs_source}.emit_error", 1)
                     self._report_logging_error("Failed to emit log record.")
@@ -259,6 +316,10 @@ class BaseLogHandler(logging.Handler):
         if not self.handler:
             return
         try:
+            # Flush any remaining emitted count.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.flush()
         except Exception:
             self.stats.incr(f"mwaa.logging.{self.logs_source}.flush_error", 1)
@@ -313,12 +374,16 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            self.logs_source = "Task"
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers("Task")
             self.handler = ForkSafeFluentHandler(
                 'customer.task.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -342,6 +407,7 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
             self.handler.setFormatter(TaskFormatter())
 
         elif self.enabled:
+            self.logs_source = "Task"
             # identical to open-source implementation, except create_log_group set to False
             self.handler = watchtower.CloudWatchLogHandler(
                 log_group_name=self.log_group_name,

--- a/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.10.3/python/mwaa/logging/cloudwatch_handlers.py
@@ -37,6 +37,42 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
 
+# Batch size for the emitted counter: we accumulate locally and flush to StatsD
+# every N records to avoid doubling the UDP packet rate at high throughput.
+_EMITTED_BATCH_SIZE = 100
+# Time-based flush interval (seconds) for the emitted counter: ensures low-volume
+# sources still report metrics regularly for pattern observation.
+_EMITTED_FLUSH_INTERVAL_SECONDS = 60
+
+
+def _make_overflow_handlers(logs_source: str):
+    """
+    Create queue_overflow_handler and buffer_overflow_handler callbacks for a
+    ForkSafeFluentHandler instance.
+
+    These callbacks emit StatsD metrics when the fluent sender drops log records,
+    giving us visibility into log loss from the Python side of the NCL pipeline.
+
+    Args:
+        logs_source: Identifies the log source (e.g. "scheduler", "task") for the
+            metric name: mwaa.logging.{logs_source}.ncl_queue_evicted_records, etc.
+
+    Returns:
+        (queue_overflow_handler, buffer_overflow_handler) tuple of callables.
+    """
+    stats = get_statsd()
+
+    def queue_overflow_handler(discarded_bytes):
+        """Called once per eviction when the circular queue is full."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_queue_evicted_records", 1)
+
+    def buffer_overflow_handler(pendings):
+        """Called when the TCP send buffer exceeds bufmax after a socket failure."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow", 1)
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow_bytes", len(pendings))
+
+    return queue_overflow_handler, buffer_overflow_handler
+
 # fmt: off
 # IMPORTANT NOTE: The time complexity of log inspection is O(M*N) where M is the number
 # of logs and N is the number of log patterns. As such, each new pattern added will
@@ -106,6 +142,12 @@ class BaseLogHandler(logging.Handler):
         logging.Handler.__init__(self)
 
         self.stats = get_statsd()
+        # Batched emitted counter: accumulate locally, flush to StatsD every
+        # _EMITTED_BATCH_SIZE records or _EMITTED_FLUSH_INTERVAL_SECONDS,
+        # whichever comes first. Avoids excessive UDP packet rate at high
+        # throughput while still providing regular data points for low-volume sources.
+        self._emitted_count = 0
+        self._last_emitted_flush = time.time()
 
     def create_cloudwatch_handler(
         self,
@@ -132,12 +174,15 @@ class BaseLogHandler(logging.Handler):
         self.log_stream = stream_name
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers(logs_source)
             self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -187,6 +232,10 @@ class BaseLogHandler(logging.Handler):
     def close(self):
         """Close the log handler (by closing the underlying log handler)."""
         if self.handler is not None:
+            # Flush any remaining emitted count before closing.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.close()
             self.handler = None
 
@@ -230,6 +279,14 @@ class BaseLogHandler(logging.Handler):
                 try:
                     self.handler.emit(record)  # type: ignore
                     self.sniff_errors(record)
+                    # Batch the emitted metric to avoid flooding StatsD with per-record packets.
+                    # Flush on count threshold OR time interval, whichever comes first.
+                    self._emitted_count += 1
+                    if self._emitted_count >= _EMITTED_BATCH_SIZE or \
+                            (time.time() - self._last_emitted_flush) >= _EMITTED_FLUSH_INTERVAL_SECONDS:
+                        self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                        self._emitted_count = 0
+                        self._last_emitted_flush = time.time()
                 except Exception:
                     self.stats.incr(f"mwaa.logging.{self.logs_source}.emit_error", 1)
                     self._report_logging_error("Failed to emit log record.")
@@ -258,6 +315,10 @@ class BaseLogHandler(logging.Handler):
         if not self.handler:
             return
         try:
+            # Flush any remaining emitted count.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.flush()
         except Exception:
             self.stats.incr(f"mwaa.logging.{self.logs_source}.flush_error", 1)
@@ -312,12 +373,16 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            self.logs_source = "Task"
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers("Task")
             self.handler = ForkSafeFluentHandler(
                 'customer.task.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -341,6 +406,7 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
             self.handler.setFormatter(TaskFormatter())
 
         elif self.enabled:
+            self.logs_source = "Task"
             # identical to open-source implementation, except create_log_group set to False
             self.handler = watchtower.CloudWatchLogHandler(
                 log_group_name=self.log_group_name,

--- a/images/airflow/2.11.0/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.11.0/python/mwaa/logging/cloudwatch_handlers.py
@@ -37,6 +37,42 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
 
+# Batch size for the emitted counter: we accumulate locally and flush to StatsD
+# every N records to avoid doubling the UDP packet rate at high throughput.
+_EMITTED_BATCH_SIZE = 100
+# Time-based flush interval (seconds) for the emitted counter: ensures low-volume
+# sources still report metrics regularly for pattern observation.
+_EMITTED_FLUSH_INTERVAL_SECONDS = 60
+
+
+def _make_overflow_handlers(logs_source: str):
+    """
+    Create queue_overflow_handler and buffer_overflow_handler callbacks for a
+    ForkSafeFluentHandler instance.
+
+    These callbacks emit StatsD metrics when the fluent sender drops log records,
+    giving us visibility into log loss from the Python side of the NCL pipeline.
+
+    Args:
+        logs_source: Identifies the log source (e.g. "scheduler", "task") for the
+            metric name: mwaa.logging.{logs_source}.ncl_queue_evicted_records, etc.
+
+    Returns:
+        (queue_overflow_handler, buffer_overflow_handler) tuple of callables.
+    """
+    stats = get_statsd()
+
+    def queue_overflow_handler(discarded_bytes):
+        """Called once per eviction when the circular queue is full."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_queue_evicted_records", 1)
+
+    def buffer_overflow_handler(pendings):
+        """Called when the TCP send buffer exceeds bufmax after a socket failure."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow", 1)
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow_bytes", len(pendings))
+
+    return queue_overflow_handler, buffer_overflow_handler
+
 
 # fmt: off
 # IMPORTANT NOTE: The time complexity of log inspection is O(M*N) where M is the number
@@ -107,6 +143,12 @@ class BaseLogHandler(logging.Handler):
         logging.Handler.__init__(self)
 
         self.stats = get_statsd()
+        # Batched emitted counter: accumulate locally, flush to StatsD every
+        # _EMITTED_BATCH_SIZE records or _EMITTED_FLUSH_INTERVAL_SECONDS,
+        # whichever comes first. Avoids excessive UDP packet rate at high
+        # throughput while still providing regular data points for low-volume sources.
+        self._emitted_count = 0
+        self._last_emitted_flush = time.time()
 
     def create_cloudwatch_handler(
         self,
@@ -133,12 +175,15 @@ class BaseLogHandler(logging.Handler):
         self.log_stream = stream_name
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers(logs_source)
             self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -188,6 +233,10 @@ class BaseLogHandler(logging.Handler):
     def close(self):
         """Close the log handler (by closing the underlying log handler)."""
         if self.handler is not None:
+            # Flush any remaining emitted count before closing.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.close()
             self.handler = None
 
@@ -231,6 +280,14 @@ class BaseLogHandler(logging.Handler):
                 try:
                     self.handler.emit(record)  # type: ignore
                     self.sniff_errors(record)
+                    # Batch the emitted metric to avoid flooding StatsD with per-record packets.
+                    # Flush on count threshold OR time interval, whichever comes first.
+                    self._emitted_count += 1
+                    if self._emitted_count >= _EMITTED_BATCH_SIZE or \
+                            (time.time() - self._last_emitted_flush) >= _EMITTED_FLUSH_INTERVAL_SECONDS:
+                        self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                        self._emitted_count = 0
+                        self._last_emitted_flush = time.time()
                 except Exception:
                     self.stats.incr(f"mwaa.logging.{self.logs_source}.emit_error", 1)
                     self._report_logging_error("Failed to emit log record.")
@@ -259,6 +316,10 @@ class BaseLogHandler(logging.Handler):
         if not self.handler:
             return
         try:
+            # Flush any remaining emitted count.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.flush()
         except Exception:
             self.stats.incr(f"mwaa.logging.{self.logs_source}.flush_error", 1)
@@ -330,12 +391,16 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            self.logs_source = "Task"
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers("Task")
             self.handler = ForkSafeFluentHandler(
                 'customer.task.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -359,6 +424,7 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
             self.handler.setFormatter(TaskFormatter())
 
         elif self.enabled:
+            self.logs_source = "Task"
             # identical to open-source implementation, except create_log_group set to False
             self.handler = watchtower.CloudWatchLogHandler(
                 log_group_name=self.log_group_name,

--- a/images/airflow/2.11.2/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.11.2/python/mwaa/logging/cloudwatch_handlers.py
@@ -37,6 +37,42 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
 
+# Batch size for the emitted counter: we accumulate locally and flush to StatsD
+# every N records to avoid doubling the UDP packet rate at high throughput.
+_EMITTED_BATCH_SIZE = 100
+# Time-based flush interval (seconds) for the emitted counter: ensures low-volume
+# sources still report metrics regularly for pattern observation.
+_EMITTED_FLUSH_INTERVAL_SECONDS = 60
+
+
+def _make_overflow_handlers(logs_source: str):
+    """
+    Create queue_overflow_handler and buffer_overflow_handler callbacks for a
+    ForkSafeFluentHandler instance.
+
+    These callbacks emit StatsD metrics when the fluent sender drops log records,
+    giving us visibility into log loss from the Python side of the NCL pipeline.
+
+    Args:
+        logs_source: Identifies the log source (e.g. "scheduler", "task") for the
+            metric name: mwaa.logging.{logs_source}.ncl_queue_evicted_records, etc.
+
+    Returns:
+        (queue_overflow_handler, buffer_overflow_handler) tuple of callables.
+    """
+    stats = get_statsd()
+
+    def queue_overflow_handler(discarded_bytes):
+        """Called once per eviction when the circular queue is full."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_queue_evicted_records", 1)
+
+    def buffer_overflow_handler(pendings):
+        """Called when the TCP send buffer exceeds bufmax after a socket failure."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow", 1)
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow_bytes", len(pendings))
+
+    return queue_overflow_handler, buffer_overflow_handler
+
 
 # fmt: off
 # IMPORTANT NOTE: The time complexity of log inspection is O(M*N) where M is the number
@@ -107,6 +143,12 @@ class BaseLogHandler(logging.Handler):
         logging.Handler.__init__(self)
 
         self.stats = get_statsd()
+        # Batched emitted counter: accumulate locally, flush to StatsD every
+        # _EMITTED_BATCH_SIZE records or _EMITTED_FLUSH_INTERVAL_SECONDS,
+        # whichever comes first. Avoids excessive UDP packet rate at high
+        # throughput while still providing regular data points for low-volume sources.
+        self._emitted_count = 0
+        self._last_emitted_flush = time.time()
 
     def create_cloudwatch_handler(
         self,
@@ -133,12 +175,15 @@ class BaseLogHandler(logging.Handler):
         self.log_stream = stream_name
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers(logs_source)
             self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -188,6 +233,10 @@ class BaseLogHandler(logging.Handler):
     def close(self):
         """Close the log handler (by closing the underlying log handler)."""
         if self.handler is not None:
+            # Flush any remaining emitted count before closing.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.close()
             self.handler = None
 
@@ -231,6 +280,14 @@ class BaseLogHandler(logging.Handler):
                 try:
                     self.handler.emit(record)  # type: ignore
                     self.sniff_errors(record)
+                    # Batch the emitted metric to avoid flooding StatsD with per-record packets.
+                    # Flush on count threshold OR time interval, whichever comes first.
+                    self._emitted_count += 1
+                    if self._emitted_count >= _EMITTED_BATCH_SIZE or \
+                            (time.time() - self._last_emitted_flush) >= _EMITTED_FLUSH_INTERVAL_SECONDS:
+                        self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                        self._emitted_count = 0
+                        self._last_emitted_flush = time.time()
                 except Exception:
                     self.stats.incr(f"mwaa.logging.{self.logs_source}.emit_error", 1)
                     self._report_logging_error("Failed to emit log record.")
@@ -259,6 +316,10 @@ class BaseLogHandler(logging.Handler):
         if not self.handler:
             return
         try:
+            # Flush any remaining emitted count.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.flush()
         except Exception:
             self.stats.incr(f"mwaa.logging.{self.logs_source}.flush_error", 1)
@@ -330,12 +391,16 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            self.logs_source = "Task"
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers("Task")
             self.handler = ForkSafeFluentHandler(
                 'customer.task.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -359,6 +424,7 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
             self.handler.setFormatter(TaskFormatter())
 
         elif self.enabled:
+            self.logs_source = "Task"
             # identical to open-source implementation, except create_log_group set to False
             self.handler = watchtower.CloudWatchLogHandler(
                 log_group_name=self.log_group_name,

--- a/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/2.9.2/python/mwaa/logging/cloudwatch_handlers.py
@@ -37,6 +37,42 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
 
+# Batch size for the emitted counter: we accumulate locally and flush to StatsD
+# every N records to avoid doubling the UDP packet rate at high throughput.
+_EMITTED_BATCH_SIZE = 100
+# Time-based flush interval (seconds) for the emitted counter: ensures low-volume
+# sources still report metrics regularly for pattern observation.
+_EMITTED_FLUSH_INTERVAL_SECONDS = 60
+
+
+def _make_overflow_handlers(logs_source: str):
+    """
+    Create queue_overflow_handler and buffer_overflow_handler callbacks for a
+    ForkSafeFluentHandler instance.
+
+    These callbacks emit StatsD metrics when the fluent sender drops log records,
+    giving us visibility into log loss from the Python side of the NCL pipeline.
+
+    Args:
+        logs_source: Identifies the log source (e.g. "scheduler", "task") for the
+            metric name: mwaa.logging.{logs_source}.ncl_queue_evicted_records, etc.
+
+    Returns:
+        (queue_overflow_handler, buffer_overflow_handler) tuple of callables.
+    """
+    stats = get_statsd()
+
+    def queue_overflow_handler(discarded_bytes):
+        """Called once per eviction when the circular queue is full."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_queue_evicted_records", 1)
+
+    def buffer_overflow_handler(pendings):
+        """Called when the TCP send buffer exceeds bufmax after a socket failure."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow", 1)
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow_bytes", len(pendings))
+
+    return queue_overflow_handler, buffer_overflow_handler
+
 
 # fmt: off
 # IMPORTANT NOTE: The time complexity of log inspection is O(M*N) where M is the number
@@ -107,6 +143,12 @@ class BaseLogHandler(logging.Handler):
         logging.Handler.__init__(self)
 
         self.stats = get_statsd()
+        # Batched emitted counter: accumulate locally, flush to StatsD every
+        # _EMITTED_BATCH_SIZE records or _EMITTED_FLUSH_INTERVAL_SECONDS,
+        # whichever comes first. Avoids excessive UDP packet rate at high
+        # throughput while still providing regular data points for low-volume sources.
+        self._emitted_count = 0
+        self._last_emitted_flush = time.time()
 
     def create_cloudwatch_handler(
         self,
@@ -133,12 +175,15 @@ class BaseLogHandler(logging.Handler):
         self.log_stream = stream_name
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers(logs_source)
             self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -188,6 +233,10 @@ class BaseLogHandler(logging.Handler):
     def close(self):
         """Close the log handler (by closing the underlying log handler)."""
         if self.handler is not None:
+            # Flush any remaining emitted count before closing.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.close()
             self.handler = None
 
@@ -231,6 +280,14 @@ class BaseLogHandler(logging.Handler):
                 try:
                     self.handler.emit(record)  # type: ignore
                     self.sniff_errors(record)
+                    # Batch the emitted metric to avoid flooding StatsD with per-record packets.
+                    # Flush on count threshold OR time interval, whichever comes first.
+                    self._emitted_count += 1
+                    if self._emitted_count >= _EMITTED_BATCH_SIZE or \
+                            (time.time() - self._last_emitted_flush) >= _EMITTED_FLUSH_INTERVAL_SECONDS:
+                        self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                        self._emitted_count = 0
+                        self._last_emitted_flush = time.time()
                 except Exception:
                     self.stats.incr(f"mwaa.logging.{self.logs_source}.emit_error", 1)
                     self._report_logging_error("Failed to emit log record.")
@@ -259,6 +316,10 @@ class BaseLogHandler(logging.Handler):
         if not self.handler:
             return
         try:
+            # Flush any remaining emitted count.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.flush()
         except Exception:
             self.stats.incr(f"mwaa.logging.{self.logs_source}.flush_error", 1)
@@ -313,12 +374,16 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
         logs_client: CloudWatchLogsClient = boto3.client("logs")  # type: ignore
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            self.logs_source = "Task"
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers("Task")
             self.handler = ForkSafeFluentHandler(
                 'customer.task.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -342,6 +407,7 @@ class TaskLogHandler(BaseLogHandler, CloudwatchTaskHandler):
             self.handler.setFormatter(TaskFormatter())
 
         elif self.enabled:
+            self.logs_source = "Task"
             # identical to open-source implementation, except create_log_group set to False
             self.handler = watchtower.CloudWatchLogHandler(
                 log_group_name=self.log_group_name,

--- a/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
@@ -50,6 +50,43 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
 
+# Batch size for the emitted counter: we accumulate locally and flush to StatsD
+# every N records to avoid doubling the UDP packet rate at high throughput.
+_EMITTED_BATCH_SIZE = 100
+# Time-based flush interval (seconds) for the emitted counter: ensures low-volume
+# sources still report metrics regularly for pattern observation.
+_EMITTED_FLUSH_INTERVAL_SECONDS = 60
+
+
+def _make_overflow_handlers(logs_source: str):
+    """
+    Create queue_overflow_handler and buffer_overflow_handler callbacks for a
+    ForkSafeFluentHandler instance.
+
+    These callbacks emit StatsD metrics when the fluent sender drops log records,
+    giving us visibility into log loss from the Python side of the NCL pipeline.
+
+    Args:
+        logs_source: Identifies the log source (e.g. "scheduler", "task") for the
+            metric name: mwaa.logging.{logs_source}.ncl_queue_evicted_records, etc.
+
+    Returns:
+        (queue_overflow_handler, buffer_overflow_handler) tuple of callables.
+    """
+    stats = get_statsd()
+
+    def queue_overflow_handler(discarded_bytes):
+        """Called once per eviction when the circular queue is full."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_queue_evicted_records", 1)
+
+    def buffer_overflow_handler(pendings):
+        """Called when the TCP send buffer exceeds bufmax after a socket failure."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow", 1)
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow_bytes", len(pendings))
+
+    return queue_overflow_handler, buffer_overflow_handler
+
+
 
 # fmt: off
 # IMPORTANT NOTE: The time complexity of log inspection is O(M*N) where M is the number
@@ -120,6 +157,12 @@ class BaseLogHandler(logging.Handler):
         logging.Handler.__init__(self)
 
         self.stats = get_statsd()
+        # Batched emitted counter: accumulate locally, flush to StatsD every
+        # _EMITTED_BATCH_SIZE records or _EMITTED_FLUSH_INTERVAL_SECONDS,
+        # whichever comes first. Avoids excessive UDP packet rate at high
+        # throughput while still providing regular data points for low-volume sources.
+        self._emitted_count = 0
+        self._last_emitted_flush = time.time()
 
     def create_cloudwatch_handler(
         self,
@@ -146,12 +189,15 @@ class BaseLogHandler(logging.Handler):
         self.log_stream = stream_name
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers(logs_source)
             self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -202,6 +248,10 @@ class BaseLogHandler(logging.Handler):
     def close(self):
         """Close the log handler (by closing the underlying log handler)."""
         if self.handler is not None:
+            # Flush any remaining emitted count before closing.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.close()
             self.handler = None
 
@@ -245,6 +295,14 @@ class BaseLogHandler(logging.Handler):
                 try:
                     self.handler.emit(record)  # type: ignore
                     self.sniff_errors(record)
+                    # Batch the emitted metric to avoid flooding StatsD with per-record packets.
+                    # Flush on count threshold OR time interval, whichever comes first.
+                    self._emitted_count += 1
+                    if self._emitted_count >= _EMITTED_BATCH_SIZE or \
+                            (time.time() - self._last_emitted_flush) >= _EMITTED_FLUSH_INTERVAL_SECONDS:
+                        self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                        self._emitted_count = 0
+                        self._last_emitted_flush = time.time()
                 except Exception:
                     self.stats.incr(f"mwaa.logging.{self.logs_source}.emit_error", 1)
                     self._report_logging_error("Failed to emit log record.")
@@ -273,6 +331,10 @@ class BaseLogHandler(logging.Handler):
         if not self.handler:
             return
         try:
+            # Flush any remaining emitted count.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.flush()
         except Exception:
             self.stats.incr(f"mwaa.logging.{self.logs_source}.flush_error", 1)
@@ -284,7 +346,7 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         which uses Structlog. The main logic resides in 'processors' property which is loaded by Structlog logger in
         task-sdk/src/airflow/sdk/log.py#L143
     """
-    LOG_SOURCE = "task"
+    LOG_SOURCE = "Task"
     _MAX_EVENT_BYTES = 260_000 # ~254 KB, leaving headroom for CW overhead + JSON envelope
     # In Airflow currently there are some logs that "seeps" out of the traditional task log stream. Ideally we should
     # use log_filename_template config to generate a pattern for filtering only task log streams. But that config
@@ -485,12 +547,16 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         from airflow.sdk.log import relative_path_from_logger
 
         if self.NON_CRITICAL_LOGGING_ENABLED:
+            self.logs_source = "Task"
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers("Task")
             _handler = ForkSafeFluentHandler(
                 'customer.task.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -544,6 +610,14 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
                         record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
                     try:
                         _handler.emit(record)
+                        # Batch the emitted metric to avoid flooding StatsD with per-record packets.
+                        # Flush on count threshold OR time interval, whichever comes first.
+                        self._emitted_count += 1
+                        if self._emitted_count >= _EMITTED_BATCH_SIZE or \
+                                (time.time() - self._last_emitted_flush) >= _EMITTED_FLUSH_INTERVAL_SECONDS:
+                            self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.ncl_emitted_records", self._emitted_count)
+                            self._emitted_count = 0
+                            self._last_emitted_flush = time.time()
                     except Exception:
                         self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.emit_error", 1)
                 return event

--- a/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -50,6 +50,43 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
 
+# Batch size for the emitted counter: we accumulate locally and flush to StatsD
+# every N records to avoid doubling the UDP packet rate at high throughput.
+_EMITTED_BATCH_SIZE = 100
+# Time-based flush interval (seconds) for the emitted counter: ensures low-volume
+# sources still report metrics regularly for pattern observation.
+_EMITTED_FLUSH_INTERVAL_SECONDS = 60
+
+
+def _make_overflow_handlers(logs_source: str):
+    """
+    Create queue_overflow_handler and buffer_overflow_handler callbacks for a
+    ForkSafeFluentHandler instance.
+
+    These callbacks emit StatsD metrics when the fluent sender drops log records,
+    giving us visibility into log loss from the Python side of the NCL pipeline.
+
+    Args:
+        logs_source: Identifies the log source (e.g. "scheduler", "task") for the
+            metric name: mwaa.logging.{logs_source}.ncl_queue_evicted_records, etc.
+
+    Returns:
+        (queue_overflow_handler, buffer_overflow_handler) tuple of callables.
+    """
+    stats = get_statsd()
+
+    def queue_overflow_handler(discarded_bytes):
+        """Called once per eviction when the circular queue is full."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_queue_evicted_records", 1)
+
+    def buffer_overflow_handler(pendings):
+        """Called when the TCP send buffer exceeds bufmax after a socket failure."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow", 1)
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow_bytes", len(pendings))
+
+    return queue_overflow_handler, buffer_overflow_handler
+
+
 
 # fmt: off
 # IMPORTANT NOTE: The time complexity of log inspection is O(M*N) where M is the number
@@ -120,6 +157,12 @@ class BaseLogHandler(logging.Handler):
         logging.Handler.__init__(self)
 
         self.stats = get_statsd()
+        # Batched emitted counter: accumulate locally, flush to StatsD every
+        # _EMITTED_BATCH_SIZE records or _EMITTED_FLUSH_INTERVAL_SECONDS,
+        # whichever comes first. Avoids excessive UDP packet rate at high
+        # throughput while still providing regular data points for low-volume sources.
+        self._emitted_count = 0
+        self._last_emitted_flush = time.time()
 
     def create_cloudwatch_handler(
         self,
@@ -146,12 +189,15 @@ class BaseLogHandler(logging.Handler):
         self.log_stream = stream_name
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers(logs_source)
             self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -202,6 +248,10 @@ class BaseLogHandler(logging.Handler):
     def close(self):
         """Close the log handler (by closing the underlying log handler)."""
         if self.handler is not None:
+            # Flush any remaining emitted count before closing.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.close()
             self.handler = None
 
@@ -245,6 +295,14 @@ class BaseLogHandler(logging.Handler):
                 try:
                     self.handler.emit(record)  # type: ignore
                     self.sniff_errors(record)
+                    # Batch the emitted metric to avoid flooding StatsD with per-record packets.
+                    # Flush on count threshold OR time interval, whichever comes first.
+                    self._emitted_count += 1
+                    if self._emitted_count >= _EMITTED_BATCH_SIZE or \
+                            (time.time() - self._last_emitted_flush) >= _EMITTED_FLUSH_INTERVAL_SECONDS:
+                        self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                        self._emitted_count = 0
+                        self._last_emitted_flush = time.time()
                 except Exception:
                     self.stats.incr(f"mwaa.logging.{self.logs_source}.emit_error", 1)
                     self._report_logging_error("Failed to emit log record.")
@@ -273,6 +331,10 @@ class BaseLogHandler(logging.Handler):
         if not self.handler:
             return
         try:
+            # Flush any remaining emitted count.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.flush()
         except Exception:
             self.stats.incr(f"mwaa.logging.{self.logs_source}.flush_error", 1)
@@ -284,7 +346,7 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         which uses Structlog. The main logic resides in 'processors' property which is loaded by Structlog logger in
         task-sdk/src/airflow/sdk/log.py#L143
     """
-    LOG_SOURCE = "task"
+    LOG_SOURCE = "Task"
     # In Airflow currently there are some logs that "seeps" out of the traditional task log stream. Ideally we should
     # use log_filename_template config to generate a pattern for filtering only task log streams. But that config
     # value is not a regex pattern but instead a Jinja template. As a workaround for now we use a deny list instead.
@@ -334,12 +396,16 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         from airflow.sdk.log import relative_path_from_logger
 
         if self.NON_CRITICAL_LOGGING_ENABLED:
+            self.logs_source = "Task"
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers("Task")
             _handler = ForkSafeFluentHandler(
                 'customer.task.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -392,6 +458,14 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
                     record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
                 try:
                     _handler.emit(record)
+                    # Batch the emitted metric to avoid flooding StatsD with per-record packets.
+                    # Flush on count threshold OR time interval, whichever comes first.
+                    self._emitted_count += 1
+                    if self._emitted_count >= _EMITTED_BATCH_SIZE or \
+                            (time.time() - self._last_emitted_flush) >= _EMITTED_FLUSH_INTERVAL_SECONDS:
+                        self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.ncl_emitted_records", self._emitted_count)
+                        self._emitted_count = 0
+                        self._last_emitted_flush = time.time()
                 except Exception:
                     self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.emit_error", 1)
                 return event

--- a/images/airflow/3.3.0/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.3.0/python/mwaa/logging/cloudwatch_handlers.py
@@ -50,6 +50,43 @@ USE_NON_CRITICAL_LOGGING = os.environ.get('USE_NON_CRITICAL_LOGGING', 'false')
 LOG_GROUP_INIT_WAIT_SECONDS = 900
 ERROR_REPORTING_WAIT_SECONDS = 60
 
+# Batch size for the emitted counter: we accumulate locally and flush to StatsD
+# every N records to avoid doubling the UDP packet rate at high throughput.
+_EMITTED_BATCH_SIZE = 100
+# Time-based flush interval (seconds) for the emitted counter: ensures low-volume
+# sources still report metrics regularly for pattern observation.
+_EMITTED_FLUSH_INTERVAL_SECONDS = 60
+
+
+def _make_overflow_handlers(logs_source: str):
+    """
+    Create queue_overflow_handler and buffer_overflow_handler callbacks for a
+    ForkSafeFluentHandler instance.
+
+    These callbacks emit StatsD metrics when the fluent sender drops log records,
+    giving us visibility into log loss from the Python side of the NCL pipeline.
+
+    Args:
+        logs_source: Identifies the log source (e.g. "scheduler", "task") for the
+            metric name: mwaa.logging.{logs_source}.ncl_queue_evicted_records, etc.
+
+    Returns:
+        (queue_overflow_handler, buffer_overflow_handler) tuple of callables.
+    """
+    stats = get_statsd()
+
+    def queue_overflow_handler(discarded_bytes):
+        """Called once per eviction when the circular queue is full."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_queue_evicted_records", 1)
+
+    def buffer_overflow_handler(pendings):
+        """Called when the TCP send buffer exceeds bufmax after a socket failure."""
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow", 1)
+        stats.incr(f"mwaa.logging.{logs_source}.ncl_buffer_overflow_bytes", len(pendings))
+
+    return queue_overflow_handler, buffer_overflow_handler
+
+
 
 # fmt: off
 # IMPORTANT NOTE: The time complexity of log inspection is O(M*N) where M is the number
@@ -120,6 +157,12 @@ class BaseLogHandler(logging.Handler):
         logging.Handler.__init__(self)
 
         self.stats = get_statsd()
+        # Batched emitted counter: accumulate locally, flush to StatsD every
+        # _EMITTED_BATCH_SIZE records or _EMITTED_FLUSH_INTERVAL_SECONDS,
+        # whichever comes first. Avoids excessive UDP packet rate at high
+        # throughput while still providing regular data points for low-volume sources.
+        self._emitted_count = 0
+        self._last_emitted_flush = time.time()
 
     def create_cloudwatch_handler(
         self,
@@ -146,12 +189,15 @@ class BaseLogHandler(logging.Handler):
         self.log_stream = stream_name
 
         if self.enabled and self.NON_CRITICAL_LOGGING_ENABLED:
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers(logs_source)
             self.handler = ForkSafeFluentHandler(
                 'customer.logs',
                 host='localhost',
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
                 # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
                 nanosecond_precision=True,
             )
@@ -202,6 +248,10 @@ class BaseLogHandler(logging.Handler):
     def close(self):
         """Close the log handler (by closing the underlying log handler)."""
         if self.handler is not None:
+            # Flush any remaining emitted count before closing.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.close()
             self.handler = None
 
@@ -245,6 +295,14 @@ class BaseLogHandler(logging.Handler):
                 try:
                     self.handler.emit(record)  # type: ignore
                     self.sniff_errors(record)
+                    # Batch the emitted metric to avoid flooding StatsD with per-record packets.
+                    # Flush on count threshold OR time interval, whichever comes first.
+                    self._emitted_count += 1
+                    if self._emitted_count >= _EMITTED_BATCH_SIZE or \
+                            (time.time() - self._last_emitted_flush) >= _EMITTED_FLUSH_INTERVAL_SECONDS:
+                        self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                        self._emitted_count = 0
+                        self._last_emitted_flush = time.time()
                 except Exception:
                     self.stats.incr(f"mwaa.logging.{self.logs_source}.emit_error", 1)
                     self._report_logging_error("Failed to emit log record.")
@@ -273,6 +331,10 @@ class BaseLogHandler(logging.Handler):
         if not self.handler:
             return
         try:
+            # Flush any remaining emitted count.
+            if self._emitted_count > 0:
+                self.stats.incr(f"mwaa.logging.{self.logs_source}.ncl_emitted_records", self._emitted_count)
+                self._emitted_count = 0
             self.handler.flush()
         except Exception:
             self.stats.incr(f"mwaa.logging.{self.logs_source}.flush_error", 1)
@@ -284,7 +346,7 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
         which uses Structlog. The main logic resides in 'processors' property which is loaded by Structlog logger in
         task-sdk/src/airflow/sdk/log.py#L143
     """
-    LOG_SOURCE = "task"
+    LOG_SOURCE = "Task"
     # In Airflow currently there are some logs that "seeps" out of the traditional task log stream. Ideally we should
     # use log_filename_template config to generate a pattern for filtering only task log streams. But that config
     # value is not a regex pattern but instead a Jinja template. As a workaround for now we use a deny list instead.

--- a/tests/images/airflow/2.10.1/python/mwaa/logging/test_cloudwatch_handler_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/logging/test_cloudwatch_handler_2_10_1.py
@@ -1,8 +1,9 @@
 import logging
+import time
 import pytest
 import os
 import importlib
-from unittest.mock import patch, Mock, MagicMock, ANY
+from unittest.mock import patch, Mock, MagicMock, ANY, call
 from airflow.models.taskinstance import TaskInstance
 from mwaa.config.setup_environment import (
     setup_environment_variables,
@@ -190,6 +191,8 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=ANY,
+                buffer_overflow_handler=ANY,
                 nanosecond_precision=True,
             )
 
@@ -217,6 +220,8 @@ def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -243,6 +248,8 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -267,6 +274,8 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -293,5 +302,164 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
+
+# --- Tests for NCL observability metrics ---
+
+def test_queue_overflow_handler_emits_metric(mock_boto3_client):
+    """Verify that queue_overflow_handler fires the queue_evicted StatsD metric."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            queue_handler, _ = _make_overflow_handlers("scheduler")
+            queue_handler(b'\x00' * 128)
+
+            mock_stats.incr.assert_called_once_with("mwaa.logging.scheduler.ncl_queue_evicted_records", 1)
+
+
+def test_buffer_overflow_handler_emits_metrics(mock_boto3_client):
+    """Verify that buffer_overflow_handler fires both buffer_overflow and buffer_overflow_bytes metrics."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            _, buffer_handler = _make_overflow_handlers("worker")
+            fake_pendings = b'\x00' * 2048
+            buffer_handler(fake_pendings)
+
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow", 1)
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow_bytes", 2048)
+
+
+def test_emitted_counter_batches_at_threshold(mock_boto3_client, mock_fluent):
+    """Verify that the emitted metric is batched: fires every _EMITTED_BATCH_SIZE records."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_BATCH_SIZE
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit _EMITTED_BATCH_SIZE - 1 records: no emitted metric yet
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(_EMITTED_BATCH_SIZE - 1):
+            handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0, "Should not have flushed emitted yet"
+
+        # One more emit crosses the threshold
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call(f"mwaa.logging.scheduler.ncl_emitted_records", _EMITTED_BATCH_SIZE)
+
+
+def test_emitted_counter_flushes_remainder_on_close(mock_boto3_client, mock_fluent):
+    """Verify that close() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'worker')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # Close should flush the remainder
+        handler.close()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.worker.ncl_emitted_records", 5)
+
+
+def test_emitted_counter_flushes_remainder_on_flush(mock_boto3_client, mock_fluent):
+    """Verify that flush() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 3 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(3):
+            handler.emit(record)
+
+        handler.flush()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 3)
+
+
+def test_emitted_counter_flushes_on_time_interval(mock_boto3_client, mock_fluent):
+    """Verify that the emitted counter flushes after _EMITTED_FLUSH_INTERVAL_SECONDS even below batch threshold."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_FLUSH_INTERVAL_SECONDS
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (well below batch threshold of 100)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # No flush yet — below threshold and within time window
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0
+
+        # Simulate time passing beyond the flush interval
+        handler._last_emitted_flush = time.time() - _EMITTED_FLUSH_INTERVAL_SECONDS - 1
+
+        # Next emit should trigger a time-based flush
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        # 5 from before + 1 that triggered the flush = 6
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 6)

--- a/tests/images/airflow/2.10.3/python/mwaa/logging/test_cloudwatch_handler_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/logging/test_cloudwatch_handler_2_10_3.py
@@ -1,8 +1,9 @@
 import logging
 import pytest
 import os
+import time
 import importlib
-from unittest.mock import patch, Mock, MagicMock, ANY
+from unittest.mock import patch, Mock, MagicMock, ANY, call
 from airflow.models.taskinstance import TaskInstance
 from mwaa.config.setup_environment import (
     setup_environment_variables,
@@ -196,6 +197,8 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=ANY,
+                buffer_overflow_handler=ANY,
                 nanosecond_precision=True,
             )
 
@@ -223,6 +226,8 @@ def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -249,6 +254,8 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -273,6 +280,8 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -299,5 +308,165 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
+
+
+# --- Tests for NCL observability metrics ---
+
+def test_queue_overflow_handler_emits_metric(mock_boto3_client):
+    """Verify that queue_overflow_handler fires the queue_evicted StatsD metric."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            queue_handler, _ = _make_overflow_handlers("scheduler")
+            queue_handler(b'\x00' * 128)
+
+            mock_stats.incr.assert_called_once_with("mwaa.logging.scheduler.ncl_queue_evicted_records", 1)
+
+
+def test_buffer_overflow_handler_emits_metrics(mock_boto3_client):
+    """Verify that buffer_overflow_handler fires both buffer_overflow and buffer_overflow_bytes metrics."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            _, buffer_handler = _make_overflow_handlers("worker")
+            fake_pendings = b'\x00' * 2048
+            buffer_handler(fake_pendings)
+
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow", 1)
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow_bytes", 2048)
+
+
+def test_emitted_counter_batches_at_threshold(mock_boto3_client, mock_fluent):
+    """Verify that the emitted metric is batched: fires every _EMITTED_BATCH_SIZE records."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_BATCH_SIZE
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit _EMITTED_BATCH_SIZE - 1 records: no emitted metric yet
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(_EMITTED_BATCH_SIZE - 1):
+            handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0, "Should not have flushed emitted yet"
+
+        # One more emit crosses the threshold
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call(f"mwaa.logging.scheduler.ncl_emitted_records", _EMITTED_BATCH_SIZE)
+
+
+def test_emitted_counter_flushes_remainder_on_close(mock_boto3_client, mock_fluent):
+    """Verify that close() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'worker')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # Close should flush the remainder
+        handler.close()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.worker.ncl_emitted_records", 5)
+
+
+def test_emitted_counter_flushes_remainder_on_flush(mock_boto3_client, mock_fluent):
+    """Verify that flush() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 3 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(3):
+            handler.emit(record)
+
+        handler.flush()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 3)
+
+
+def test_emitted_counter_flushes_on_time_interval(mock_boto3_client, mock_fluent):
+    """Verify that the emitted counter flushes after _EMITTED_FLUSH_INTERVAL_SECONDS even below batch threshold."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_FLUSH_INTERVAL_SECONDS
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (well below batch threshold of 100)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # No flush yet — below threshold and within time window
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0
+
+        # Simulate time passing beyond the flush interval
+        handler._last_emitted_flush = time.time() - _EMITTED_FLUSH_INTERVAL_SECONDS - 1
+
+        # Next emit should trigger a time-based flush
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        # 5 from before + 1 that triggered the flush = 6
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 6)

--- a/tests/images/airflow/2.11.0/python/mwaa/logging/test_cloudwatch_handler_2_11_0.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/logging/test_cloudwatch_handler_2_11_0.py
@@ -1,9 +1,10 @@
 import logging
+import time
 import pytest
 import os
 import importlib
 import types
-from unittest.mock import patch, Mock, MagicMock, ANY
+from unittest.mock import patch, Mock, MagicMock, ANY, call
 from airflow.models.taskinstance import TaskInstance
 from mwaa.config.setup_environment import (
     setup_environment_variables,
@@ -197,6 +198,8 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=ANY,
+                buffer_overflow_handler=ANY,
                 nanosecond_precision=True,
             )
 
@@ -224,6 +227,8 @@ def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -250,6 +255,8 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -274,6 +281,8 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -300,6 +309,8 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -325,3 +336,160 @@ def test_task_log_handler_io_override_exception_is_caught(mocker):
 
     # Assert warning logged
     mock_warning.return_value.warning.assert_called_once()
+
+# --- Tests for NCL observability metrics ---
+
+def test_queue_overflow_handler_emits_metric(mock_boto3_client):
+    """Verify that queue_overflow_handler fires the queue_evicted StatsD metric."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            queue_handler, _ = _make_overflow_handlers("scheduler")
+            queue_handler(b'\x00' * 128)
+
+            mock_stats.incr.assert_called_once_with("mwaa.logging.scheduler.ncl_queue_evicted_records", 1)
+
+
+def test_buffer_overflow_handler_emits_metrics(mock_boto3_client):
+    """Verify that buffer_overflow_handler fires both buffer_overflow and buffer_overflow_bytes metrics."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            _, buffer_handler = _make_overflow_handlers("worker")
+            fake_pendings = b'\x00' * 2048
+            buffer_handler(fake_pendings)
+
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow", 1)
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow_bytes", 2048)
+
+
+def test_emitted_counter_batches_at_threshold(mock_boto3_client, mock_fluent):
+    """Verify that the emitted metric is batched: fires every _EMITTED_BATCH_SIZE records."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_BATCH_SIZE
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit _EMITTED_BATCH_SIZE - 1 records: no emitted metric yet
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(_EMITTED_BATCH_SIZE - 1):
+            handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0, "Should not have flushed emitted yet"
+
+        # One more emit crosses the threshold
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call(f"mwaa.logging.scheduler.ncl_emitted_records", _EMITTED_BATCH_SIZE)
+
+
+def test_emitted_counter_flushes_remainder_on_close(mock_boto3_client, mock_fluent):
+    """Verify that close() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'worker')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # Close should flush the remainder
+        handler.close()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.worker.ncl_emitted_records", 5)
+
+
+def test_emitted_counter_flushes_remainder_on_flush(mock_boto3_client, mock_fluent):
+    """Verify that flush() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 3 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(3):
+            handler.emit(record)
+
+        handler.flush()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 3)
+
+
+def test_emitted_counter_flushes_on_time_interval(mock_boto3_client, mock_fluent):
+    """Verify that the emitted counter flushes after _EMITTED_FLUSH_INTERVAL_SECONDS even below batch threshold."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_FLUSH_INTERVAL_SECONDS
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (well below batch threshold of 100)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # No flush yet — below threshold and within time window
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0
+
+        # Simulate time passing beyond the flush interval
+        handler._last_emitted_flush = time.time() - _EMITTED_FLUSH_INTERVAL_SECONDS - 1
+
+        # Next emit should trigger a time-based flush
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        # 5 from before + 1 that triggered the flush = 6
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 6)

--- a/tests/images/airflow/2.11.2/python/mwaa/logging/test_cloudwatch_handler_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/logging/test_cloudwatch_handler_2_11_2.py
@@ -1,9 +1,10 @@
 import logging
+import time
 import pytest
 import os
 import importlib
 import types
-from unittest.mock import patch, Mock, MagicMock, ANY
+from unittest.mock import patch, Mock, MagicMock, ANY, call
 from airflow.models.taskinstance import TaskInstance
 from mwaa.config.setup_environment import (
     setup_environment_variables,
@@ -197,6 +198,8 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=ANY,
+                buffer_overflow_handler=ANY,
                 nanosecond_precision=True,
             )
 
@@ -224,6 +227,8 @@ def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -250,6 +255,8 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -274,6 +281,8 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -300,6 +309,8 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -325,3 +336,160 @@ def test_task_log_handler_io_override_exception_is_caught(mocker):
 
     # Assert warning logged
     mock_warning.return_value.warning.assert_called_once()
+
+# --- Tests for NCL observability metrics ---
+
+def test_queue_overflow_handler_emits_metric(mock_boto3_client):
+    """Verify that queue_overflow_handler fires the queue_evicted StatsD metric."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            queue_handler, _ = _make_overflow_handlers("scheduler")
+            queue_handler(b'\x00' * 128)
+
+            mock_stats.incr.assert_called_once_with("mwaa.logging.scheduler.ncl_queue_evicted_records", 1)
+
+
+def test_buffer_overflow_handler_emits_metrics(mock_boto3_client):
+    """Verify that buffer_overflow_handler fires both buffer_overflow and buffer_overflow_bytes metrics."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            _, buffer_handler = _make_overflow_handlers("worker")
+            fake_pendings = b'\x00' * 2048
+            buffer_handler(fake_pendings)
+
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow", 1)
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow_bytes", 2048)
+
+
+def test_emitted_counter_batches_at_threshold(mock_boto3_client, mock_fluent):
+    """Verify that the emitted metric is batched: fires every _EMITTED_BATCH_SIZE records."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_BATCH_SIZE
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit _EMITTED_BATCH_SIZE - 1 records: no emitted metric yet
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(_EMITTED_BATCH_SIZE - 1):
+            handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0, "Should not have flushed emitted yet"
+
+        # One more emit crosses the threshold
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call(f"mwaa.logging.scheduler.ncl_emitted_records", _EMITTED_BATCH_SIZE)
+
+
+def test_emitted_counter_flushes_remainder_on_close(mock_boto3_client, mock_fluent):
+    """Verify that close() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'worker')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # Close should flush the remainder
+        handler.close()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.worker.ncl_emitted_records", 5)
+
+
+def test_emitted_counter_flushes_remainder_on_flush(mock_boto3_client, mock_fluent):
+    """Verify that flush() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 3 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(3):
+            handler.emit(record)
+
+        handler.flush()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 3)
+
+
+def test_emitted_counter_flushes_on_time_interval(mock_boto3_client, mock_fluent):
+    """Verify that the emitted counter flushes after _EMITTED_FLUSH_INTERVAL_SECONDS even below batch threshold."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_FLUSH_INTERVAL_SECONDS
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (well below batch threshold of 100)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # No flush yet — below threshold and within time window
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0
+
+        # Simulate time passing beyond the flush interval
+        handler._last_emitted_flush = time.time() - _EMITTED_FLUSH_INTERVAL_SECONDS - 1
+
+        # Next emit should trigger a time-based flush
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        # 5 from before + 1 that triggered the flush = 6
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 6)

--- a/tests/images/airflow/2.9.2/python/mwaa/logging/test_cloudwatch_handler_2_9_2.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/logging/test_cloudwatch_handler_2_9_2.py
@@ -1,8 +1,9 @@
 import logging
+import time
 import pytest
 import os
 import importlib
-from unittest.mock import patch, Mock, MagicMock, ANY
+from unittest.mock import patch, Mock, MagicMock, ANY, call
 from airflow.models.taskinstance import TaskInstance
 from mwaa.config.setup_environment import (
     setup_environment_variables,
@@ -191,6 +192,8 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=ANY,
+                buffer_overflow_handler=ANY,
                 nanosecond_precision=True,
             )
 
@@ -218,6 +221,8 @@ def test_task_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -244,6 +249,8 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -268,6 +275,8 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -294,5 +303,164 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
+
+# --- Tests for NCL observability metrics ---
+
+def test_queue_overflow_handler_emits_metric(mock_boto3_client):
+    """Verify that queue_overflow_handler fires the queue_evicted StatsD metric."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            queue_handler, _ = _make_overflow_handlers("scheduler")
+            queue_handler(b'\x00' * 128)
+
+            mock_stats.incr.assert_called_once_with("mwaa.logging.scheduler.ncl_queue_evicted_records", 1)
+
+
+def test_buffer_overflow_handler_emits_metrics(mock_boto3_client):
+    """Verify that buffer_overflow_handler fires both buffer_overflow and buffer_overflow_bytes metrics."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            _, buffer_handler = _make_overflow_handlers("worker")
+            fake_pendings = b'\x00' * 2048
+            buffer_handler(fake_pendings)
+
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow", 1)
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow_bytes", 2048)
+
+
+def test_emitted_counter_batches_at_threshold(mock_boto3_client, mock_fluent):
+    """Verify that the emitted metric is batched: fires every _EMITTED_BATCH_SIZE records."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_BATCH_SIZE
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit _EMITTED_BATCH_SIZE - 1 records: no emitted metric yet
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(_EMITTED_BATCH_SIZE - 1):
+            handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0, "Should not have flushed emitted yet"
+
+        # One more emit crosses the threshold
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call(f"mwaa.logging.scheduler.ncl_emitted_records", _EMITTED_BATCH_SIZE)
+
+
+def test_emitted_counter_flushes_remainder_on_close(mock_boto3_client, mock_fluent):
+    """Verify that close() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'worker')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # Close should flush the remainder
+        handler.close()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.worker.ncl_emitted_records", 5)
+
+
+def test_emitted_counter_flushes_remainder_on_flush(mock_boto3_client, mock_fluent):
+    """Verify that flush() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 3 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(3):
+            handler.emit(record)
+
+        handler.flush()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 3)
+
+
+def test_emitted_counter_flushes_on_time_interval(mock_boto3_client, mock_fluent):
+    """Verify that the emitted counter flushes after _EMITTED_FLUSH_INTERVAL_SECONDS even below batch threshold."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_FLUSH_INTERVAL_SECONDS
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (well below batch threshold of 100)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # No flush yet — below threshold and within time window
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0
+
+        # Simulate time passing beyond the flush interval
+        handler._last_emitted_flush = time.time() - _EMITTED_FLUSH_INTERVAL_SECONDS - 1
+
+        # Next emit should trigger a time-based flush
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        # 5 from before + 1 that triggered the flush = 6
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 6)

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -1,11 +1,12 @@
 import json
 import logging
+import time
 import pytest
 import os
 import importlib
 import types
 from datetime import datetime, timezone, timedelta
-from unittest.mock import patch, Mock, MagicMock, ANY
+from unittest.mock import patch, Mock, MagicMock, ANY, call
 
 from mwaa.config.setup_environment import (
     setup_environment_variables,
@@ -193,6 +194,8 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=ANY,
+                buffer_overflow_handler=ANY,
                 nanosecond_precision=True,
             )
 
@@ -421,6 +424,8 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -445,6 +450,8 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -471,6 +478,8 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -501,6 +510,8 @@ def test_cloudwatch_remote_task_logger_uses_fluent_when_non_critical(mock_boto3_
             port=24224,
             queue_maxsize=50000,
             queue_circular=True,
+            queue_overflow_handler=ANY,
+            buffer_overflow_handler=ANY,
             nanosecond_precision=True,
         )
         assert not mock_watchtower.called, (
@@ -1116,7 +1127,7 @@ class TestSplitOversizeEvent:
         msg = {"event": "test", "level": "info"}
         with patch.object(logger, '_split_oversize_event_inner', side_effect=RuntimeError("fail")):
             logger._split_oversize_event(msg)
-            logger.stats.incr.assert_called_once_with("mwaa.logging.task.split_error", 1)
+            logger.stats.incr.assert_called_once_with("mwaa.logging.Task.split_error", 1)
 
     # --- Watchtower compatibility ---
 
@@ -1163,3 +1174,160 @@ class TestSplitOversizeEvent:
         # Verify no data loss: concatenated events must equal original
         reassembled = "".join(chunk["event"] for chunk in result)
         assert reassembled == event, "Data loss detected: reassembled chunks don't match original event"
+
+# --- Tests for NCL observability metrics ---
+
+def test_queue_overflow_handler_emits_metric(mock_boto3_client):
+    """Verify that queue_overflow_handler fires the queue_evicted StatsD metric."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            queue_handler, _ = _make_overflow_handlers("scheduler")
+            queue_handler(b'\x00' * 128)
+
+            mock_stats.incr.assert_called_once_with("mwaa.logging.scheduler.ncl_queue_evicted_records", 1)
+
+
+def test_buffer_overflow_handler_emits_metrics(mock_boto3_client):
+    """Verify that buffer_overflow_handler fires both buffer_overflow and buffer_overflow_bytes metrics."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            _, buffer_handler = _make_overflow_handlers("worker")
+            fake_pendings = b'\x00' * 2048
+            buffer_handler(fake_pendings)
+
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow", 1)
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow_bytes", 2048)
+
+
+def test_emitted_counter_batches_at_threshold(mock_boto3_client, mock_fluent):
+    """Verify that the emitted metric is batched: fires every _EMITTED_BATCH_SIZE records."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_BATCH_SIZE
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit _EMITTED_BATCH_SIZE - 1 records: no emitted metric yet
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(_EMITTED_BATCH_SIZE - 1):
+            handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0, "Should not have flushed emitted yet"
+
+        # One more emit crosses the threshold
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call(f"mwaa.logging.scheduler.ncl_emitted_records", _EMITTED_BATCH_SIZE)
+
+
+def test_emitted_counter_flushes_remainder_on_close(mock_boto3_client, mock_fluent):
+    """Verify that close() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'worker')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # Close should flush the remainder
+        handler.close()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.worker.ncl_emitted_records", 5)
+
+
+def test_emitted_counter_flushes_remainder_on_flush(mock_boto3_client, mock_fluent):
+    """Verify that flush() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 3 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(3):
+            handler.emit(record)
+
+        handler.flush()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 3)
+
+
+def test_emitted_counter_flushes_on_time_interval(mock_boto3_client, mock_fluent):
+    """Verify that the emitted counter flushes after _EMITTED_FLUSH_INTERVAL_SECONDS even below batch threshold."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_FLUSH_INTERVAL_SECONDS
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (well below batch threshold of 100)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # No flush yet — below threshold and within time window
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0
+
+        # Simulate time passing beyond the flush interval
+        handler._last_emitted_flush = time.time() - _EMITTED_FLUSH_INTERVAL_SECONDS - 1
+
+        # Next emit should trigger a time-based flush
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        # 5 from before + 1 that triggered the flush = 6
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 6)

--- a/tests/images/airflow/3.2.1/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/logging/test_cloudwatch_handler.py
@@ -1,10 +1,11 @@
 import logging
+import time
 import pytest
 import os
 import importlib
 import types
 from datetime import datetime, timezone, timedelta
-from unittest.mock import patch, Mock, MagicMock, ANY
+from unittest.mock import patch, Mock, MagicMock, ANY, call
 
 from mwaa.config.setup_environment import (
     setup_environment_variables,
@@ -190,6 +191,8 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=ANY,
+                buffer_overflow_handler=ANY,
                 nanosecond_precision=True,
             )
 
@@ -499,6 +502,8 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -522,6 +527,8 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -547,6 +554,8 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -576,6 +585,8 @@ def test_cloudwatch_remote_task_logger_uses_fluent_when_non_critical(mock_boto3_
             port=24224,
             queue_maxsize=50000,
             queue_circular=True,
+            queue_overflow_handler=ANY,
+            buffer_overflow_handler=ANY,
             nanosecond_precision=True,
         )
         assert not mock_watchtower.called, (
@@ -960,3 +971,160 @@ def test_discover_triggerer_streams_follows_pagination(mock_boto3_client):
         assert stream_page2 in streams
         assert len(streams) == 2
         assert logger.hook.conn.describe_log_streams.call_count == 2
+
+# --- Tests for NCL observability metrics ---
+
+def test_queue_overflow_handler_emits_metric(mock_boto3_client):
+    """Verify that queue_overflow_handler fires the queue_evicted StatsD metric."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            queue_handler, _ = _make_overflow_handlers("scheduler")
+            queue_handler(b'\x00' * 128)
+
+            mock_stats.incr.assert_called_once_with("mwaa.logging.scheduler.ncl_queue_evicted_records", 1)
+
+
+def test_buffer_overflow_handler_emits_metrics(mock_boto3_client):
+    """Verify that buffer_overflow_handler fires both buffer_overflow and buffer_overflow_bytes metrics."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            _, buffer_handler = _make_overflow_handlers("worker")
+            fake_pendings = b'\x00' * 2048
+            buffer_handler(fake_pendings)
+
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow", 1)
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow_bytes", 2048)
+
+
+def test_emitted_counter_batches_at_threshold(mock_boto3_client, mock_fluent):
+    """Verify that the emitted metric is batched: fires every _EMITTED_BATCH_SIZE records."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_BATCH_SIZE
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit _EMITTED_BATCH_SIZE - 1 records: no emitted metric yet
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(_EMITTED_BATCH_SIZE - 1):
+            handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0, "Should not have flushed emitted yet"
+
+        # One more emit crosses the threshold
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call(f"mwaa.logging.scheduler.ncl_emitted_records", _EMITTED_BATCH_SIZE)
+
+
+def test_emitted_counter_flushes_remainder_on_close(mock_boto3_client, mock_fluent):
+    """Verify that close() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'worker')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # Close should flush the remainder
+        handler.close()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.worker.ncl_emitted_records", 5)
+
+
+def test_emitted_counter_flushes_remainder_on_flush(mock_boto3_client, mock_fluent):
+    """Verify that flush() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 3 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(3):
+            handler.emit(record)
+
+        handler.flush()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 3)
+
+
+def test_emitted_counter_flushes_on_time_interval(mock_boto3_client, mock_fluent):
+    """Verify that the emitted counter flushes after _EMITTED_FLUSH_INTERVAL_SECONDS even below batch threshold."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_FLUSH_INTERVAL_SECONDS
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (well below batch threshold of 100)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # No flush yet — below threshold and within time window
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0
+
+        # Simulate time passing beyond the flush interval
+        handler._last_emitted_flush = time.time() - _EMITTED_FLUSH_INTERVAL_SECONDS - 1
+
+        # Next emit should trigger a time-based flush
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        # 5 from before + 1 that triggered the flush = 6
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 6)

--- a/tests/images/airflow/3.3.0/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/logging/test_cloudwatch_handler.py
@@ -1,10 +1,11 @@
 import logging
+import time
 import pytest
 import os
 import importlib
 import types
 from datetime import datetime, timezone, timedelta
-from unittest.mock import patch, Mock, MagicMock, ANY
+from unittest.mock import patch, Mock, MagicMock, ANY, call
 
 from mwaa.config.setup_environment import (
     setup_environment_variables,
@@ -190,6 +191,8 @@ def test_log_handler_creation(mock_boto3_client, mock_watchtower, mock_fluent, u
                 port=24224,
                 queue_maxsize=50000,
                 queue_circular=True,
+                queue_overflow_handler=ANY,
+                buffer_overflow_handler=ANY,
                 nanosecond_precision=True,
             )
 
@@ -499,6 +502,8 @@ def test_subprocess_log_handler_with_fluent(mock_boto3_client, mock_fluent):
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -522,6 +527,8 @@ def test_dag_processor_manager_log_handler(mock_boto3_client, mock_fluent, mock_
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -547,6 +554,8 @@ def test_dag_processing_log_handler(mock_boto3_client, mock_fluent, mock_watchto
             'port': 24224,
             'queue_maxsize': 50000,
             'queue_circular': True,
+            'queue_overflow_handler': ANY,
+            'buffer_overflow_handler': ANY,
             'nanosecond_precision': True,
         }
 
@@ -927,3 +936,160 @@ def test_discover_triggerer_streams_follows_pagination(mock_boto3_client):
         assert stream_page2 in streams
         assert len(streams) == 2
         assert logger.hook.conn.describe_log_streams.call_count == 2
+
+# --- Tests for NCL observability metrics ---
+
+def test_queue_overflow_handler_emits_metric(mock_boto3_client):
+    """Verify that queue_overflow_handler fires the queue_evicted StatsD metric."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            queue_handler, _ = _make_overflow_handlers("scheduler")
+            queue_handler(b'\x00' * 128)
+
+            mock_stats.incr.assert_called_once_with("mwaa.logging.scheduler.ncl_queue_evicted_records", 1)
+
+
+def test_buffer_overflow_handler_emits_metrics(mock_boto3_client):
+    """Verify that buffer_overflow_handler fires both buffer_overflow and buffer_overflow_bytes metrics."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import _make_overflow_handlers
+
+        with patch('mwaa.logging.cloudwatch_handlers.get_statsd') as mock_get_statsd:
+            mock_stats = MagicMock()
+            mock_get_statsd.return_value = mock_stats
+
+            _, buffer_handler = _make_overflow_handlers("worker")
+            fake_pendings = b'\x00' * 2048
+            buffer_handler(fake_pendings)
+
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow", 1)
+            mock_stats.incr.assert_any_call("mwaa.logging.worker.ncl_buffer_overflow_bytes", 2048)
+
+
+def test_emitted_counter_batches_at_threshold(mock_boto3_client, mock_fluent):
+    """Verify that the emitted metric is batched: fires every _EMITTED_BATCH_SIZE records."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_BATCH_SIZE
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit _EMITTED_BATCH_SIZE - 1 records: no emitted metric yet
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(_EMITTED_BATCH_SIZE - 1):
+            handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0, "Should not have flushed emitted yet"
+
+        # One more emit crosses the threshold
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call(f"mwaa.logging.scheduler.ncl_emitted_records", _EMITTED_BATCH_SIZE)
+
+
+def test_emitted_counter_flushes_remainder_on_close(mock_boto3_client, mock_fluent):
+    """Verify that close() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'worker')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # Close should flush the remainder
+        handler.close()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.worker.ncl_emitted_records", 5)
+
+
+def test_emitted_counter_flushes_remainder_on_flush(mock_boto3_client, mock_fluent):
+    """Verify that flush() flushes any remaining emitted count."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 3 records (below threshold)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(3):
+            handler.emit(record)
+
+        handler.flush()
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 3)
+
+
+def test_emitted_counter_flushes_on_time_interval(mock_boto3_client, mock_fluent):
+    """Verify that the emitted counter flushes after _EMITTED_FLUSH_INTERVAL_SECONDS even below batch threshold."""
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+        from mwaa.logging.cloudwatch_handlers import BaseLogHandler, _EMITTED_FLUSH_INTERVAL_SECONDS
+
+        handler = BaseLogHandler('arn:aws:logs:us-west-2:123456789012:log-group:test', None, True)
+        handler.create_cloudwatch_handler('test_stream', 'scheduler')
+
+        mock_stats = MagicMock()
+        handler.stats = mock_stats
+
+        # Emit 5 records (well below batch threshold of 100)
+        record = logging.LogRecord('test', logging.INFO, '', 0, 'msg', (), None)
+        for _ in range(5):
+            handler.emit(record)
+
+        # No flush yet — below threshold and within time window
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 0
+
+        # Simulate time passing beyond the flush interval
+        handler._last_emitted_flush = time.time() - _EMITTED_FLUSH_INTERVAL_SECONDS - 1
+
+        # Next emit should trigger a time-based flush
+        handler.emit(record)
+
+        emitted_calls = [c for c in mock_stats.incr.call_args_list if 'emitted' in str(c)]
+        assert len(emitted_calls) == 1
+        # 5 from before + 1 that triggered the flush = 6
+        assert emitted_calls[0] == call("mwaa.logging.scheduler.ncl_emitted_records", 6)


### PR DESCRIPTION
## NCL Pipeline Observability — Python-Side Metrics

  ### Summary

  Adds 4 new StatsD metrics to `cloudwatch_handlers.py` across all 8 Airflow versions, providing visibility into log record throughput and loss between Python and Fluent Bit in the Non-Critical Logging pipeline.

  ### New Metrics

  | StatsD Name | CloudWatch Name (after sidecar transform) | What it detects |
  |-------------|-------------------------------------------|-----------------|
  | `mwaa.logging.{source}.ncl_emitted_records` | `NCLEmittedRecords` | Records successfully handed to Fluent Bit (throughput baseline) |
  | `mwaa.logging.{source}.ncl_queue_evicted_records` | `NCLQueueEvictedRecords` | Records evicted from the 50k circular queue (Python→FB backpressure) |
  | `mwaa.logging.{source}.ncl_buffer_overflow` | `NCLBufferOverflow` | Buffer discard events when Fluent Bit TCP endpoint is unreachable |
  | `mwaa.logging.{source}.ncl_buffer_overflow_bytes` | `NCLBufferOverflowBytes` | Bytes lost in buffer discards |

  Where `{source}` is `Scheduler`, `Worker`, `WebServer`, `Task`, `DAGProcessing`, or `DAGProcessorManager`.

  ### Implementation

  - **`_make_overflow_handlers(logs_source)`** factory wires `queue_overflow_handler` and `buffer_overflow_handler` callbacks into every `ForkSafeFluentHandler` construction (both subprocess and task handler paths)
  - **Batched emitted counter** flushes to StatsD every 100 records OR every 60 seconds (whichever comes first), avoiding per-record UDP overhead while providing regular data points for pattern observation
  - **Remainder flushing** in `close()` and `flush()` ensures low-volume sources don't lose their final count

  ### Bug Fix

  `TaskLogHandler.set_context()` (2.x) and `CloudWatchRemoteTaskLogger.processors` (3.x) never set `self.logs_source`, leaving it as `"Unknown"` from `BaseLogHandler.__init__`. This caused existing metrics
  (`emit_error`, `flush_error`, `ErrorLog_*`) to report with `AirflowComponent=Unknown` for all task logs. Fixed by setting `self.logs_source = "Task"` in both paths.

  ### Versions Updated

  2.9.2, 2.10.1, 2.10.3, 2.11.0, 2.11.2, 3.0.6, 3.2.1

  ### Testing

  - Unit tests updated and passing for all versions (new assertions for overflow handler kwargs + 6 new test cases in 2.10.3 covering overflow handlers, batched emitted counter, time-based flush)
  - Verified end-to-end on a live NCL-enabled environment: `NCLEmittedRecords` appeared in CloudWatch with correct values after deploying the image alongside the sidecar metric transform change
  - Verified `NCLQueueEvictedRecords` by deploying a test image with `queue_maxsize=10` and running a DAG that produces >10 log lines — confirmed evictions appeared in CloudWatch
  -  Verified `NCLBufferOverflow` and `NCLBufferOverflowBytes` by deploying a test image with Fluent Bit port changed to an unreachable port (24225) and running a stress DAG producing >1MB of logs — confirmed both
  metrics appeared in CloudWatch once the 1MB `bufmax` threshold was exceeded


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
