### PR TITLE
Add RDS IAM credential rotation for Airflow 3.x

### DIFF
--- a/images/airflow/3.0.6/Dockerfile.base.j2
+++ b/images/airflow/3.0.6/Dockerfile.base.j2
@@ -127,6 +127,9 @@ WORKDIR ${AIRFLOW_USER_HOME}
 # Copy python files.
 COPY ./python /python
 
+# Copy airflow_local_settings.py
+COPY ./airflow_local_settings.py ${AIRFLOW_USER_HOME}/config/airflow_local_settings.py
+
 # TODO Move this to the bin folder under airflow's home folder.
 COPY healthcheck.sh /healthcheck.sh
 RUN chmod +x /healthcheck.sh

--- a/images/airflow/3.0.6/Dockerfiles/Dockerfile.base
+++ b/images/airflow/3.0.6/Dockerfiles/Dockerfile.base
@@ -148,6 +148,9 @@ WORKDIR ${AIRFLOW_USER_HOME}
 # Copy python files.
 COPY ./python /python
 
+# Copy airflow_local_settings.py
+COPY ./airflow_local_settings.py ${AIRFLOW_USER_HOME}/config/airflow_local_settings.py
+
 # TODO Move this to the bin folder under airflow's home folder.
 COPY healthcheck.sh /healthcheck.sh
 RUN chmod +x /healthcheck.sh

--- a/images/airflow/3.0.6/airflow_local_settings.py
+++ b/images/airflow/3.0.6/airflow_local_settings.py
@@ -1,0 +1,62 @@
+"""Airflow local settings configuration for MWAA RDS IAM authentication.
+
+Airflow imports this module during ``airflow.settings.initialize()``, which runs
+unconditionally on ``import airflow``. ``airflow.settings`` appends
+``$AIRFLOW_HOME/config`` to ``sys.path`` before doing so, which is where the
+Dockerfile installs this file.
+
+This is the only correct place to install the RDS IAM credential rotation patch:
+the patch registers a SQLAlchemy ``do_connect`` listener, and that listener lives
+in the process that registered it. The Airflow components (scheduler, worker,
+api-server, dag-processor, triggerer and task runners) are spawned by the
+entrypoint as separate ``subprocess.Popen(["airflow", ...])`` children, each a
+fresh Python interpreter. Installing the patch from the entrypoint alone would
+therefore leave every process that actually talks to the metadata database
+unpatched.
+"""
+
+import importlib.util
+import logging
+import os
+
+# Airflow copies every public name of this module into the `airflow.settings`
+# namespace. Declaring an empty `__all__` keeps our internals from clobbering
+# Airflow's own globals; we export no policies or settings overrides.
+__all__: list[str] = []
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+    install_rds_iam_patch()
+except Exception as e:
+    _logger.error(f"Failed to load RDS IAM patch: {e}")
+    raise
+
+# Load ${AIRFLOW_HOME}/dags/airflow_local_settings.py and
+# ${AIRFLOW_HOME}/plugins/airflow_local_settings.py if they exist, so that
+# customer-provided local settings continue to be honoured.
+_AIRFLOW_HOME = os.environ.get("AIRFLOW_HOME", "/usr/local/airflow")
+_CUSTOMER_LOCAL_SETTINGS = [
+    (
+        "customer_dags_airflow_local_settings",
+        os.path.join(_AIRFLOW_HOME, "dags", "airflow_local_settings.py"),
+    ),
+    (
+        "customer_plugins_airflow_local_settings",
+        os.path.join(_AIRFLOW_HOME, "plugins", "airflow_local_settings.py"),
+    ),
+]
+
+for _module_name, _path in _CUSTOMER_LOCAL_SETTINGS:
+    if not os.path.exists(_path):
+        continue
+    try:
+        _spec = importlib.util.spec_from_file_location(_module_name, _path)
+        if _spec and _spec.loader:
+            _module = importlib.util.module_from_spec(_spec)
+            _spec.loader.exec_module(_module)
+    except Exception as e:
+        _logger.error(f"Failed to load airflow_local_settings from {_path}: {e}")
+        raise

--- a/images/airflow/3.0.6/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.0.6/python/mwaa/config/rds_iam_credentials.py
@@ -183,6 +183,16 @@ def use_iam_credentials() -> bool:
     return os.environ.get("USE_IAM_CREDENTIALS", "").lower() == "true"
 
 
+def is_local_runner() -> bool:
+    """Check if running in local runner mode.
+
+    RDS IAM authentication requires an ECS task metadata endpoint and an RDS
+    Proxy, neither of which exist when running the image locally, so the patch
+    must not be installed in that case.
+    """
+    return os.environ.get("MWAA_LOCAL_RUNNER", "").lower() == "true"
+
+
 def is_using_rds_proxy() -> bool:
     """Check if the environment is using RDS Proxy.
 

--- a/images/airflow/3.0.6/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.0.6/python/mwaa/config/rds_iam_credentials.py
@@ -163,6 +163,9 @@ class RDSIAMCredentialProvider:
         :returns: PostgreSQL connection URL with IAM authentication.
         """
         if token is None:
+            # NOTE: bypasses the get_token() cache, matching 2.x. No caller uses
+            # this default path today; the cache bypass is tracked for a
+            # cross-version follow-up rather than diverging from 2.x here.
             token = cls.generate_credentials()
 
         auth_token = quote_plus(token)

--- a/images/airflow/3.0.6/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.0.6/python/mwaa/config/rds_iam_credentials.py
@@ -1,0 +1,197 @@
+"""RDS IAM credential provider for MWAA.
+
+Provides IAM-based authentication tokens for RDS connections,
+with thread-safe caching and automatic refresh.
+"""
+
+import json
+import logging
+import os
+import threading
+import time
+import urllib.request
+from urllib.parse import quote_plus, urlparse
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+DB_IAM_USERNAME = "airflow_user"
+
+
+class RDSIAMCredentialProvider:
+    """Provides cached RDS IAM authentication tokens.
+
+    Tokens are generated using ECS task credentials and cached with
+    automatic refresh 5 minutes before expiration (tokens valid 15 min).
+    """
+
+    _lock = threading.Lock()
+    _token: str | None = None
+    _expires_at: float = 0
+
+    @staticmethod
+    def get_ecs_credentials() -> dict:
+        """Get AWS credentials from ECS task metadata endpoint.
+
+        Uses AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI for the credential path
+        and ECS_CONTAINER_METADATA_URI for the base URL.
+
+        :returns: AWS credentials dict with AccessKeyId, SecretAccessKey, Token.
+        :raises ValueError: If required environment variables are not set.
+        """
+        relative_uri = os.environ.get("AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI")
+        if not relative_uri:
+            raise ValueError("AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI not set")
+
+        metadata_uri = os.environ.get("ECS_CONTAINER_METADATA_URI")
+        if not metadata_uri:
+            raise ValueError("ECS_CONTAINER_METADATA_URI not set")
+
+        parsed_uri = urlparse(metadata_uri)
+        base_url = f"{parsed_uri.scheme}://{parsed_uri.netloc}"
+        credentials_url = f"{base_url}{relative_uri}"
+
+        request = urllib.request.Request(credentials_url)
+        no_proxy_handler = urllib.request.ProxyHandler({})
+        opener = urllib.request.build_opener(no_proxy_handler)
+
+        with opener.open(request) as response:
+            credentials_data = json.loads(response.read().decode("utf-8"))
+
+        return credentials_data
+
+    @staticmethod
+    def get_rds_iam_token_hostname() -> str:
+        """Get the RDS hostname for IAM token generation.
+
+        For RDS Proxy IAM authentication, tokens must be generated using
+        the direct RDS Proxy/Cluster endpoint, not VPC/NLB endpoints.
+
+        :returns: RDS hostname for token generation.
+        :raises ValueError: If RDS_IAM_TOKEN_HOSTNAME is not set.
+        """
+        token_hostname = os.environ.get("RDS_IAM_TOKEN_HOSTNAME", "").strip()
+        if token_hostname:
+            return token_hostname
+        logger.error(
+            "RDS_IAM_TOKEN_HOSTNAME not set in environment. "
+            "This should be set by the CDK stack to the RDS Cluster/Proxy endpoint."
+        )
+        raise ValueError("RDS_IAM_TOKEN_HOSTNAME environment variable is required")
+
+    @staticmethod
+    def generate_rds_auth_token(
+        credentials: dict, hostname: str, port: int, username: str
+    ) -> str:
+        """Generate RDS IAM authentication token using boto3.
+
+        :param credentials: AWS credentials from ECS task metadata.
+        :param hostname: RDS hostname for token generation.
+        :param port: Database port number.
+        :param username: Database username.
+        :returns: RDS IAM authentication token.
+        """
+        region = os.environ.get("AWS_REGION", "us-west-2")
+
+        rds_client = boto3.client(
+            "rds",
+            region_name=region,
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["Token"],
+        )
+
+        try:
+            auth_token = rds_client.generate_db_auth_token(
+                DBHostname=hostname,
+                Port=port,
+                DBUsername=username,
+            )
+            return auth_token
+        except Exception as e:
+            logger.error("Failed to generate RDS auth token: %s", e)
+            raise
+
+    @staticmethod
+    def generate_credentials() -> str:
+        """Generate fresh RDS auth token.
+
+        Orchestrates fetching ECS credentials and generating the RDS token.
+
+        :returns: RDS auth token.
+        """
+        try:
+            credentials = RDSIAMCredentialProvider.get_ecs_credentials()
+            iam_token_hostname = RDSIAMCredentialProvider.get_rds_iam_token_hostname()
+            auth_token = RDSIAMCredentialProvider.generate_rds_auth_token(
+                credentials=credentials,
+                hostname=iam_token_hostname,
+                port=int(os.environ.get("MWAA__DB__POSTGRES_PORT", "5432")),
+                username=DB_IAM_USERNAME,
+            )
+            return auth_token
+        except Exception as e:
+            logger.error("Failed to generate credentials: %s", e)
+            raise
+
+    @classmethod
+    def get_token(cls) -> str:
+        """Get cached RDS IAM token, refreshing if expired or missing.
+
+        Uses thread-safe caching with 5-minute refresh buffer before
+        the 15-minute token expiration.
+
+        :returns: Cached or freshly generated RDS auth token.
+        """
+        now = time.time()
+
+        # Refresh token in cache if missing or expires in 5 mins.
+        if cls._token is None or now > cls._expires_at - 300:
+            with cls._lock:
+                if cls._token is None or now > cls._expires_at - 300:
+                    cls._token = cls.generate_credentials()
+                    cls._expires_at = now + 15 * 60  # 15 mins
+
+        return cls._token
+
+    @classmethod
+    def create_db_connection_url(cls, token: str | None = None) -> str:
+        """Create a PostgreSQL connection URL for RDS IAM authentication.
+
+        :param token: RDS IAM auth token. If None, generates a fresh token.
+        :returns: PostgreSQL connection URL with IAM authentication.
+        """
+        if token is None:
+            token = cls.generate_credentials()
+
+        auth_token = quote_plus(token)
+        postgres_host = os.environ.get("MWAA__DB__POSTGRES_HOST", "localhost")
+        postgres_port = os.environ.get("MWAA__DB__POSTGRES_PORT", "5432")
+        postgres_db = os.environ.get("MWAA__DB__POSTGRES_DB", "AirflowMetadata")
+        ssl_mode = os.environ.get("MWAA__DB__POSTGRES_SSLMODE", "require")
+
+        return (
+            f"postgresql+psycopg2://{DB_IAM_USERNAME}:{auth_token}"
+            f"@{postgres_host}:{postgres_port}/{postgres_db}"
+            f"?sslmode={ssl_mode}"
+        )
+
+
+def use_iam_credentials() -> bool:
+    """Check if RDS IAM credentials should be used."""
+    return os.environ.get("USE_IAM_CREDENTIALS", "").lower() == "true"
+
+
+def is_using_rds_proxy() -> bool:
+    """Check if the environment is using RDS Proxy.
+
+    MWAA__DB__POSTGRES_SSLMODE is set to 'require' only for environments
+    using RDS Proxy. RDS IAM authentication is only supported when
+    connecting through RDS Proxy.
+    """
+    ssl_mode = os.environ.get("MWAA__DB__POSTGRES_SSLMODE")
+    if ssl_mode is None:
+        logger.warning("MWAA__DB__POSTGRES_SSLMODE not set in environment.")
+        return False
+    return ssl_mode == "require"

--- a/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
@@ -18,6 +18,10 @@ import logging
 import os
 from functools import cache
 
+# NOTE: SQLAlchemy 1.4 (which Airflow 3.0.6 ships) does not re-export
+# make_url from the top-level sqlalchemy package; that alias was only added
+# in SQLAlchemy 2.0. The 3.2.1/3.3.0 images use the preferred
+# `from sqlalchemy import make_url`.
 from sqlalchemy.engine import make_url
 
 from mwaa.config.database import get_db_connection_string
@@ -141,11 +145,17 @@ def install_rds_iam_patch() -> None:
         token = RDSIAMCredentialProvider.get_token()
         url = make_url(RDSIAMCredentialProvider.create_db_connection_url(token))
 
-        # Clear existing connection params to avoid conflicts between
-        # SQLAlchemy versions (SA 2.0 uses 'dbname' in cparams while
-        # translate_connect_args returns 'database' -- both present causes
-        # psycopg2 to raise "can't specify both 'database' and 'dbname'").
-        cparams.clear()
+        # Drop only the credential/identity keys before rebuilding from the
+        # IAM URL. SQLAlchemy 2.0's psycopg2 dialect places 'dbname' in
+        # cparams while url.translate_connect_args() returns 'database', and
+        # psycopg2 rejects a connect() call carrying both (same for
+        # 'username' vs 'user'), so both aliases of each pair are popped.
+        # Everything else in cparams is preserved: engine connect_args such
+        # as MWAA_CONNECT_ARGS' connect_timeout and keepalives* settings
+        # (wired in via AIRFLOW__DATABASE__SQL_ALCHEMY_CONNECT_ARGS) arrive
+        # through cparams and must survive the token injection.
+        for stale_key in ("dbname", "database", "username", "user", "password"):
+            cparams.pop(stale_key, None)
         cparams.update(url.translate_connect_args(username="user"))
         cparams.update(url.query)
 

--- a/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
@@ -1,0 +1,111 @@
+"""RDS IAM authentication patch for SQLAlchemy connections.
+
+Attaches a global listener to SQLAlchemy's Engine class that intercepts
+metadata database connections and replaces credentials with fresh IAM tokens.
+
+This module is feature-flag controlled by USE_IAM_CREDENTIALS=true,
+only activates for RDS Proxy environments, and skips the migrate-db process.
+"""
+
+import logging
+import os
+
+from sqlalchemy import make_url
+
+from mwaa.config.rds_iam_credentials import (
+    RDSIAMCredentialProvider,
+    is_using_rds_proxy,
+    use_iam_credentials,
+)
+
+logger = logging.getLogger(__name__)
+
+MWAA_AIRFLOW_COMPONENT = os.environ.get("MWAA_AIRFLOW_COMPONENT")
+
+
+def _is_from_migrate_db() -> bool:
+    """Check if the current process is the migrate-db container."""
+    if MWAA_AIRFLOW_COMPONENT is None:
+        logger.debug("MWAA_AIRFLOW_COMPONENT not set in environment.")
+        return False
+    return MWAA_AIRFLOW_COMPONENT == "migrate-db"
+
+
+def _get_metadata_url():
+    """Get the parsed metadata DB URL from environment."""
+    conn_str = os.environ.get("AIRFLOW__DATABASE__SQL_ALCHEMY_CONN")
+    if not conn_str:
+        return None
+    return make_url(conn_str)
+
+
+def _is_accessing_metadata_db(dialect, cargs, cparams) -> bool:
+    """Return True if the connection targets the Airflow metadata DB."""
+    metadata_url = _get_metadata_url()
+    if metadata_url is None:
+        return False
+
+    # Try detecting from cargs (dsn string)
+    if cargs:
+        try:
+            url_obj = make_url(cargs[0])
+            if (
+                url_obj.host == metadata_url.host
+                and url_obj.database == metadata_url.database
+                and url_obj.port == metadata_url.port
+                and url_obj.username in ["airflow_user", "adminuser"]
+            ):
+                return True
+        except Exception:
+            pass
+
+    # Try detecting from cparams (kwargs dict)
+    host = cparams.get("host")
+    db = cparams.get("dbname") or cparams.get("database")
+    port = cparams.get("port")
+    username = cparams.get("username") or cparams.get("user")
+
+    return (
+        host == metadata_url.host
+        and db == metadata_url.database
+        and port == metadata_url.port
+        and username in ["airflow_user", "adminuser"]
+    )
+
+
+def install_rds_iam_patch() -> None:
+    """Install the RDS IAM authentication patch if conditions are met.
+
+    Conditions:
+    - USE_IAM_CREDENTIALS=true
+    - Environment uses RDS Proxy (MWAA__DB__POSTGRES_SSLMODE=require)
+    - Current process is NOT migrate-db
+    """
+    if not use_iam_credentials():
+        logger.info("RDS IAM patch not installed: USE_IAM_CREDENTIALS is not true.")
+        return
+
+    if not is_using_rds_proxy():
+        logger.info("RDS IAM patch not installed: not using RDS Proxy.")
+        return
+
+    if _is_from_migrate_db():
+        logger.info("RDS IAM patch not installed: running in migrate-db process.")
+        return
+
+    from sqlalchemy import event
+    from sqlalchemy.engine import Engine
+
+    def patch_rds_iam_authentication(dialect, conn_rec, cargs, cparams):
+        """SQLAlchemy do_connect event listener that injects IAM tokens."""
+        if not _is_accessing_metadata_db(dialect, cargs, cparams):
+            return
+
+        token = RDSIAMCredentialProvider.get_token()
+        url = make_url(RDSIAMCredentialProvider.create_db_connection_url(token))
+
+        cparams.update(url.translate_connect_args(username="user"))
+        cparams.update(url.query)
+
+    event.listen(Engine, "do_connect", patch_rds_iam_authentication)
+    logger.info("RDS IAM authentication patch installed successfully.")

--- a/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
@@ -30,8 +30,6 @@ from mwaa.config.rds_iam_credentials import (
 
 logger = logging.getLogger(__name__)
 
-MWAA_AIRFLOW_COMPONENT = os.environ.get("MWAA_AIRFLOW_COMPONENT")
-
 # Set once the do_connect listener has been registered, so that installing the
 # patch more than once in the same process does not stack duplicate listeners.
 _patch_installed = False
@@ -39,10 +37,11 @@ _patch_installed = False
 
 def _is_from_migrate_db() -> bool:
     """Check if the current process is the migrate-db container."""
-    if MWAA_AIRFLOW_COMPONENT is None:
+    component = os.environ.get("MWAA_AIRFLOW_COMPONENT")
+    if component is None:
         logger.debug("MWAA_AIRFLOW_COMPONENT not set in environment.")
         return False
-    return MWAA_AIRFLOW_COMPONENT == "migrate-db"
+    return component == "migrate-db"
 
 
 @cache

--- a/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
@@ -10,7 +10,7 @@ only activates for RDS Proxy environments, and skips the migrate-db process.
 import logging
 import os
 
-from sqlalchemy import make_url
+from sqlalchemy.engine import make_url
 
 from mwaa.config.rds_iam_credentials import (
     RDSIAMCredentialProvider,

--- a/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
@@ -3,17 +3,27 @@
 Attaches a global listener to SQLAlchemy's Engine class that intercepts
 metadata database connections and replaces credentials with fresh IAM tokens.
 
-This module is feature-flag controlled by USE_IAM_CREDENTIALS=true,
-only activates for RDS Proxy environments, and skips the migrate-db process.
+This module is feature-flag controlled by USE_IAM_CREDENTIALS=true, only
+activates for RDS Proxy environments, and skips the migrate-db process and the
+local runner.
+
+``install_rds_iam_patch()`` is called from ``airflow_local_settings.py``, which
+Airflow imports during ``settings.initialize()`` in every Airflow process. The
+listener registered here only affects the process that registers it, so it has
+to be installed there rather than from the entrypoint, whose Airflow components
+run as separate subprocesses.
 """
 
 import logging
 import os
+from functools import cache
 
 from sqlalchemy.engine import make_url
 
+from mwaa.config.database import get_db_connection_string
 from mwaa.config.rds_iam_credentials import (
     RDSIAMCredentialProvider,
+    is_local_runner,
     is_using_rds_proxy,
     use_iam_credentials,
 )
@@ -21,6 +31,10 @@ from mwaa.config.rds_iam_credentials import (
 logger = logging.getLogger(__name__)
 
 MWAA_AIRFLOW_COMPONENT = os.environ.get("MWAA_AIRFLOW_COMPONENT")
+
+# Set once the do_connect listener has been registered, so that installing the
+# patch more than once in the same process does not stack duplicate listeners.
+_patch_installed = False
 
 
 def _is_from_migrate_db() -> bool:
@@ -31,12 +45,25 @@ def _is_from_migrate_db() -> bool:
     return MWAA_AIRFLOW_COMPONENT == "migrate-db"
 
 
+@cache
 def _get_metadata_url():
-    """Get the parsed metadata DB URL from environment."""
-    conn_str = os.environ.get("AIRFLOW__DATABASE__SQL_ALCHEMY_CONN")
-    if not conn_str:
+    """Get the parsed metadata DB URL.
+
+    Derived from ``get_db_connection_string()`` rather than from
+    ``AIRFLOW__DATABASE__SQL_ALCHEMY_CONN``: that variable is only placed in the
+    environment dictionary handed to the Airflow subprocesses, so it is not
+    guaranteed to be present in ``os.environ`` of the process evaluating this.
+    The underlying ``MWAA__DB__*`` variables are always present.
+
+    The result is cached because this is consulted on every connection attempt.
+    """
+    try:
+        return make_url(get_db_connection_string())
+    except Exception as e:
+        # Never let this propagate into the do_connect listener: raising there
+        # would break every database connection in the process.
+        logger.error("Could not determine the metadata DB URL: %s", e)
         return None
-    return make_url(conn_str)
 
 
 def _is_accessing_metadata_db(dialect, cargs, cparams) -> bool:
@@ -80,7 +107,14 @@ def install_rds_iam_patch() -> None:
     - USE_IAM_CREDENTIALS=true
     - Environment uses RDS Proxy (MWAA__DB__POSTGRES_SSLMODE=require)
     - Current process is NOT migrate-db
+    - Current process is NOT the local runner
     """
+    global _patch_installed
+
+    if _patch_installed:
+        logger.debug("RDS IAM patch already installed in this process.")
+        return
+
     if not use_iam_credentials():
         logger.info("RDS IAM patch not installed: USE_IAM_CREDENTIALS is not true.")
         return
@@ -91,6 +125,10 @@ def install_rds_iam_patch() -> None:
 
     if _is_from_migrate_db():
         logger.info("RDS IAM patch not installed: running in migrate-db process.")
+        return
+
+    if is_local_runner():
+        logger.info("RDS IAM patch not installed: running in local runner mode.")
         return
 
     from sqlalchemy import event
@@ -108,4 +146,5 @@ def install_rds_iam_patch() -> None:
         cparams.update(url.query)
 
     event.listen(Engine, "do_connect", patch_rds_iam_authentication)
+    _patch_installed = True
     logger.info("RDS IAM authentication patch installed successfully.")

--- a/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
@@ -141,6 +141,11 @@ def install_rds_iam_patch() -> None:
         token = RDSIAMCredentialProvider.get_token()
         url = make_url(RDSIAMCredentialProvider.create_db_connection_url(token))
 
+        # Clear existing connection params to avoid conflicts between
+        # SQLAlchemy versions (SA 2.0 uses 'dbname' in cparams while
+        # translate_connect_args returns 'database' -- both present causes
+        # psycopg2 to raise "can't specify both 'database' and 'dbname'").
+        cparams.clear()
         cparams.update(url.translate_connect_args(username="user"))
         cparams.update(url.query)
 

--- a/images/airflow/3.0.6/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.0.6/python/mwaa/database/migrate_with_downgrade.py
@@ -75,7 +75,22 @@ def _ensure_rds_iam_user():
                 logger.info("RDS IAM connection successful.")
                 return engine
 
-            db_engine = _connect_iam()
+            try:
+                db_engine = _connect_iam()
+            except Exception as iam_error:
+                # Deliberate hard failure, unlike the best-effort paths in this
+                # function. Reaching here means neither the static credentials
+                # nor an RDS IAM token can open a connection, so the grants
+                # below cannot be applied and migrate-db must not continue.
+                # Raising explicitly, rather than letting _connect_iam()
+                # propagate on its own, keeps the intent unambiguous and puts a
+                # single precise error in the logs instead of surfacing later as
+                # a lock-acquisition failure in _migrate_db().
+                raise RuntimeError(
+                    "Could not connect to the metadata database with either "
+                    "static or RDS IAM credentials; unable to ensure the RDS "
+                    "IAM user."
+                ) from iam_error
         else:
             logger.warning(
                 "Error while ensuring rds iam db credentials, skipping. %s", e

--- a/images/airflow/3.0.6/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.0.6/python/mwaa/database/migrate_with_downgrade.py
@@ -26,6 +26,7 @@ from mwaa.utils.dblock import with_db_lock
 from airflow.cli.commands import db_command as airflow_db_command
 
 DB_IAM_USERNAME = "airflow_user"
+DB_ADMIN_USERNAME = "adminuser"
 DB_NAME = "AirflowMetadata"
 
 # Usually, we pass the `__name__` variable instead as that defaults to the module path,
@@ -95,47 +96,66 @@ def _ensure_rds_iam_user():
                 else:
                     logger.info("db rds iam user already exists")
 
-                # Always ensure permissions are up to date
-                conn.execute(text(f"GRANT rds_iam TO {DB_IAM_USERNAME}"))
-                conn.execute(
-                    text(
-                        f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'
+                # Only the admin role can hand out these privileges. When this
+                # runs as airflow_user the grants would fail, so mirror the 2.x
+                # behaviour and gate them on the current role.
+                current_role = conn.execute(text("SELECT current_user")).scalar()
+
+                if current_role == DB_ADMIN_USERNAME:
+                    logger.info(
+                        "Current role is %s, setting up permissions for %s",
+                        DB_ADMIN_USERNAME,
+                        DB_IAM_USERNAME,
                     )
-                )
-                conn.execute(text(f"GRANT ALL ON SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(
-                    text(
-                        f"GRANT ALL ON ALL TABLES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    conn.execute(text(f"GRANT rds_iam TO {DB_IAM_USERNAME}"))
+                    conn.execute(
+                        text(
+                            f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'
+                        )
                     )
-                )
-                conn.execute(
-                    text(
-                        f"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(f"GRANT ALL ON SCHEMA public TO {DB_IAM_USERNAME}")
                     )
-                )
-                conn.execute(
-                    text(
-                        f"GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(
+                            f"GRANT ALL ON ALL TABLES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                        )
                     )
-                )
-                conn.execute(
-                    text(
-                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
-                        f"GRANT ALL ON TABLES TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(
+                            f"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                        )
                     )
-                )
-                conn.execute(
-                    text(
-                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
-                        f"GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(
+                            f"GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO {DB_IAM_USERNAME}"
+                        )
                     )
-                )
-                conn.execute(
-                    text(
-                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
-                        f"GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(
+                            f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                            f"GRANT ALL ON TABLES TO {DB_IAM_USERNAME}"
+                        )
                     )
-                )
+                    conn.execute(
+                        text(
+                            f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                            f"GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"
+                        )
+                    )
+                    conn.execute(
+                        text(
+                            f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                            f"GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"
+                        )
+                    )
+                    # Needed so that airflow_user inherits ownership of objects
+                    # created by adminuser during migrations.
+                    conn.execute(
+                        text(f"GRANT {DB_ADMIN_USERNAME} TO {DB_IAM_USERNAME}")
+                    )
+                elif current_role == DB_IAM_USERNAME:
+                    logger.info("Current role is %s", DB_IAM_USERNAME)
     except Exception as e:
         logger.warning("Error while ensuring rds iam db credentials, skipping. %s", e)
 

--- a/images/airflow/3.0.6/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.0.6/python/mwaa/database/migrate_with_downgrade.py
@@ -16,6 +16,11 @@ import os
 import sys
 
 from mwaa.config.database import get_db_connection_string
+from mwaa.config.rds_iam_credentials import (
+    RDSIAMCredentialProvider,
+    is_using_rds_proxy,
+    use_iam_credentials,
+)
 from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 from mwaa.utils.dblock import with_db_lock
 from airflow.cli.commands import db_command as airflow_db_command
@@ -53,28 +58,86 @@ def _ensure_rds_iam_user():
             return engine
 
         db_engine = _connect_static()
+
+    except Exception as e:
+        logger.warning(f"Static credential connection failed: {e}")
+
+        if use_iam_credentials() and is_using_rds_proxy():
+            @with_db_retry
+            def _connect_iam():
+                logger.info("Attempting connection with RDS IAM credentials.")
+                token = RDSIAMCredentialProvider.get_token()
+                url = RDSIAMCredentialProvider.create_db_connection_url(token)
+                engine = create_engine(url, **MAINTENANCE_ENGINE_KWARGS)
+                with engine.connect() as conn:
+                    conn.execute(text("SELECT 1"))
+                logger.info("RDS IAM connection successful.")
+                return engine
+
+            db_engine = _connect_iam()
+        else:
+            logger.warning(
+                "Error while ensuring rds iam db credentials, skipping. %s", e
+            )
+            return
+
+    try:
         with db_engine.connect() as conn:
             with conn.begin():
-                result = conn.execute(text("SELECT 1 FROM pg_roles WHERE rolname = :rolename"), {"rolename": DB_IAM_USERNAME})
+                result = conn.execute(
+                    text("SELECT 1 FROM pg_roles WHERE rolname = :rolename"),
+                    {"rolename": DB_IAM_USERNAME},
+                )
                 if not result.fetchone():
-                    print(f"Creating user '{DB_IAM_USERNAME}'")
+                    logger.info(f"Creating user '{DB_IAM_USERNAME}'")
                     conn.execute(text(f"CREATE USER {DB_IAM_USERNAME}"))
-                    print(f"Created db rds iam user")
+                    logger.info("Created db rds iam user")
                 else:
-                    print(f"db rds iam user already exists")
+                    logger.info("db rds iam user already exists")
 
                 # Always ensure permissions are up to date
                 conn.execute(text(f"GRANT rds_iam TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'))
+                conn.execute(
+                    text(
+                        f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'
+                    )
+                )
                 conn.execute(text(f"GRANT ALL ON SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"GRANT ALL ON ALL TABLES IN SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"))
+                conn.execute(
+                    text(
+                        f"GRANT ALL ON ALL TABLES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                        f"GRANT ALL ON TABLES TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                        f"GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                        f"GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"
+                    )
+                )
     except Exception as e:
-        logger.warning(f"Error while ensuring rds iam db credentials, skipping. {e}")
+        logger.warning("Error while ensuring rds iam db credentials, skipping. %s", e)
 
 
 @with_db_lock(1234)

--- a/images/airflow/3.0.6/python/mwaa/entrypoint.py
+++ b/images/airflow/3.0.6/python/mwaa/entrypoint.py
@@ -261,12 +261,6 @@ async def main() -> None:
     executor_type = os.environ.get("MWAA__CORE__EXECUTOR_TYPE", "CeleryExecutor")
     environ = setup_environment_variables(command, executor_type)
 
-    # Install RDS IAM credential rotation for non-migrate-db commands.
-    # migrate-db uses admin credentials for schema migrations.
-    if command != "migrate-db":
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-        install_rds_iam_patch()
-
     if command == "migrate-db":
         await airflow_db_migrate(environ)
         print("Finished running db validations")

--- a/images/airflow/3.0.6/python/mwaa/entrypoint.py
+++ b/images/airflow/3.0.6/python/mwaa/entrypoint.py
@@ -261,6 +261,12 @@ async def main() -> None:
     executor_type = os.environ.get("MWAA__CORE__EXECUTOR_TYPE", "CeleryExecutor")
     environ = setup_environment_variables(command, executor_type)
 
+    # Install RDS IAM credential rotation for non-migrate-db commands.
+    # migrate-db uses admin credentials for schema migrations.
+    if command != "migrate-db":
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+        install_rds_iam_patch()
+
     if command == "migrate-db":
         await airflow_db_migrate(environ)
         print("Finished running db validations")

--- a/images/airflow/3.0.6/python/mwaa/utils/dblock.py
+++ b/images/airflow/3.0.6/python/mwaa/utils/dblock.py
@@ -28,7 +28,19 @@ F = TypeVar("F", bound=Callable[..., Any])
 @with_db_retry
 def _connect_with_retry() -> Connection:
     """Establish a DB connection with retry on transient RDS Proxy failures."""
-    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    from mwaa.config.rds_iam_credentials import (
+        is_using_rds_proxy,
+        use_iam_credentials,
+    )
+
+    if use_iam_credentials() and is_using_rds_proxy():
+        from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+        token = RDSIAMCredentialProvider.get_token()
+        conn_url = RDSIAMCredentialProvider.create_db_connection_url(token)
+    else:
+        conn_url = get_db_connection_string()
+    engine = create_engine(conn_url, **MAINTENANCE_ENGINE_KWARGS)
     return engine.connect()
 
 

--- a/images/airflow/3.0.6/run.sh
+++ b/images/airflow/3.0.6/run.sh
@@ -73,6 +73,10 @@ MWAA__CORE__API_SERVER_URL="http://mwaa-306-webserver:8080"
 GENERATE_BILL_OF_MATERIALS="False"
 export GENERATE_BILL_OF_MATERIALS
 
+# Local Runner Indicator
+MWAA_LOCAL_RUNNER="true"
+export MWAA_LOCAL_RUNNER
+
 # MWAA Configuration
 MWAA__CORE__REQUIREMENTS_PATH="/usr/local/airflow/requirements/requirements.txt"
 MWAA__CORE__STARTUP_SCRIPT_PATH="/usr/local/airflow/startup/startup.sh"

--- a/images/airflow/3.2.1/Dockerfile.base.j2
+++ b/images/airflow/3.2.1/Dockerfile.base.j2
@@ -127,6 +127,9 @@ WORKDIR ${AIRFLOW_USER_HOME}
 # Copy python files.
 COPY ./python /python
 
+# Copy airflow_local_settings.py
+COPY ./airflow_local_settings.py ${AIRFLOW_USER_HOME}/config/airflow_local_settings.py
+
 # TODO Move this to the bin folder under airflow's home folder.
 COPY healthcheck.sh /healthcheck.sh
 RUN chmod +x /healthcheck.sh

--- a/images/airflow/3.2.1/Dockerfiles/Dockerfile.base
+++ b/images/airflow/3.2.1/Dockerfiles/Dockerfile.base
@@ -148,6 +148,9 @@ WORKDIR ${AIRFLOW_USER_HOME}
 # Copy python files.
 COPY ./python /python
 
+# Copy airflow_local_settings.py
+COPY ./airflow_local_settings.py ${AIRFLOW_USER_HOME}/config/airflow_local_settings.py
+
 # TODO Move this to the bin folder under airflow's home folder.
 COPY healthcheck.sh /healthcheck.sh
 RUN chmod +x /healthcheck.sh

--- a/images/airflow/3.2.1/airflow_local_settings.py
+++ b/images/airflow/3.2.1/airflow_local_settings.py
@@ -1,0 +1,62 @@
+"""Airflow local settings configuration for MWAA RDS IAM authentication.
+
+Airflow imports this module during ``airflow.settings.initialize()``, which runs
+unconditionally on ``import airflow``. ``airflow.settings`` appends
+``$AIRFLOW_HOME/config`` to ``sys.path`` before doing so, which is where the
+Dockerfile installs this file.
+
+This is the only correct place to install the RDS IAM credential rotation patch:
+the patch registers a SQLAlchemy ``do_connect`` listener, and that listener lives
+in the process that registered it. The Airflow components (scheduler, worker,
+api-server, dag-processor, triggerer and task runners) are spawned by the
+entrypoint as separate ``subprocess.Popen(["airflow", ...])`` children, each a
+fresh Python interpreter. Installing the patch from the entrypoint alone would
+therefore leave every process that actually talks to the metadata database
+unpatched.
+"""
+
+import importlib.util
+import logging
+import os
+
+# Airflow copies every public name of this module into the `airflow.settings`
+# namespace. Declaring an empty `__all__` keeps our internals from clobbering
+# Airflow's own globals; we export no policies or settings overrides.
+__all__: list[str] = []
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+    install_rds_iam_patch()
+except Exception as e:
+    _logger.error(f"Failed to load RDS IAM patch: {e}")
+    raise
+
+# Load ${AIRFLOW_HOME}/dags/airflow_local_settings.py and
+# ${AIRFLOW_HOME}/plugins/airflow_local_settings.py if they exist, so that
+# customer-provided local settings continue to be honoured.
+_AIRFLOW_HOME = os.environ.get("AIRFLOW_HOME", "/usr/local/airflow")
+_CUSTOMER_LOCAL_SETTINGS = [
+    (
+        "customer_dags_airflow_local_settings",
+        os.path.join(_AIRFLOW_HOME, "dags", "airflow_local_settings.py"),
+    ),
+    (
+        "customer_plugins_airflow_local_settings",
+        os.path.join(_AIRFLOW_HOME, "plugins", "airflow_local_settings.py"),
+    ),
+]
+
+for _module_name, _path in _CUSTOMER_LOCAL_SETTINGS:
+    if not os.path.exists(_path):
+        continue
+    try:
+        _spec = importlib.util.spec_from_file_location(_module_name, _path)
+        if _spec and _spec.loader:
+            _module = importlib.util.module_from_spec(_spec)
+            _spec.loader.exec_module(_module)
+    except Exception as e:
+        _logger.error(f"Failed to load airflow_local_settings from {_path}: {e}")
+        raise

--- a/images/airflow/3.2.1/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.2.1/python/mwaa/config/rds_iam_credentials.py
@@ -183,6 +183,16 @@ def use_iam_credentials() -> bool:
     return os.environ.get("USE_IAM_CREDENTIALS", "").lower() == "true"
 
 
+def is_local_runner() -> bool:
+    """Check if running in local runner mode.
+
+    RDS IAM authentication requires an ECS task metadata endpoint and an RDS
+    Proxy, neither of which exist when running the image locally, so the patch
+    must not be installed in that case.
+    """
+    return os.environ.get("MWAA_LOCAL_RUNNER", "").lower() == "true"
+
+
 def is_using_rds_proxy() -> bool:
     """Check if the environment is using RDS Proxy.
 

--- a/images/airflow/3.2.1/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.2.1/python/mwaa/config/rds_iam_credentials.py
@@ -163,6 +163,9 @@ class RDSIAMCredentialProvider:
         :returns: PostgreSQL connection URL with IAM authentication.
         """
         if token is None:
+            # NOTE: bypasses the get_token() cache, matching 2.x. No caller uses
+            # this default path today; the cache bypass is tracked for a
+            # cross-version follow-up rather than diverging from 2.x here.
             token = cls.generate_credentials()
 
         auth_token = quote_plus(token)

--- a/images/airflow/3.2.1/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.2.1/python/mwaa/config/rds_iam_credentials.py
@@ -1,0 +1,197 @@
+"""RDS IAM credential provider for MWAA.
+
+Provides IAM-based authentication tokens for RDS connections,
+with thread-safe caching and automatic refresh.
+"""
+
+import json
+import logging
+import os
+import threading
+import time
+import urllib.request
+from urllib.parse import quote_plus, urlparse
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+DB_IAM_USERNAME = "airflow_user"
+
+
+class RDSIAMCredentialProvider:
+    """Provides cached RDS IAM authentication tokens.
+
+    Tokens are generated using ECS task credentials and cached with
+    automatic refresh 5 minutes before expiration (tokens valid 15 min).
+    """
+
+    _lock = threading.Lock()
+    _token: str | None = None
+    _expires_at: float = 0
+
+    @staticmethod
+    def get_ecs_credentials() -> dict:
+        """Get AWS credentials from ECS task metadata endpoint.
+
+        Uses AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI for the credential path
+        and ECS_CONTAINER_METADATA_URI for the base URL.
+
+        :returns: AWS credentials dict with AccessKeyId, SecretAccessKey, Token.
+        :raises ValueError: If required environment variables are not set.
+        """
+        relative_uri = os.environ.get("AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI")
+        if not relative_uri:
+            raise ValueError("AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI not set")
+
+        metadata_uri = os.environ.get("ECS_CONTAINER_METADATA_URI")
+        if not metadata_uri:
+            raise ValueError("ECS_CONTAINER_METADATA_URI not set")
+
+        parsed_uri = urlparse(metadata_uri)
+        base_url = f"{parsed_uri.scheme}://{parsed_uri.netloc}"
+        credentials_url = f"{base_url}{relative_uri}"
+
+        request = urllib.request.Request(credentials_url)
+        no_proxy_handler = urllib.request.ProxyHandler({})
+        opener = urllib.request.build_opener(no_proxy_handler)
+
+        with opener.open(request) as response:
+            credentials_data = json.loads(response.read().decode("utf-8"))
+
+        return credentials_data
+
+    @staticmethod
+    def get_rds_iam_token_hostname() -> str:
+        """Get the RDS hostname for IAM token generation.
+
+        For RDS Proxy IAM authentication, tokens must be generated using
+        the direct RDS Proxy/Cluster endpoint, not VPC/NLB endpoints.
+
+        :returns: RDS hostname for token generation.
+        :raises ValueError: If RDS_IAM_TOKEN_HOSTNAME is not set.
+        """
+        token_hostname = os.environ.get("RDS_IAM_TOKEN_HOSTNAME", "").strip()
+        if token_hostname:
+            return token_hostname
+        logger.error(
+            "RDS_IAM_TOKEN_HOSTNAME not set in environment. "
+            "This should be set by the CDK stack to the RDS Cluster/Proxy endpoint."
+        )
+        raise ValueError("RDS_IAM_TOKEN_HOSTNAME environment variable is required")
+
+    @staticmethod
+    def generate_rds_auth_token(
+        credentials: dict, hostname: str, port: int, username: str
+    ) -> str:
+        """Generate RDS IAM authentication token using boto3.
+
+        :param credentials: AWS credentials from ECS task metadata.
+        :param hostname: RDS hostname for token generation.
+        :param port: Database port number.
+        :param username: Database username.
+        :returns: RDS IAM authentication token.
+        """
+        region = os.environ.get("AWS_REGION", "us-west-2")
+
+        rds_client = boto3.client(
+            "rds",
+            region_name=region,
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["Token"],
+        )
+
+        try:
+            auth_token = rds_client.generate_db_auth_token(
+                DBHostname=hostname,
+                Port=port,
+                DBUsername=username,
+            )
+            return auth_token
+        except Exception as e:
+            logger.error("Failed to generate RDS auth token: %s", e)
+            raise
+
+    @staticmethod
+    def generate_credentials() -> str:
+        """Generate fresh RDS auth token.
+
+        Orchestrates fetching ECS credentials and generating the RDS token.
+
+        :returns: RDS auth token.
+        """
+        try:
+            credentials = RDSIAMCredentialProvider.get_ecs_credentials()
+            iam_token_hostname = RDSIAMCredentialProvider.get_rds_iam_token_hostname()
+            auth_token = RDSIAMCredentialProvider.generate_rds_auth_token(
+                credentials=credentials,
+                hostname=iam_token_hostname,
+                port=int(os.environ.get("MWAA__DB__POSTGRES_PORT", "5432")),
+                username=DB_IAM_USERNAME,
+            )
+            return auth_token
+        except Exception as e:
+            logger.error("Failed to generate credentials: %s", e)
+            raise
+
+    @classmethod
+    def get_token(cls) -> str:
+        """Get cached RDS IAM token, refreshing if expired or missing.
+
+        Uses thread-safe caching with 5-minute refresh buffer before
+        the 15-minute token expiration.
+
+        :returns: Cached or freshly generated RDS auth token.
+        """
+        now = time.time()
+
+        # Refresh token in cache if missing or expires in 5 mins.
+        if cls._token is None or now > cls._expires_at - 300:
+            with cls._lock:
+                if cls._token is None or now > cls._expires_at - 300:
+                    cls._token = cls.generate_credentials()
+                    cls._expires_at = now + 15 * 60  # 15 mins
+
+        return cls._token
+
+    @classmethod
+    def create_db_connection_url(cls, token: str | None = None) -> str:
+        """Create a PostgreSQL connection URL for RDS IAM authentication.
+
+        :param token: RDS IAM auth token. If None, generates a fresh token.
+        :returns: PostgreSQL connection URL with IAM authentication.
+        """
+        if token is None:
+            token = cls.generate_credentials()
+
+        auth_token = quote_plus(token)
+        postgres_host = os.environ.get("MWAA__DB__POSTGRES_HOST", "localhost")
+        postgres_port = os.environ.get("MWAA__DB__POSTGRES_PORT", "5432")
+        postgres_db = os.environ.get("MWAA__DB__POSTGRES_DB", "AirflowMetadata")
+        ssl_mode = os.environ.get("MWAA__DB__POSTGRES_SSLMODE", "require")
+
+        return (
+            f"postgresql+psycopg2://{DB_IAM_USERNAME}:{auth_token}"
+            f"@{postgres_host}:{postgres_port}/{postgres_db}"
+            f"?sslmode={ssl_mode}"
+        )
+
+
+def use_iam_credentials() -> bool:
+    """Check if RDS IAM credentials should be used."""
+    return os.environ.get("USE_IAM_CREDENTIALS", "").lower() == "true"
+
+
+def is_using_rds_proxy() -> bool:
+    """Check if the environment is using RDS Proxy.
+
+    MWAA__DB__POSTGRES_SSLMODE is set to 'require' only for environments
+    using RDS Proxy. RDS IAM authentication is only supported when
+    connecting through RDS Proxy.
+    """
+    ssl_mode = os.environ.get("MWAA__DB__POSTGRES_SSLMODE")
+    if ssl_mode is None:
+        logger.warning("MWAA__DB__POSTGRES_SSLMODE not set in environment.")
+        return False
+    return ssl_mode == "require"

--- a/images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py
@@ -3,17 +3,27 @@
 Attaches a global listener to SQLAlchemy's Engine class that intercepts
 metadata database connections and replaces credentials with fresh IAM tokens.
 
-This module is feature-flag controlled by USE_IAM_CREDENTIALS=true,
-only activates for RDS Proxy environments, and skips the migrate-db process.
+This module is feature-flag controlled by USE_IAM_CREDENTIALS=true, only
+activates for RDS Proxy environments, and skips the migrate-db process and the
+local runner.
+
+``install_rds_iam_patch()`` is called from ``airflow_local_settings.py``, which
+Airflow imports during ``settings.initialize()`` in every Airflow process. The
+listener registered here only affects the process that registers it, so it has
+to be installed there rather than from the entrypoint, whose Airflow components
+run as separate subprocesses.
 """
 
 import logging
 import os
+from functools import cache
 
 from sqlalchemy import make_url
 
+from mwaa.config.database import get_db_connection_string
 from mwaa.config.rds_iam_credentials import (
     RDSIAMCredentialProvider,
+    is_local_runner,
     is_using_rds_proxy,
     use_iam_credentials,
 )
@@ -21,6 +31,10 @@ from mwaa.config.rds_iam_credentials import (
 logger = logging.getLogger(__name__)
 
 MWAA_AIRFLOW_COMPONENT = os.environ.get("MWAA_AIRFLOW_COMPONENT")
+
+# Set once the do_connect listener has been registered, so that installing the
+# patch more than once in the same process does not stack duplicate listeners.
+_patch_installed = False
 
 
 def _is_from_migrate_db() -> bool:
@@ -31,12 +45,25 @@ def _is_from_migrate_db() -> bool:
     return MWAA_AIRFLOW_COMPONENT == "migrate-db"
 
 
+@cache
 def _get_metadata_url():
-    """Get the parsed metadata DB URL from environment."""
-    conn_str = os.environ.get("AIRFLOW__DATABASE__SQL_ALCHEMY_CONN")
-    if not conn_str:
+    """Get the parsed metadata DB URL.
+
+    Derived from ``get_db_connection_string()`` rather than from
+    ``AIRFLOW__DATABASE__SQL_ALCHEMY_CONN``: that variable is only placed in the
+    environment dictionary handed to the Airflow subprocesses, so it is not
+    guaranteed to be present in ``os.environ`` of the process evaluating this.
+    The underlying ``MWAA__DB__*`` variables are always present.
+
+    The result is cached because this is consulted on every connection attempt.
+    """
+    try:
+        return make_url(get_db_connection_string())
+    except Exception as e:
+        # Never let this propagate into the do_connect listener: raising there
+        # would break every database connection in the process.
+        logger.error("Could not determine the metadata DB URL: %s", e)
         return None
-    return make_url(conn_str)
 
 
 def _is_accessing_metadata_db(dialect, cargs, cparams) -> bool:
@@ -80,7 +107,14 @@ def install_rds_iam_patch() -> None:
     - USE_IAM_CREDENTIALS=true
     - Environment uses RDS Proxy (MWAA__DB__POSTGRES_SSLMODE=require)
     - Current process is NOT migrate-db
+    - Current process is NOT the local runner
     """
+    global _patch_installed
+
+    if _patch_installed:
+        logger.debug("RDS IAM patch already installed in this process.")
+        return
+
     if not use_iam_credentials():
         logger.info("RDS IAM patch not installed: USE_IAM_CREDENTIALS is not true.")
         return
@@ -91,6 +125,10 @@ def install_rds_iam_patch() -> None:
 
     if _is_from_migrate_db():
         logger.info("RDS IAM patch not installed: running in migrate-db process.")
+        return
+
+    if is_local_runner():
+        logger.info("RDS IAM patch not installed: running in local runner mode.")
         return
 
     from sqlalchemy import event
@@ -108,4 +146,5 @@ def install_rds_iam_patch() -> None:
         cparams.update(url.query)
 
     event.listen(Engine, "do_connect", patch_rds_iam_authentication)
+    _patch_installed = True
     logger.info("RDS IAM authentication patch installed successfully.")

--- a/images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py
@@ -141,11 +141,17 @@ def install_rds_iam_patch() -> None:
         token = RDSIAMCredentialProvider.get_token()
         url = make_url(RDSIAMCredentialProvider.create_db_connection_url(token))
 
-        # Clear existing connection params to avoid conflicts between
-        # SQLAlchemy versions (SA 2.0 uses 'dbname' in cparams while
-        # translate_connect_args returns 'database' -- both present causes
-        # psycopg2 to raise "can't specify both 'database' and 'dbname'").
-        cparams.clear()
+        # Drop only the credential/identity keys before rebuilding from the
+        # IAM URL. SQLAlchemy 2.0's psycopg2 dialect places 'dbname' in
+        # cparams while url.translate_connect_args() returns 'database', and
+        # psycopg2 rejects a connect() call carrying both (same for
+        # 'username' vs 'user'), so both aliases of each pair are popped.
+        # Everything else in cparams is preserved: engine connect_args such
+        # as MWAA_CONNECT_ARGS' connect_timeout and keepalives* settings
+        # (wired in via AIRFLOW__DATABASE__SQL_ALCHEMY_CONNECT_ARGS) arrive
+        # through cparams and must survive the token injection.
+        for stale_key in ("dbname", "database", "username", "user", "password"):
+            cparams.pop(stale_key, None)
         cparams.update(url.translate_connect_args(username="user"))
         cparams.update(url.query)
 

--- a/images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py
@@ -1,0 +1,111 @@
+"""RDS IAM authentication patch for SQLAlchemy connections.
+
+Attaches a global listener to SQLAlchemy's Engine class that intercepts
+metadata database connections and replaces credentials with fresh IAM tokens.
+
+This module is feature-flag controlled by USE_IAM_CREDENTIALS=true,
+only activates for RDS Proxy environments, and skips the migrate-db process.
+"""
+
+import logging
+import os
+
+from sqlalchemy import make_url
+
+from mwaa.config.rds_iam_credentials import (
+    RDSIAMCredentialProvider,
+    is_using_rds_proxy,
+    use_iam_credentials,
+)
+
+logger = logging.getLogger(__name__)
+
+MWAA_AIRFLOW_COMPONENT = os.environ.get("MWAA_AIRFLOW_COMPONENT")
+
+
+def _is_from_migrate_db() -> bool:
+    """Check if the current process is the migrate-db container."""
+    if MWAA_AIRFLOW_COMPONENT is None:
+        logger.debug("MWAA_AIRFLOW_COMPONENT not set in environment.")
+        return False
+    return MWAA_AIRFLOW_COMPONENT == "migrate-db"
+
+
+def _get_metadata_url():
+    """Get the parsed metadata DB URL from environment."""
+    conn_str = os.environ.get("AIRFLOW__DATABASE__SQL_ALCHEMY_CONN")
+    if not conn_str:
+        return None
+    return make_url(conn_str)
+
+
+def _is_accessing_metadata_db(dialect, cargs, cparams) -> bool:
+    """Return True if the connection targets the Airflow metadata DB."""
+    metadata_url = _get_metadata_url()
+    if metadata_url is None:
+        return False
+
+    # Try detecting from cargs (dsn string)
+    if cargs:
+        try:
+            url_obj = make_url(cargs[0])
+            if (
+                url_obj.host == metadata_url.host
+                and url_obj.database == metadata_url.database
+                and url_obj.port == metadata_url.port
+                and url_obj.username in ["airflow_user", "adminuser"]
+            ):
+                return True
+        except Exception:
+            pass
+
+    # Try detecting from cparams (kwargs dict)
+    host = cparams.get("host")
+    db = cparams.get("dbname") or cparams.get("database")
+    port = cparams.get("port")
+    username = cparams.get("username") or cparams.get("user")
+
+    return (
+        host == metadata_url.host
+        and db == metadata_url.database
+        and port == metadata_url.port
+        and username in ["airflow_user", "adminuser"]
+    )
+
+
+def install_rds_iam_patch() -> None:
+    """Install the RDS IAM authentication patch if conditions are met.
+
+    Conditions:
+    - USE_IAM_CREDENTIALS=true
+    - Environment uses RDS Proxy (MWAA__DB__POSTGRES_SSLMODE=require)
+    - Current process is NOT migrate-db
+    """
+    if not use_iam_credentials():
+        logger.info("RDS IAM patch not installed: USE_IAM_CREDENTIALS is not true.")
+        return
+
+    if not is_using_rds_proxy():
+        logger.info("RDS IAM patch not installed: not using RDS Proxy.")
+        return
+
+    if _is_from_migrate_db():
+        logger.info("RDS IAM patch not installed: running in migrate-db process.")
+        return
+
+    from sqlalchemy import event
+    from sqlalchemy.engine import Engine
+
+    def patch_rds_iam_authentication(dialect, conn_rec, cargs, cparams):
+        """SQLAlchemy do_connect event listener that injects IAM tokens."""
+        if not _is_accessing_metadata_db(dialect, cargs, cparams):
+            return
+
+        token = RDSIAMCredentialProvider.get_token()
+        url = make_url(RDSIAMCredentialProvider.create_db_connection_url(token))
+
+        cparams.update(url.translate_connect_args(username="user"))
+        cparams.update(url.query)
+
+    event.listen(Engine, "do_connect", patch_rds_iam_authentication)
+    logger.info("RDS IAM authentication patch installed successfully.")

--- a/images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py
@@ -30,8 +30,6 @@ from mwaa.config.rds_iam_credentials import (
 
 logger = logging.getLogger(__name__)
 
-MWAA_AIRFLOW_COMPONENT = os.environ.get("MWAA_AIRFLOW_COMPONENT")
-
 # Set once the do_connect listener has been registered, so that installing the
 # patch more than once in the same process does not stack duplicate listeners.
 _patch_installed = False
@@ -39,10 +37,11 @@ _patch_installed = False
 
 def _is_from_migrate_db() -> bool:
     """Check if the current process is the migrate-db container."""
-    if MWAA_AIRFLOW_COMPONENT is None:
+    component = os.environ.get("MWAA_AIRFLOW_COMPONENT")
+    if component is None:
         logger.debug("MWAA_AIRFLOW_COMPONENT not set in environment.")
         return False
-    return MWAA_AIRFLOW_COMPONENT == "migrate-db"
+    return component == "migrate-db"
 
 
 @cache

--- a/images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py
@@ -141,6 +141,11 @@ def install_rds_iam_patch() -> None:
         token = RDSIAMCredentialProvider.get_token()
         url = make_url(RDSIAMCredentialProvider.create_db_connection_url(token))
 
+        # Clear existing connection params to avoid conflicts between
+        # SQLAlchemy versions (SA 2.0 uses 'dbname' in cparams while
+        # translate_connect_args returns 'database' -- both present causes
+        # psycopg2 to raise "can't specify both 'database' and 'dbname'").
+        cparams.clear()
         cparams.update(url.translate_connect_args(username="user"))
         cparams.update(url.query)
 

--- a/images/airflow/3.2.1/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.2.1/python/mwaa/database/migrate_with_downgrade.py
@@ -26,6 +26,7 @@ from mwaa.utils.dblock import with_db_lock
 from airflow.cli.commands import db_command as airflow_db_command
 
 DB_IAM_USERNAME = "airflow_user"
+DB_ADMIN_USERNAME = "adminuser"
 DB_NAME = "AirflowMetadata"
 
 # Usually, we pass the `__name__` variable instead as that defaults to the module path,
@@ -96,47 +97,66 @@ def _ensure_rds_iam_user():
                 else:
                     logger.info("db rds iam user already exists")
 
-                # Always ensure permissions are up to date
-                conn.execute(text(f"GRANT rds_iam TO {DB_IAM_USERNAME}"))
-                conn.execute(
-                    text(
-                        f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'
+                # Only the admin role can hand out these privileges. When this
+                # runs as airflow_user the grants would fail, so mirror the 2.x
+                # behaviour and gate them on the current role.
+                current_role = conn.execute(text("SELECT current_user")).scalar()
+
+                if current_role == DB_ADMIN_USERNAME:
+                    logger.info(
+                        "Current role is %s, setting up permissions for %s",
+                        DB_ADMIN_USERNAME,
+                        DB_IAM_USERNAME,
                     )
-                )
-                conn.execute(text(f"GRANT ALL ON SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(
-                    text(
-                        f"GRANT ALL ON ALL TABLES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    conn.execute(text(f"GRANT rds_iam TO {DB_IAM_USERNAME}"))
+                    conn.execute(
+                        text(
+                            f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'
+                        )
                     )
-                )
-                conn.execute(
-                    text(
-                        f"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(f"GRANT ALL ON SCHEMA public TO {DB_IAM_USERNAME}")
                     )
-                )
-                conn.execute(
-                    text(
-                        f"GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(
+                            f"GRANT ALL ON ALL TABLES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                        )
                     )
-                )
-                conn.execute(
-                    text(
-                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
-                        f"GRANT ALL ON TABLES TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(
+                            f"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                        )
                     )
-                )
-                conn.execute(
-                    text(
-                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
-                        f"GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(
+                            f"GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO {DB_IAM_USERNAME}"
+                        )
                     )
-                )
-                conn.execute(
-                    text(
-                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
-                        f"GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(
+                            f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                            f"GRANT ALL ON TABLES TO {DB_IAM_USERNAME}"
+                        )
                     )
-                )
+                    conn.execute(
+                        text(
+                            f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                            f"GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"
+                        )
+                    )
+                    conn.execute(
+                        text(
+                            f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                            f"GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"
+                        )
+                    )
+                    # Needed so that airflow_user inherits ownership of objects
+                    # created by adminuser during migrations.
+                    conn.execute(
+                        text(f"GRANT {DB_ADMIN_USERNAME} TO {DB_IAM_USERNAME}")
+                    )
+                elif current_role == DB_IAM_USERNAME:
+                    logger.info("Current role is %s", DB_IAM_USERNAME)
     except Exception as e:
         logger.warning("Error while ensuring rds iam db credentials, skipping. %s", e)
 

--- a/images/airflow/3.2.1/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.2.1/python/mwaa/database/migrate_with_downgrade.py
@@ -16,6 +16,11 @@ import os
 import sys
 
 from mwaa.config.database import get_db_connection_string
+from mwaa.config.rds_iam_credentials import (
+    RDSIAMCredentialProvider,
+    is_using_rds_proxy,
+    use_iam_credentials,
+)
 from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 from mwaa.utils.dblock import with_db_lock
 from airflow.cli.commands import db_command as airflow_db_command
@@ -54,28 +59,86 @@ def _create_engine_with_retry():
 def _ensure_rds_iam_user():
     try:
         db_engine = _create_engine_with_retry()
+
+    except Exception as e:
+        logger.warning(f"Static credential connection failed: {e}")
+
+        if use_iam_credentials() and is_using_rds_proxy():
+            @with_db_retry
+            def _connect_iam():
+                logger.info("Attempting connection with RDS IAM credentials.")
+                token = RDSIAMCredentialProvider.get_token()
+                url = RDSIAMCredentialProvider.create_db_connection_url(token)
+                engine = create_engine(url, **MAINTENANCE_ENGINE_KWARGS)
+                with engine.connect() as conn:
+                    conn.execute(text("SELECT 1"))
+                logger.info("RDS IAM connection successful.")
+                return engine
+
+            db_engine = _connect_iam()
+        else:
+            logger.warning(
+                "Error while ensuring rds iam db credentials, skipping. %s", e
+            )
+            return
+
+    try:
         with db_engine.connect() as conn:
             with conn.begin():
-                result = conn.execute(text("SELECT 1 FROM pg_roles WHERE rolname = :rolename"), {"rolename": DB_IAM_USERNAME})
+                result = conn.execute(
+                    text("SELECT 1 FROM pg_roles WHERE rolname = :rolename"),
+                    {"rolename": DB_IAM_USERNAME},
+                )
                 if not result.fetchone():
-                    print(f"Creating user '{DB_IAM_USERNAME}'")
+                    logger.info(f"Creating user '{DB_IAM_USERNAME}'")
                     conn.execute(text(f"CREATE USER {DB_IAM_USERNAME}"))
-                    print(f"Created db rds iam user")
+                    logger.info("Created db rds iam user")
                 else:
-                    print(f"db rds iam user already exists")
+                    logger.info("db rds iam user already exists")
 
                 # Always ensure permissions are up to date
                 conn.execute(text(f"GRANT rds_iam TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'))
+                conn.execute(
+                    text(
+                        f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'
+                    )
+                )
                 conn.execute(text(f"GRANT ALL ON SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"GRANT ALL ON ALL TABLES IN SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"))
+                conn.execute(
+                    text(
+                        f"GRANT ALL ON ALL TABLES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                        f"GRANT ALL ON TABLES TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                        f"GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                        f"GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"
+                    )
+                )
     except Exception as e:
-        logger.warning(f"Error while ensuring rds iam db credentials, skipping. {e}")
+        logger.warning("Error while ensuring rds iam db credentials, skipping. %s", e)
 
 
 @with_db_lock(1234)

--- a/images/airflow/3.2.1/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.2.1/python/mwaa/database/migrate_with_downgrade.py
@@ -76,7 +76,22 @@ def _ensure_rds_iam_user():
                 logger.info("RDS IAM connection successful.")
                 return engine
 
-            db_engine = _connect_iam()
+            try:
+                db_engine = _connect_iam()
+            except Exception as iam_error:
+                # Deliberate hard failure, unlike the best-effort paths in this
+                # function. Reaching here means neither the static credentials
+                # nor an RDS IAM token can open a connection, so the grants
+                # below cannot be applied and migrate-db must not continue.
+                # Raising explicitly, rather than letting _connect_iam()
+                # propagate on its own, keeps the intent unambiguous and puts a
+                # single precise error in the logs instead of surfacing later as
+                # a lock-acquisition failure in _migrate_db().
+                raise RuntimeError(
+                    "Could not connect to the metadata database with either "
+                    "static or RDS IAM credentials; unable to ensure the RDS "
+                    "IAM user."
+                ) from iam_error
         else:
             logger.warning(
                 "Error while ensuring rds iam db credentials, skipping. %s", e

--- a/images/airflow/3.2.1/python/mwaa/entrypoint.py
+++ b/images/airflow/3.2.1/python/mwaa/entrypoint.py
@@ -262,6 +262,12 @@ async def main() -> None:
     executor_type = os.environ.get("MWAA__CORE__EXECUTOR_TYPE", "CeleryExecutor")
     environ = setup_environment_variables(command, executor_type)
 
+    # Install RDS IAM credential rotation for non-migrate-db commands.
+    # migrate-db uses admin credentials for schema migrations.
+    if command != "migrate-db":
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+        install_rds_iam_patch()
+
     if command == "migrate-db":
         await airflow_db_migrate(environ)
         print("Finished running db validations")

--- a/images/airflow/3.2.1/python/mwaa/entrypoint.py
+++ b/images/airflow/3.2.1/python/mwaa/entrypoint.py
@@ -262,12 +262,6 @@ async def main() -> None:
     executor_type = os.environ.get("MWAA__CORE__EXECUTOR_TYPE", "CeleryExecutor")
     environ = setup_environment_variables(command, executor_type)
 
-    # Install RDS IAM credential rotation for non-migrate-db commands.
-    # migrate-db uses admin credentials for schema migrations.
-    if command != "migrate-db":
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-        install_rds_iam_patch()
-
     if command == "migrate-db":
         await airflow_db_migrate(environ)
         print("Finished running db validations")

--- a/images/airflow/3.2.1/python/mwaa/utils/dblock.py
+++ b/images/airflow/3.2.1/python/mwaa/utils/dblock.py
@@ -28,7 +28,19 @@ F = TypeVar("F", bound=Callable[..., Any])
 @with_db_retry
 def _connect_with_retry() -> Connection:
     """Establish a DB connection with retry on transient RDS Proxy failures."""
-    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    from mwaa.config.rds_iam_credentials import (
+        is_using_rds_proxy,
+        use_iam_credentials,
+    )
+
+    if use_iam_credentials() and is_using_rds_proxy():
+        from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+        token = RDSIAMCredentialProvider.get_token()
+        conn_url = RDSIAMCredentialProvider.create_db_connection_url(token)
+    else:
+        conn_url = get_db_connection_string()
+    engine = create_engine(conn_url, **MAINTENANCE_ENGINE_KWARGS)
     return engine.connect()
 
 

--- a/images/airflow/3.2.1/run.sh
+++ b/images/airflow/3.2.1/run.sh
@@ -73,6 +73,10 @@ MWAA__CORE__API_SERVER_URL="http://mwaa-320-webserver:8080"
 GENERATE_BILL_OF_MATERIALS="False"
 export GENERATE_BILL_OF_MATERIALS
 
+# Local Runner Indicator
+MWAA_LOCAL_RUNNER="true"
+export MWAA_LOCAL_RUNNER
+
 # MWAA Configuration
 MWAA__CORE__REQUIREMENTS_PATH="/usr/local/airflow/requirements/requirements.txt"
 MWAA__CORE__STARTUP_SCRIPT_PATH="/usr/local/airflow/startup/startup.sh"

--- a/images/airflow/3.3.0/Dockerfile.base.j2
+++ b/images/airflow/3.3.0/Dockerfile.base.j2
@@ -127,6 +127,9 @@ WORKDIR ${AIRFLOW_USER_HOME}
 # Copy python files.
 COPY ./python /python
 
+# Copy airflow_local_settings.py
+COPY ./airflow_local_settings.py ${AIRFLOW_USER_HOME}/config/airflow_local_settings.py
+
 # TODO Move this to the bin folder under airflow's home folder.
 COPY healthcheck.sh /healthcheck.sh
 RUN chmod +x /healthcheck.sh

--- a/images/airflow/3.3.0/Dockerfiles/Dockerfile.base
+++ b/images/airflow/3.3.0/Dockerfiles/Dockerfile.base
@@ -148,6 +148,9 @@ WORKDIR ${AIRFLOW_USER_HOME}
 # Copy python files.
 COPY ./python /python
 
+# Copy airflow_local_settings.py
+COPY ./airflow_local_settings.py ${AIRFLOW_USER_HOME}/config/airflow_local_settings.py
+
 # TODO Move this to the bin folder under airflow's home folder.
 COPY healthcheck.sh /healthcheck.sh
 RUN chmod +x /healthcheck.sh

--- a/images/airflow/3.3.0/airflow_local_settings.py
+++ b/images/airflow/3.3.0/airflow_local_settings.py
@@ -1,0 +1,62 @@
+"""Airflow local settings configuration for MWAA RDS IAM authentication.
+
+Airflow imports this module during ``airflow.settings.initialize()``, which runs
+unconditionally on ``import airflow``. ``airflow.settings`` appends
+``$AIRFLOW_HOME/config`` to ``sys.path`` before doing so, which is where the
+Dockerfile installs this file.
+
+This is the only correct place to install the RDS IAM credential rotation patch:
+the patch registers a SQLAlchemy ``do_connect`` listener, and that listener lives
+in the process that registered it. The Airflow components (scheduler, worker,
+api-server, dag-processor, triggerer and task runners) are spawned by the
+entrypoint as separate ``subprocess.Popen(["airflow", ...])`` children, each a
+fresh Python interpreter. Installing the patch from the entrypoint alone would
+therefore leave every process that actually talks to the metadata database
+unpatched.
+"""
+
+import importlib.util
+import logging
+import os
+
+# Airflow copies every public name of this module into the `airflow.settings`
+# namespace. Declaring an empty `__all__` keeps our internals from clobbering
+# Airflow's own globals; we export no policies or settings overrides.
+__all__: list[str] = []
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+    install_rds_iam_patch()
+except Exception as e:
+    _logger.error(f"Failed to load RDS IAM patch: {e}")
+    raise
+
+# Load ${AIRFLOW_HOME}/dags/airflow_local_settings.py and
+# ${AIRFLOW_HOME}/plugins/airflow_local_settings.py if they exist, so that
+# customer-provided local settings continue to be honoured.
+_AIRFLOW_HOME = os.environ.get("AIRFLOW_HOME", "/usr/local/airflow")
+_CUSTOMER_LOCAL_SETTINGS = [
+    (
+        "customer_dags_airflow_local_settings",
+        os.path.join(_AIRFLOW_HOME, "dags", "airflow_local_settings.py"),
+    ),
+    (
+        "customer_plugins_airflow_local_settings",
+        os.path.join(_AIRFLOW_HOME, "plugins", "airflow_local_settings.py"),
+    ),
+]
+
+for _module_name, _path in _CUSTOMER_LOCAL_SETTINGS:
+    if not os.path.exists(_path):
+        continue
+    try:
+        _spec = importlib.util.spec_from_file_location(_module_name, _path)
+        if _spec and _spec.loader:
+            _module = importlib.util.module_from_spec(_spec)
+            _spec.loader.exec_module(_module)
+    except Exception as e:
+        _logger.error(f"Failed to load airflow_local_settings from {_path}: {e}")
+        raise

--- a/images/airflow/3.3.0/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.3.0/python/mwaa/config/rds_iam_credentials.py
@@ -183,6 +183,16 @@ def use_iam_credentials() -> bool:
     return os.environ.get("USE_IAM_CREDENTIALS", "").lower() == "true"
 
 
+def is_local_runner() -> bool:
+    """Check if running in local runner mode.
+
+    RDS IAM authentication requires an ECS task metadata endpoint and an RDS
+    Proxy, neither of which exist when running the image locally, so the patch
+    must not be installed in that case.
+    """
+    return os.environ.get("MWAA_LOCAL_RUNNER", "").lower() == "true"
+
+
 def is_using_rds_proxy() -> bool:
     """Check if the environment is using RDS Proxy.
 

--- a/images/airflow/3.3.0/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.3.0/python/mwaa/config/rds_iam_credentials.py
@@ -163,6 +163,9 @@ class RDSIAMCredentialProvider:
         :returns: PostgreSQL connection URL with IAM authentication.
         """
         if token is None:
+            # NOTE: bypasses the get_token() cache, matching 2.x. No caller uses
+            # this default path today; the cache bypass is tracked for a
+            # cross-version follow-up rather than diverging from 2.x here.
             token = cls.generate_credentials()
 
         auth_token = quote_plus(token)

--- a/images/airflow/3.3.0/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.3.0/python/mwaa/config/rds_iam_credentials.py
@@ -1,0 +1,197 @@
+"""RDS IAM credential provider for MWAA.
+
+Provides IAM-based authentication tokens for RDS connections,
+with thread-safe caching and automatic refresh.
+"""
+
+import json
+import logging
+import os
+import threading
+import time
+import urllib.request
+from urllib.parse import quote_plus, urlparse
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+DB_IAM_USERNAME = "airflow_user"
+
+
+class RDSIAMCredentialProvider:
+    """Provides cached RDS IAM authentication tokens.
+
+    Tokens are generated using ECS task credentials and cached with
+    automatic refresh 5 minutes before expiration (tokens valid 15 min).
+    """
+
+    _lock = threading.Lock()
+    _token: str | None = None
+    _expires_at: float = 0
+
+    @staticmethod
+    def get_ecs_credentials() -> dict:
+        """Get AWS credentials from ECS task metadata endpoint.
+
+        Uses AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI for the credential path
+        and ECS_CONTAINER_METADATA_URI for the base URL.
+
+        :returns: AWS credentials dict with AccessKeyId, SecretAccessKey, Token.
+        :raises ValueError: If required environment variables are not set.
+        """
+        relative_uri = os.environ.get("AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI")
+        if not relative_uri:
+            raise ValueError("AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI not set")
+
+        metadata_uri = os.environ.get("ECS_CONTAINER_METADATA_URI")
+        if not metadata_uri:
+            raise ValueError("ECS_CONTAINER_METADATA_URI not set")
+
+        parsed_uri = urlparse(metadata_uri)
+        base_url = f"{parsed_uri.scheme}://{parsed_uri.netloc}"
+        credentials_url = f"{base_url}{relative_uri}"
+
+        request = urllib.request.Request(credentials_url)
+        no_proxy_handler = urllib.request.ProxyHandler({})
+        opener = urllib.request.build_opener(no_proxy_handler)
+
+        with opener.open(request) as response:
+            credentials_data = json.loads(response.read().decode("utf-8"))
+
+        return credentials_data
+
+    @staticmethod
+    def get_rds_iam_token_hostname() -> str:
+        """Get the RDS hostname for IAM token generation.
+
+        For RDS Proxy IAM authentication, tokens must be generated using
+        the direct RDS Proxy/Cluster endpoint, not VPC/NLB endpoints.
+
+        :returns: RDS hostname for token generation.
+        :raises ValueError: If RDS_IAM_TOKEN_HOSTNAME is not set.
+        """
+        token_hostname = os.environ.get("RDS_IAM_TOKEN_HOSTNAME", "").strip()
+        if token_hostname:
+            return token_hostname
+        logger.error(
+            "RDS_IAM_TOKEN_HOSTNAME not set in environment. "
+            "This should be set by the CDK stack to the RDS Cluster/Proxy endpoint."
+        )
+        raise ValueError("RDS_IAM_TOKEN_HOSTNAME environment variable is required")
+
+    @staticmethod
+    def generate_rds_auth_token(
+        credentials: dict, hostname: str, port: int, username: str
+    ) -> str:
+        """Generate RDS IAM authentication token using boto3.
+
+        :param credentials: AWS credentials from ECS task metadata.
+        :param hostname: RDS hostname for token generation.
+        :param port: Database port number.
+        :param username: Database username.
+        :returns: RDS IAM authentication token.
+        """
+        region = os.environ.get("AWS_REGION", "us-west-2")
+
+        rds_client = boto3.client(
+            "rds",
+            region_name=region,
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["Token"],
+        )
+
+        try:
+            auth_token = rds_client.generate_db_auth_token(
+                DBHostname=hostname,
+                Port=port,
+                DBUsername=username,
+            )
+            return auth_token
+        except Exception as e:
+            logger.error("Failed to generate RDS auth token: %s", e)
+            raise
+
+    @staticmethod
+    def generate_credentials() -> str:
+        """Generate fresh RDS auth token.
+
+        Orchestrates fetching ECS credentials and generating the RDS token.
+
+        :returns: RDS auth token.
+        """
+        try:
+            credentials = RDSIAMCredentialProvider.get_ecs_credentials()
+            iam_token_hostname = RDSIAMCredentialProvider.get_rds_iam_token_hostname()
+            auth_token = RDSIAMCredentialProvider.generate_rds_auth_token(
+                credentials=credentials,
+                hostname=iam_token_hostname,
+                port=int(os.environ.get("MWAA__DB__POSTGRES_PORT", "5432")),
+                username=DB_IAM_USERNAME,
+            )
+            return auth_token
+        except Exception as e:
+            logger.error("Failed to generate credentials: %s", e)
+            raise
+
+    @classmethod
+    def get_token(cls) -> str:
+        """Get cached RDS IAM token, refreshing if expired or missing.
+
+        Uses thread-safe caching with 5-minute refresh buffer before
+        the 15-minute token expiration.
+
+        :returns: Cached or freshly generated RDS auth token.
+        """
+        now = time.time()
+
+        # Refresh token in cache if missing or expires in 5 mins.
+        if cls._token is None or now > cls._expires_at - 300:
+            with cls._lock:
+                if cls._token is None or now > cls._expires_at - 300:
+                    cls._token = cls.generate_credentials()
+                    cls._expires_at = now + 15 * 60  # 15 mins
+
+        return cls._token
+
+    @classmethod
+    def create_db_connection_url(cls, token: str | None = None) -> str:
+        """Create a PostgreSQL connection URL for RDS IAM authentication.
+
+        :param token: RDS IAM auth token. If None, generates a fresh token.
+        :returns: PostgreSQL connection URL with IAM authentication.
+        """
+        if token is None:
+            token = cls.generate_credentials()
+
+        auth_token = quote_plus(token)
+        postgres_host = os.environ.get("MWAA__DB__POSTGRES_HOST", "localhost")
+        postgres_port = os.environ.get("MWAA__DB__POSTGRES_PORT", "5432")
+        postgres_db = os.environ.get("MWAA__DB__POSTGRES_DB", "AirflowMetadata")
+        ssl_mode = os.environ.get("MWAA__DB__POSTGRES_SSLMODE", "require")
+
+        return (
+            f"postgresql+psycopg2://{DB_IAM_USERNAME}:{auth_token}"
+            f"@{postgres_host}:{postgres_port}/{postgres_db}"
+            f"?sslmode={ssl_mode}"
+        )
+
+
+def use_iam_credentials() -> bool:
+    """Check if RDS IAM credentials should be used."""
+    return os.environ.get("USE_IAM_CREDENTIALS", "").lower() == "true"
+
+
+def is_using_rds_proxy() -> bool:
+    """Check if the environment is using RDS Proxy.
+
+    MWAA__DB__POSTGRES_SSLMODE is set to 'require' only for environments
+    using RDS Proxy. RDS IAM authentication is only supported when
+    connecting through RDS Proxy.
+    """
+    ssl_mode = os.environ.get("MWAA__DB__POSTGRES_SSLMODE")
+    if ssl_mode is None:
+        logger.warning("MWAA__DB__POSTGRES_SSLMODE not set in environment.")
+        return False
+    return ssl_mode == "require"

--- a/images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py
@@ -3,17 +3,27 @@
 Attaches a global listener to SQLAlchemy's Engine class that intercepts
 metadata database connections and replaces credentials with fresh IAM tokens.
 
-This module is feature-flag controlled by USE_IAM_CREDENTIALS=true,
-only activates for RDS Proxy environments, and skips the migrate-db process.
+This module is feature-flag controlled by USE_IAM_CREDENTIALS=true, only
+activates for RDS Proxy environments, and skips the migrate-db process and the
+local runner.
+
+``install_rds_iam_patch()`` is called from ``airflow_local_settings.py``, which
+Airflow imports during ``settings.initialize()`` in every Airflow process. The
+listener registered here only affects the process that registers it, so it has
+to be installed there rather than from the entrypoint, whose Airflow components
+run as separate subprocesses.
 """
 
 import logging
 import os
+from functools import cache
 
 from sqlalchemy import make_url
 
+from mwaa.config.database import get_db_connection_string
 from mwaa.config.rds_iam_credentials import (
     RDSIAMCredentialProvider,
+    is_local_runner,
     is_using_rds_proxy,
     use_iam_credentials,
 )
@@ -21,6 +31,10 @@ from mwaa.config.rds_iam_credentials import (
 logger = logging.getLogger(__name__)
 
 MWAA_AIRFLOW_COMPONENT = os.environ.get("MWAA_AIRFLOW_COMPONENT")
+
+# Set once the do_connect listener has been registered, so that installing the
+# patch more than once in the same process does not stack duplicate listeners.
+_patch_installed = False
 
 
 def _is_from_migrate_db() -> bool:
@@ -31,12 +45,25 @@ def _is_from_migrate_db() -> bool:
     return MWAA_AIRFLOW_COMPONENT == "migrate-db"
 
 
+@cache
 def _get_metadata_url():
-    """Get the parsed metadata DB URL from environment."""
-    conn_str = os.environ.get("AIRFLOW__DATABASE__SQL_ALCHEMY_CONN")
-    if not conn_str:
+    """Get the parsed metadata DB URL.
+
+    Derived from ``get_db_connection_string()`` rather than from
+    ``AIRFLOW__DATABASE__SQL_ALCHEMY_CONN``: that variable is only placed in the
+    environment dictionary handed to the Airflow subprocesses, so it is not
+    guaranteed to be present in ``os.environ`` of the process evaluating this.
+    The underlying ``MWAA__DB__*`` variables are always present.
+
+    The result is cached because this is consulted on every connection attempt.
+    """
+    try:
+        return make_url(get_db_connection_string())
+    except Exception as e:
+        # Never let this propagate into the do_connect listener: raising there
+        # would break every database connection in the process.
+        logger.error("Could not determine the metadata DB URL: %s", e)
         return None
-    return make_url(conn_str)
 
 
 def _is_accessing_metadata_db(dialect, cargs, cparams) -> bool:
@@ -80,7 +107,14 @@ def install_rds_iam_patch() -> None:
     - USE_IAM_CREDENTIALS=true
     - Environment uses RDS Proxy (MWAA__DB__POSTGRES_SSLMODE=require)
     - Current process is NOT migrate-db
+    - Current process is NOT the local runner
     """
+    global _patch_installed
+
+    if _patch_installed:
+        logger.debug("RDS IAM patch already installed in this process.")
+        return
+
     if not use_iam_credentials():
         logger.info("RDS IAM patch not installed: USE_IAM_CREDENTIALS is not true.")
         return
@@ -91,6 +125,10 @@ def install_rds_iam_patch() -> None:
 
     if _is_from_migrate_db():
         logger.info("RDS IAM patch not installed: running in migrate-db process.")
+        return
+
+    if is_local_runner():
+        logger.info("RDS IAM patch not installed: running in local runner mode.")
         return
 
     from sqlalchemy import event
@@ -108,4 +146,5 @@ def install_rds_iam_patch() -> None:
         cparams.update(url.query)
 
     event.listen(Engine, "do_connect", patch_rds_iam_authentication)
+    _patch_installed = True
     logger.info("RDS IAM authentication patch installed successfully.")

--- a/images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py
@@ -141,11 +141,17 @@ def install_rds_iam_patch() -> None:
         token = RDSIAMCredentialProvider.get_token()
         url = make_url(RDSIAMCredentialProvider.create_db_connection_url(token))
 
-        # Clear existing connection params to avoid conflicts between
-        # SQLAlchemy versions (SA 2.0 uses 'dbname' in cparams while
-        # translate_connect_args returns 'database' -- both present causes
-        # psycopg2 to raise "can't specify both 'database' and 'dbname'").
-        cparams.clear()
+        # Drop only the credential/identity keys before rebuilding from the
+        # IAM URL. SQLAlchemy 2.0's psycopg2 dialect places 'dbname' in
+        # cparams while url.translate_connect_args() returns 'database', and
+        # psycopg2 rejects a connect() call carrying both (same for
+        # 'username' vs 'user'), so both aliases of each pair are popped.
+        # Everything else in cparams is preserved: engine connect_args such
+        # as MWAA_CONNECT_ARGS' connect_timeout and keepalives* settings
+        # (wired in via AIRFLOW__DATABASE__SQL_ALCHEMY_CONNECT_ARGS) arrive
+        # through cparams and must survive the token injection.
+        for stale_key in ("dbname", "database", "username", "user", "password"):
+            cparams.pop(stale_key, None)
         cparams.update(url.translate_connect_args(username="user"))
         cparams.update(url.query)
 

--- a/images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py
@@ -1,0 +1,111 @@
+"""RDS IAM authentication patch for SQLAlchemy connections.
+
+Attaches a global listener to SQLAlchemy's Engine class that intercepts
+metadata database connections and replaces credentials with fresh IAM tokens.
+
+This module is feature-flag controlled by USE_IAM_CREDENTIALS=true,
+only activates for RDS Proxy environments, and skips the migrate-db process.
+"""
+
+import logging
+import os
+
+from sqlalchemy import make_url
+
+from mwaa.config.rds_iam_credentials import (
+    RDSIAMCredentialProvider,
+    is_using_rds_proxy,
+    use_iam_credentials,
+)
+
+logger = logging.getLogger(__name__)
+
+MWAA_AIRFLOW_COMPONENT = os.environ.get("MWAA_AIRFLOW_COMPONENT")
+
+
+def _is_from_migrate_db() -> bool:
+    """Check if the current process is the migrate-db container."""
+    if MWAA_AIRFLOW_COMPONENT is None:
+        logger.debug("MWAA_AIRFLOW_COMPONENT not set in environment.")
+        return False
+    return MWAA_AIRFLOW_COMPONENT == "migrate-db"
+
+
+def _get_metadata_url():
+    """Get the parsed metadata DB URL from environment."""
+    conn_str = os.environ.get("AIRFLOW__DATABASE__SQL_ALCHEMY_CONN")
+    if not conn_str:
+        return None
+    return make_url(conn_str)
+
+
+def _is_accessing_metadata_db(dialect, cargs, cparams) -> bool:
+    """Return True if the connection targets the Airflow metadata DB."""
+    metadata_url = _get_metadata_url()
+    if metadata_url is None:
+        return False
+
+    # Try detecting from cargs (dsn string)
+    if cargs:
+        try:
+            url_obj = make_url(cargs[0])
+            if (
+                url_obj.host == metadata_url.host
+                and url_obj.database == metadata_url.database
+                and url_obj.port == metadata_url.port
+                and url_obj.username in ["airflow_user", "adminuser"]
+            ):
+                return True
+        except Exception:
+            pass
+
+    # Try detecting from cparams (kwargs dict)
+    host = cparams.get("host")
+    db = cparams.get("dbname") or cparams.get("database")
+    port = cparams.get("port")
+    username = cparams.get("username") or cparams.get("user")
+
+    return (
+        host == metadata_url.host
+        and db == metadata_url.database
+        and port == metadata_url.port
+        and username in ["airflow_user", "adminuser"]
+    )
+
+
+def install_rds_iam_patch() -> None:
+    """Install the RDS IAM authentication patch if conditions are met.
+
+    Conditions:
+    - USE_IAM_CREDENTIALS=true
+    - Environment uses RDS Proxy (MWAA__DB__POSTGRES_SSLMODE=require)
+    - Current process is NOT migrate-db
+    """
+    if not use_iam_credentials():
+        logger.info("RDS IAM patch not installed: USE_IAM_CREDENTIALS is not true.")
+        return
+
+    if not is_using_rds_proxy():
+        logger.info("RDS IAM patch not installed: not using RDS Proxy.")
+        return
+
+    if _is_from_migrate_db():
+        logger.info("RDS IAM patch not installed: running in migrate-db process.")
+        return
+
+    from sqlalchemy import event
+    from sqlalchemy.engine import Engine
+
+    def patch_rds_iam_authentication(dialect, conn_rec, cargs, cparams):
+        """SQLAlchemy do_connect event listener that injects IAM tokens."""
+        if not _is_accessing_metadata_db(dialect, cargs, cparams):
+            return
+
+        token = RDSIAMCredentialProvider.get_token()
+        url = make_url(RDSIAMCredentialProvider.create_db_connection_url(token))
+
+        cparams.update(url.translate_connect_args(username="user"))
+        cparams.update(url.query)
+
+    event.listen(Engine, "do_connect", patch_rds_iam_authentication)
+    logger.info("RDS IAM authentication patch installed successfully.")

--- a/images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py
@@ -30,8 +30,6 @@ from mwaa.config.rds_iam_credentials import (
 
 logger = logging.getLogger(__name__)
 
-MWAA_AIRFLOW_COMPONENT = os.environ.get("MWAA_AIRFLOW_COMPONENT")
-
 # Set once the do_connect listener has been registered, so that installing the
 # patch more than once in the same process does not stack duplicate listeners.
 _patch_installed = False
@@ -39,10 +37,11 @@ _patch_installed = False
 
 def _is_from_migrate_db() -> bool:
     """Check if the current process is the migrate-db container."""
-    if MWAA_AIRFLOW_COMPONENT is None:
+    component = os.environ.get("MWAA_AIRFLOW_COMPONENT")
+    if component is None:
         logger.debug("MWAA_AIRFLOW_COMPONENT not set in environment.")
         return False
-    return MWAA_AIRFLOW_COMPONENT == "migrate-db"
+    return component == "migrate-db"
 
 
 @cache

--- a/images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py
@@ -141,6 +141,11 @@ def install_rds_iam_patch() -> None:
         token = RDSIAMCredentialProvider.get_token()
         url = make_url(RDSIAMCredentialProvider.create_db_connection_url(token))
 
+        # Clear existing connection params to avoid conflicts between
+        # SQLAlchemy versions (SA 2.0 uses 'dbname' in cparams while
+        # translate_connect_args returns 'database' -- both present causes
+        # psycopg2 to raise "can't specify both 'database' and 'dbname'").
+        cparams.clear()
         cparams.update(url.translate_connect_args(username="user"))
         cparams.update(url.query)
 

--- a/images/airflow/3.3.0/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.3.0/python/mwaa/database/migrate_with_downgrade.py
@@ -26,6 +26,7 @@ from mwaa.utils.dblock import with_db_lock
 from airflow.cli.commands import db_command as airflow_db_command
 
 DB_IAM_USERNAME = "airflow_user"
+DB_ADMIN_USERNAME = "adminuser"
 DB_NAME = "AirflowMetadata"
 
 # Usually, we pass the `__name__` variable instead as that defaults to the module path,
@@ -96,47 +97,66 @@ def _ensure_rds_iam_user():
                 else:
                     logger.info("db rds iam user already exists")
 
-                # Always ensure permissions are up to date
-                conn.execute(text(f"GRANT rds_iam TO {DB_IAM_USERNAME}"))
-                conn.execute(
-                    text(
-                        f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'
+                # Only the admin role can hand out these privileges. When this
+                # runs as airflow_user the grants would fail, so mirror the 2.x
+                # behaviour and gate them on the current role.
+                current_role = conn.execute(text("SELECT current_user")).scalar()
+
+                if current_role == DB_ADMIN_USERNAME:
+                    logger.info(
+                        "Current role is %s, setting up permissions for %s",
+                        DB_ADMIN_USERNAME,
+                        DB_IAM_USERNAME,
                     )
-                )
-                conn.execute(text(f"GRANT ALL ON SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(
-                    text(
-                        f"GRANT ALL ON ALL TABLES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    conn.execute(text(f"GRANT rds_iam TO {DB_IAM_USERNAME}"))
+                    conn.execute(
+                        text(
+                            f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'
+                        )
                     )
-                )
-                conn.execute(
-                    text(
-                        f"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(f"GRANT ALL ON SCHEMA public TO {DB_IAM_USERNAME}")
                     )
-                )
-                conn.execute(
-                    text(
-                        f"GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(
+                            f"GRANT ALL ON ALL TABLES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                        )
                     )
-                )
-                conn.execute(
-                    text(
-                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
-                        f"GRANT ALL ON TABLES TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(
+                            f"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                        )
                     )
-                )
-                conn.execute(
-                    text(
-                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
-                        f"GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(
+                            f"GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO {DB_IAM_USERNAME}"
+                        )
                     )
-                )
-                conn.execute(
-                    text(
-                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
-                        f"GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"
+                    conn.execute(
+                        text(
+                            f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                            f"GRANT ALL ON TABLES TO {DB_IAM_USERNAME}"
+                        )
                     )
-                )
+                    conn.execute(
+                        text(
+                            f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                            f"GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"
+                        )
+                    )
+                    conn.execute(
+                        text(
+                            f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                            f"GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"
+                        )
+                    )
+                    # Needed so that airflow_user inherits ownership of objects
+                    # created by adminuser during migrations.
+                    conn.execute(
+                        text(f"GRANT {DB_ADMIN_USERNAME} TO {DB_IAM_USERNAME}")
+                    )
+                elif current_role == DB_IAM_USERNAME:
+                    logger.info("Current role is %s", DB_IAM_USERNAME)
     except Exception as e:
         logger.warning("Error while ensuring rds iam db credentials, skipping. %s", e)
 

--- a/images/airflow/3.3.0/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.3.0/python/mwaa/database/migrate_with_downgrade.py
@@ -16,6 +16,11 @@ import os
 import sys
 
 from mwaa.config.database import get_db_connection_string
+from mwaa.config.rds_iam_credentials import (
+    RDSIAMCredentialProvider,
+    is_using_rds_proxy,
+    use_iam_credentials,
+)
 from mwaa.utils.db_retry import with_db_retry, MAINTENANCE_ENGINE_KWARGS
 from mwaa.utils.dblock import with_db_lock
 from airflow.cli.commands import db_command as airflow_db_command
@@ -54,28 +59,86 @@ def _create_engine_with_retry():
 def _ensure_rds_iam_user():
     try:
         db_engine = _create_engine_with_retry()
+
+    except Exception as e:
+        logger.warning(f"Static credential connection failed: {e}")
+
+        if use_iam_credentials() and is_using_rds_proxy():
+            @with_db_retry
+            def _connect_iam():
+                logger.info("Attempting connection with RDS IAM credentials.")
+                token = RDSIAMCredentialProvider.get_token()
+                url = RDSIAMCredentialProvider.create_db_connection_url(token)
+                engine = create_engine(url, **MAINTENANCE_ENGINE_KWARGS)
+                with engine.connect() as conn:
+                    conn.execute(text("SELECT 1"))
+                logger.info("RDS IAM connection successful.")
+                return engine
+
+            db_engine = _connect_iam()
+        else:
+            logger.warning(
+                "Error while ensuring rds iam db credentials, skipping. %s", e
+            )
+            return
+
+    try:
         with db_engine.connect() as conn:
             with conn.begin():
-                result = conn.execute(text("SELECT 1 FROM pg_roles WHERE rolname = :rolename"), {"rolename": DB_IAM_USERNAME})
+                result = conn.execute(
+                    text("SELECT 1 FROM pg_roles WHERE rolname = :rolename"),
+                    {"rolename": DB_IAM_USERNAME},
+                )
                 if not result.fetchone():
-                    print(f"Creating user '{DB_IAM_USERNAME}'")
+                    logger.info(f"Creating user '{DB_IAM_USERNAME}'")
                     conn.execute(text(f"CREATE USER {DB_IAM_USERNAME}"))
-                    print(f"Created db rds iam user")
+                    logger.info("Created db rds iam user")
                 else:
-                    print(f"db rds iam user already exists")
+                    logger.info("db rds iam user already exists")
 
                 # Always ensure permissions are up to date
                 conn.execute(text(f"GRANT rds_iam TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'))
+                conn.execute(
+                    text(
+                        f'GRANT ALL PRIVILEGES ON DATABASE "{DB_NAME}" TO {DB_IAM_USERNAME}'
+                    )
+                )
                 conn.execute(text(f"GRANT ALL ON SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"GRANT ALL ON ALL TABLES IN SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"))
-                conn.execute(text(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"))
+                conn.execute(
+                    text(
+                        f"GRANT ALL ON ALL TABLES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                        f"GRANT ALL ON TABLES TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                        f"GRANT ALL ON SEQUENCES TO {DB_IAM_USERNAME}"
+                    )
+                )
+                conn.execute(
+                    text(
+                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                        f"GRANT ALL ON FUNCTIONS TO {DB_IAM_USERNAME}"
+                    )
+                )
     except Exception as e:
-        logger.warning(f"Error while ensuring rds iam db credentials, skipping. {e}")
+        logger.warning("Error while ensuring rds iam db credentials, skipping. %s", e)
 
 
 @with_db_lock(1234)

--- a/images/airflow/3.3.0/python/mwaa/database/migrate_with_downgrade.py
+++ b/images/airflow/3.3.0/python/mwaa/database/migrate_with_downgrade.py
@@ -76,7 +76,22 @@ def _ensure_rds_iam_user():
                 logger.info("RDS IAM connection successful.")
                 return engine
 
-            db_engine = _connect_iam()
+            try:
+                db_engine = _connect_iam()
+            except Exception as iam_error:
+                # Deliberate hard failure, unlike the best-effort paths in this
+                # function. Reaching here means neither the static credentials
+                # nor an RDS IAM token can open a connection, so the grants
+                # below cannot be applied and migrate-db must not continue.
+                # Raising explicitly, rather than letting _connect_iam()
+                # propagate on its own, keeps the intent unambiguous and puts a
+                # single precise error in the logs instead of surfacing later as
+                # a lock-acquisition failure in _migrate_db().
+                raise RuntimeError(
+                    "Could not connect to the metadata database with either "
+                    "static or RDS IAM credentials; unable to ensure the RDS "
+                    "IAM user."
+                ) from iam_error
         else:
             logger.warning(
                 "Error while ensuring rds iam db credentials, skipping. %s", e

--- a/images/airflow/3.3.0/python/mwaa/entrypoint.py
+++ b/images/airflow/3.3.0/python/mwaa/entrypoint.py
@@ -261,12 +261,6 @@ async def main() -> None:
     executor_type = os.environ.get("MWAA__CORE__EXECUTOR_TYPE", "CeleryExecutor")
     environ = setup_environment_variables(command, executor_type)
 
-    # Install RDS IAM credential rotation for non-migrate-db commands.
-    # migrate-db uses admin credentials for schema migrations.
-    if command != "migrate-db":
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-        install_rds_iam_patch()
-
     if command == "migrate-db":
         await airflow_db_migrate(environ)
         print("Finished running db validations")

--- a/images/airflow/3.3.0/python/mwaa/entrypoint.py
+++ b/images/airflow/3.3.0/python/mwaa/entrypoint.py
@@ -261,6 +261,12 @@ async def main() -> None:
     executor_type = os.environ.get("MWAA__CORE__EXECUTOR_TYPE", "CeleryExecutor")
     environ = setup_environment_variables(command, executor_type)
 
+    # Install RDS IAM credential rotation for non-migrate-db commands.
+    # migrate-db uses admin credentials for schema migrations.
+    if command != "migrate-db":
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+        install_rds_iam_patch()
+
     if command == "migrate-db":
         await airflow_db_migrate(environ)
         print("Finished running db validations")

--- a/images/airflow/3.3.0/python/mwaa/utils/dblock.py
+++ b/images/airflow/3.3.0/python/mwaa/utils/dblock.py
@@ -28,7 +28,19 @@ F = TypeVar("F", bound=Callable[..., Any])
 @with_db_retry
 def _connect_with_retry() -> Connection:
     """Establish a DB connection with retry on transient RDS Proxy failures."""
-    engine = create_engine(get_db_connection_string(), **MAINTENANCE_ENGINE_KWARGS)
+    from mwaa.config.rds_iam_credentials import (
+        is_using_rds_proxy,
+        use_iam_credentials,
+    )
+
+    if use_iam_credentials() and is_using_rds_proxy():
+        from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+        token = RDSIAMCredentialProvider.get_token()
+        conn_url = RDSIAMCredentialProvider.create_db_connection_url(token)
+    else:
+        conn_url = get_db_connection_string()
+    engine = create_engine(conn_url, **MAINTENANCE_ENGINE_KWARGS)
     return engine.connect()
 
 

--- a/images/airflow/3.3.0/run.sh
+++ b/images/airflow/3.3.0/run.sh
@@ -73,6 +73,10 @@ MWAA__CORE__API_SERVER_URL="http://mwaa-330-webserver:8080"
 GENERATE_BILL_OF_MATERIALS="False"
 export GENERATE_BILL_OF_MATERIALS
 
+# Local Runner Indicator
+MWAA_LOCAL_RUNNER="true"
+export MWAA_LOCAL_RUNNER
+
 # MWAA Configuration
 MWAA__CORE__REQUIREMENTS_PATH="/usr/local/airflow/requirements/requirements.txt"
 MWAA__CORE__STARTUP_SCRIPT_PATH="/usr/local/airflow/startup/startup.sh"

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_credentials_3_0_6.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_credentials_3_0_6.py
@@ -1,0 +1,290 @@
+import pytest
+import json
+import time
+from unittest.mock import patch, MagicMock
+
+
+def test_get_ecs_credentials_success():
+    """Test successful ECS credentials retrieval"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "test_key",
+        "SecretAccessKey": "test_secret",
+        "Token": "test_token",
+    }
+
+    with patch.dict(
+        "os.environ",
+        {
+            "AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/test",
+            "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/containers/test",
+        },
+    ), patch("urllib.request.build_opener") as mock_build_opener:
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(mock_credentials).encode("utf-8")
+
+        mock_opener = MagicMock()
+        mock_opener.open.return_value.__enter__.return_value = mock_response
+        mock_build_opener.return_value = mock_opener
+
+        result = RDSIAMCredentialProvider.get_ecs_credentials()
+        assert result == mock_credentials
+
+
+def test_get_ecs_credentials_missing_env():
+    """Test ECS credentials with missing environment variables"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(
+            ValueError, match="AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI not set"
+        ):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+
+
+def test_get_ecs_credentials_missing_metadata_uri():
+    """Test ECS credentials with missing ECS_CONTAINER_METADATA_URI"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict(
+        "os.environ",
+        {"AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/test"},
+        clear=True,
+    ):
+        with pytest.raises(ValueError, match="ECS_CONTAINER_METADATA_URI not set"):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+
+
+def test_get_ecs_credentials_ignores_proxy_env_vars():
+    """Test that proxy environment variables don't affect ECS metadata requests"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "test_key",
+        "SecretAccessKey": "test_secret",
+        "Token": "test_token",
+    }
+
+    with patch.dict(
+        "os.environ",
+        {
+            "AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/test",
+            "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/containers/test",
+            "HTTP_PROXY": "http://should-not-be-used:8080",
+            "HTTPS_PROXY": "http://should-not-be-used:8080",
+        },
+    ), patch("urllib.request.build_opener") as mock_build_opener, patch(
+        "urllib.request.ProxyHandler"
+    ) as mock_proxy_handler:
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(mock_credentials).encode("utf-8")
+
+        mock_opener = MagicMock()
+        mock_opener.open.return_value.__enter__.return_value = mock_response
+        mock_build_opener.return_value = mock_opener
+
+        result = RDSIAMCredentialProvider.get_ecs_credentials()
+
+        mock_proxy_handler.assert_called_once_with({})
+        mock_build_opener.assert_called_once()
+        assert result == mock_credentials
+
+
+def test_get_rds_iam_token_hostname_success():
+    """Test successful RDS IAM token hostname retrieval"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict("os.environ", {"RDS_IAM_TOKEN_HOSTNAME": "test.rds.amazonaws.com"}):
+        result = RDSIAMCredentialProvider.get_rds_iam_token_hostname()
+        assert result == "test.rds.amazonaws.com"
+
+
+def test_get_rds_iam_token_hostname_missing():
+    """Test RDS IAM token hostname with missing environment variable"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(
+            ValueError,
+            match="RDS_IAM_TOKEN_HOSTNAME environment variable is required",
+        ):
+            RDSIAMCredentialProvider.get_rds_iam_token_hostname()
+
+
+def test_generate_rds_auth_token():
+    """Test RDS auth token generation"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "test_key",
+        "SecretAccessKey": "test_secret",
+        "Token": "test_token",
+    }
+
+    with patch("boto3.client") as mock_boto3:
+        mock_rds_client = MagicMock()
+        mock_rds_client.generate_db_auth_token.return_value = "test_auth_token"
+        mock_boto3.return_value = mock_rds_client
+
+        result = RDSIAMCredentialProvider.generate_rds_auth_token(
+            mock_credentials, "test.rds.amazonaws.com", 5432, "airflow_user"
+        )
+
+        assert result == "test_auth_token"
+        mock_rds_client.generate_db_auth_token.assert_called_once()
+
+
+def test_generate_rds_auth_token_failure():
+    """Test RDS auth token generation failure"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "test_key",
+        "SecretAccessKey": "test_secret",
+        "Token": "test_token",
+    }
+
+    with patch("boto3.client") as mock_boto3:
+        mock_rds_client = MagicMock()
+        mock_rds_client.generate_db_auth_token.side_effect = Exception(
+            "Token generation failed"
+        )
+        mock_boto3.return_value = mock_rds_client
+
+        with pytest.raises(Exception, match="Token generation failed"):
+            RDSIAMCredentialProvider.generate_rds_auth_token(
+                mock_credentials, "test.rds.amazonaws.com", 5432, "airflow_user"
+            )
+
+
+def test_get_token_cached():
+    """Test cached token retrieval"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    RDSIAMCredentialProvider._token = "cached_token"
+    RDSIAMCredentialProvider._expires_at = time.time() + 600
+
+    result = RDSIAMCredentialProvider.get_token()
+    assert result == "cached_token"
+
+
+def test_get_token_refresh_needed():
+    """Test token refresh when expired"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    RDSIAMCredentialProvider._token = "old_token"
+    RDSIAMCredentialProvider._expires_at = time.time() - 100
+
+    with patch.object(
+        RDSIAMCredentialProvider, "generate_credentials", return_value="new_token"
+    ):
+        result = RDSIAMCredentialProvider.get_token()
+        assert result == "new_token"
+        assert RDSIAMCredentialProvider._token == "new_token"
+
+
+def test_generate_credentials_success():
+    """Test successful credential generation"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "key",
+        "SecretAccessKey": "secret",
+        "Token": "token",
+    }
+
+    with patch.object(
+        RDSIAMCredentialProvider, "get_ecs_credentials", return_value=mock_credentials
+    ), patch.object(
+        RDSIAMCredentialProvider,
+        "get_rds_iam_token_hostname",
+        return_value="test.rds.amazonaws.com",
+    ), patch.object(
+        RDSIAMCredentialProvider, "generate_rds_auth_token", return_value="auth_token"
+    ):
+        result = RDSIAMCredentialProvider.generate_credentials()
+        assert result == "auth_token"
+
+
+def test_generate_credentials_failure():
+    """Test credential generation failure"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.object(
+        RDSIAMCredentialProvider,
+        "get_ecs_credentials",
+        side_effect=Exception("ECS error"),
+    ):
+        with pytest.raises(Exception, match="ECS error"):
+            RDSIAMCredentialProvider.generate_credentials()
+
+
+def test_create_db_connection_url():
+    """Test database connection URL creation"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict(
+        "os.environ",
+        {
+            "MWAA__DB__POSTGRES_HOST": "test.rds.amazonaws.com",
+            "MWAA__DB__POSTGRES_PORT": "5432",
+            "MWAA__DB__POSTGRES_DB": "airflow",
+            "MWAA__DB__POSTGRES_SSLMODE": "require",
+        },
+    ):
+        result = RDSIAMCredentialProvider.create_db_connection_url("test_token")
+        assert (
+            "postgresql+psycopg2://airflow_user:test_token"
+            "@test.rds.amazonaws.com:5432/airflow?sslmode=require" in result
+        )
+
+
+def test_create_db_connection_url_generate_token():
+    """Test database connection URL creation with token generation"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict(
+        "os.environ",
+        {
+            "MWAA__DB__POSTGRES_HOST": "test.rds.amazonaws.com",
+            "MWAA__DB__POSTGRES_PORT": "5432",
+            "MWAA__DB__POSTGRES_DB": "airflow",
+            "MWAA__DB__POSTGRES_SSLMODE": "require",
+        },
+    ), patch.object(
+        RDSIAMCredentialProvider, "generate_credentials", return_value="generated_token"
+    ):
+        result = RDSIAMCredentialProvider.create_db_connection_url()
+        assert (
+            "postgresql+psycopg2://airflow_user:generated_token"
+            "@test.rds.amazonaws.com:5432/airflow?sslmode=require" in result
+        )
+
+
+def test_use_iam_credentials():
+    """Test IAM credentials flag detection"""
+    from mwaa.config.rds_iam_credentials import use_iam_credentials
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "true"}):
+        assert use_iam_credentials() is True
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}):
+        assert use_iam_credentials() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert use_iam_credentials() is False
+
+
+def test_is_using_rds_proxy():
+    """Test RDS proxy detection"""
+    from mwaa.config.rds_iam_credentials import is_using_rds_proxy
+
+    with patch.dict("os.environ", {"MWAA__DB__POSTGRES_SSLMODE": "require"}):
+        assert is_using_rds_proxy() is True
+
+    with patch.dict("os.environ", {"MWAA__DB__POSTGRES_SSLMODE": "disable"}):
+        assert is_using_rds_proxy() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert is_using_rds_proxy() is False

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py
@@ -144,11 +144,11 @@ def test_install_rds_iam_patch_not_installed_no_iam():
     """Test patch not installed when USE_IAM_CREDENTIALS is not true"""
     from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
-    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}, clear=True), patch(
-        "sqlalchemy.event.listen"
-    ) as mock_listen:
-        install_rds_iam_patch()
-        mock_listen.assert_not_called()
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}, clear=True):
+        _reset_patch_state()
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_not_called()
 
 
 def test_install_rds_iam_patch_not_installed_no_rds_proxy():
@@ -158,9 +158,11 @@ def test_install_rds_iam_patch_not_installed_no_rds_proxy():
     with patch.dict(
         "os.environ",
         {"USE_IAM_CREDENTIALS": "true", "MWAA__DB__POSTGRES_SSLMODE": "disable"},
-    ), patch("sqlalchemy.event.listen") as mock_listen:
-        install_rds_iam_patch()
-        mock_listen.assert_not_called()
+    ):
+        _reset_patch_state()
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_not_called()
 
 
 def test_install_rds_iam_patch_not_installed_migrate_db():
@@ -469,7 +471,9 @@ def test_do_connect_listener_injects_the_token():
         "dbname": "AirflowMetadata",
         "port": 5432,
         "user": "airflow_user",
-        "stale": "should be cleared",
+        # Engine connect_args (MWAA_CONNECT_ARGS) arrive via cparams.
+        "connect_timeout": 15,
+        "keepalives": 1,
     }
 
     with patch.dict("os.environ", env, clear=True), patch.object(
@@ -480,12 +484,16 @@ def test_do_connect_listener_injects_the_token():
         _clear_metadata_url_cache(m)
         captured["fn"]("postgresql", None, [], cparams)
 
-    # cparams was rebuilt from the IAM URL, and the pre-existing key is gone.
-    assert "stale" not in cparams
+    # Credentials were rebuilt from the IAM URL.
     assert cparams["password"] == "tok"
     assert cparams["host"] == "proxy.rds.amazonaws.com"
     # 'dbname'/'database' must not both be present (psycopg2 rejects that).
     assert not ("dbname" in cparams and "database" in cparams)
+    # Engine connect_args that arrive via cparams (connect_timeout and the
+    # keepalives* settings from MWAA_CONNECT_ARGS) must survive the token
+    # injection; only the aliased credential keys are replaced.
+    assert cparams["connect_timeout"] == 15
+    assert cparams["keepalives"] == 1
 
 
 def test_do_connect_listener_ignores_other_databases():

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py
@@ -1,0 +1,206 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def test_is_from_migrate_db():
+    """Test migrate-db detection"""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict("os.environ", {"MWAA_AIRFLOW_COMPONENT": "migrate-db"}):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import _is_from_migrate_db
+
+        assert _is_from_migrate_db() is True
+
+    with patch.dict("os.environ", {"MWAA_AIRFLOW_COMPONENT": "scheduler"}):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import _is_from_migrate_db
+
+        assert _is_from_migrate_db() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import _is_from_migrate_db
+
+        assert _is_from_migrate_db() is False
+
+
+def test_is_using_rds_proxy():
+    """Test RDS proxy detection via is_using_rds_proxy helper"""
+    from mwaa.config.rds_iam_credentials import is_using_rds_proxy
+
+    with patch.dict("os.environ", {"MWAA__DB__POSTGRES_SSLMODE": "require"}):
+        assert is_using_rds_proxy() is True
+
+    with patch.dict("os.environ", {"MWAA__DB__POSTGRES_SSLMODE": "disable"}):
+        assert is_using_rds_proxy() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert is_using_rds_proxy() is False
+
+
+def test_use_iam_credentials():
+    """Test IAM credentials flag detection"""
+    from mwaa.config.rds_iam_credentials import use_iam_credentials
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "true"}):
+        assert use_iam_credentials() is True
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}):
+        assert use_iam_credentials() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert use_iam_credentials() is False
+
+
+def test_is_accessing_metadata_db():
+    """Test metadata database detection"""
+    from mwaa.config.rds_iam_patch import _is_accessing_metadata_db
+
+    with patch(
+        "mwaa.config.rds_iam_patch._get_metadata_url"
+    ) as mock_get_url:
+        mock_url = MagicMock()
+        mock_url.host = "test.rds.amazonaws.com"
+        mock_url.database = "airflow"
+        mock_url.port = 5432
+        mock_get_url.return_value = mock_url
+
+        # Test with matching parameters including username
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "database": "airflow",
+            "port": 5432,
+            "username": "airflow_user",
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is True
+
+        # Test with adminuser username
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "database": "airflow",
+            "port": 5432,
+            "username": "adminuser",
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is True
+
+        # Test with non-matching parameters
+        cparams = {
+            "host": "other.rds.amazonaws.com",
+            "database": "other",
+            "port": 3306,
+            "username": "airflow_user",
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is False
+
+        # Test with missing username
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "database": "airflow",
+            "port": 5432,
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is False
+
+
+def test_is_accessing_metadata_db_with_cargs():
+    """Test metadata database detection using cargs"""
+    from mwaa.config.rds_iam_patch import _is_accessing_metadata_db
+
+    with patch(
+        "mwaa.config.rds_iam_patch._get_metadata_url"
+    ) as mock_get_url:
+        mock_url = MagicMock()
+        mock_url.host = "test.rds.amazonaws.com"
+        mock_url.database = "airflow"
+        mock_url.port = 5432
+        mock_get_url.return_value = mock_url
+
+        # Test with matching cargs including airflow_user
+        cargs = ["postgresql://airflow_user:pass@test.rds.amazonaws.com:5432/airflow"]
+        assert _is_accessing_metadata_db("postgresql", cargs, {}) is True
+
+        # Test with matching cargs including adminuser
+        cargs = ["postgresql://adminuser:pass@test.rds.amazonaws.com:5432/airflow"]
+        assert _is_accessing_metadata_db("postgresql", cargs, {}) is True
+
+
+def test_is_accessing_metadata_db_no_conn_str():
+    """Test metadata database detection when no connection string is set"""
+    from mwaa.config.rds_iam_patch import _is_accessing_metadata_db
+
+    with patch(
+        "mwaa.config.rds_iam_patch._get_metadata_url", return_value=None
+    ):
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "database": "airflow",
+            "port": 5432,
+            "username": "airflow_user",
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is False
+
+
+def test_install_rds_iam_patch_not_installed_no_iam():
+    """Test patch not installed when USE_IAM_CREDENTIALS is not true"""
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}, clear=True), patch(
+        "sqlalchemy.event.listen"
+    ) as mock_listen:
+        install_rds_iam_patch()
+        mock_listen.assert_not_called()
+
+
+def test_install_rds_iam_patch_not_installed_no_rds_proxy():
+    """Test patch not installed when not using RDS Proxy"""
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+    with patch.dict(
+        "os.environ",
+        {"USE_IAM_CREDENTIALS": "true", "MWAA__DB__POSTGRES_SSLMODE": "disable"},
+    ), patch("sqlalchemy.event.listen") as mock_listen:
+        install_rds_iam_patch()
+        mock_listen.assert_not_called()
+
+
+def test_install_rds_iam_patch_not_installed_migrate_db():
+    """Test patch not installed for migrate-db process"""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict(
+        "os.environ",
+        {
+            "USE_IAM_CREDENTIALS": "true",
+            "MWAA__DB__POSTGRES_SSLMODE": "require",
+            "MWAA_AIRFLOW_COMPONENT": "migrate-db",
+        },
+    ):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_not_called()
+
+
+def test_install_rds_iam_patch_installed():
+    """Test patch installed when all conditions are met"""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict(
+        "os.environ",
+        {
+            "USE_IAM_CREDENTIALS": "true",
+            "MWAA__DB__POSTGRES_SSLMODE": "require",
+            "MWAA_AIRFLOW_COMPONENT": "scheduler",
+        },
+    ):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_called_once()

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py
@@ -204,3 +204,147 @@ def test_install_rds_iam_patch_installed():
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             mock_listen.assert_called_once()
+
+
+def _clear_metadata_url_cache(module=None):
+    """Clear the cached metadata URL, tolerating an uncached implementation."""
+    if module is None:
+        from mwaa.config import rds_iam_patch as module
+    getattr(module._get_metadata_url, "cache_clear", lambda: None)()
+
+
+# --- Regression tests for the aspects restored from the 2.x implementation ---
+
+# Environment describing a metadata DB reachable through an RDS Proxy. Note the
+# deliberate absence of AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: that variable is
+# only injected into the environment dict handed to the Airflow subprocesses, so
+# code running in-process must not depend on it.
+_RDS_PROXY_ENV = {
+    "USE_IAM_CREDENTIALS": "true",
+    "MWAA__DB__POSTGRES_HOST": "test.rds.amazonaws.com",
+    "MWAA__DB__POSTGRES_PORT": "5432",
+    "MWAA__DB__POSTGRES_DB": "AirflowMetadata",
+    "MWAA__DB__POSTGRES_SSLMODE": "require",
+    "MWAA__DB__CREDENTIALS": '{"username": "airflow_user", "password": "pw"}',
+    "MWAA_AIRFLOW_COMPONENT": "scheduler",
+}
+
+
+def test_get_metadata_url_derived_from_mwaa_db_env_vars():
+    """The metadata URL must come from MWAA__DB__*, not from the Airflow conn var.
+
+    Regression test: sourcing it from AIRFLOW__DATABASE__SQL_ALCHEMY_CONN made
+    _get_metadata_url() return None in every process, which silently disabled
+    token injection.
+    """
+    from mwaa.config.rds_iam_patch import _get_metadata_url
+
+    with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
+        _clear_metadata_url_cache()
+        try:
+            url = _get_metadata_url()
+            assert url is not None
+            assert url.host == "test.rds.amazonaws.com"
+            assert url.database == "AirflowMetadata"
+            assert url.port == 5432
+        finally:
+            _clear_metadata_url_cache()
+
+
+def test_get_metadata_url_returns_none_on_missing_config():
+    """A misconfigured environment must not raise into the do_connect listener."""
+    from mwaa.config.rds_iam_patch import _get_metadata_url
+
+    with patch.dict("os.environ", {}, clear=True):
+        _clear_metadata_url_cache()
+        try:
+            assert _get_metadata_url() is None
+        finally:
+            _clear_metadata_url_cache()
+
+
+def test_end_to_end_metadata_db_detected_without_airflow_conn_var():
+    """The patch must recognise the metadata DB using only MWAA__DB__* vars."""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        _clear_metadata_url_cache(mwaa.config.rds_iam_patch)
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "dbname": "AirflowMetadata",
+            "port": 5432,
+            "user": "airflow_user",
+        }
+        assert (
+            mwaa.config.rds_iam_patch._is_accessing_metadata_db(
+                "postgresql", [], cparams
+            )
+            is True
+        )
+
+
+def test_install_rds_iam_patch_not_installed_local_runner():
+    """Test patch not installed when running as the local runner."""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict(
+        "os.environ", {**_RDS_PROXY_ENV, "MWAA_LOCAL_RUNNER": "true"}, clear=True
+    ):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_not_called()
+
+
+def test_install_rds_iam_patch_is_idempotent():
+    """Installing twice in one process must register only one listener."""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            install_rds_iam_patch()
+            install_rds_iam_patch()
+            mock_listen.assert_called_once()
+
+
+def test_airflow_local_settings_installs_the_patch():
+    """airflow_local_settings.py is the hook Airflow loads in every process.
+
+    Regression test for the dropped override: without this file the do_connect
+    listener is never registered in the scheduler/worker/api-server processes,
+    which are separate Popen children of the entrypoint.
+    """
+    import importlib.util
+    import os
+
+    settings_path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..", "..", "..", "..", "..", "..", "..",
+            "images", "airflow", "3.0.6", "airflow_local_settings.py",
+        )
+    )
+    assert os.path.exists(settings_path), f"missing override: {settings_path}"
+
+    with patch(
+        "mwaa.config.rds_iam_patch.install_rds_iam_patch"
+    ) as mock_install:
+        spec = importlib.util.spec_from_file_location(
+            "mwaa_test_airflow_local_settings", settings_path
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        mock_install.assert_called_once()
+
+    # Must not leak names into the airflow.settings namespace.
+    assert module.__all__ == []

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py
@@ -2,27 +2,26 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 
+def _reset_patch_state():
+    """Reset the one-shot install flag so a test can install the patch again."""
+    from mwaa.config import rds_iam_patch
+
+    rds_iam_patch._patch_installed = False
+    getattr(rds_iam_patch._get_metadata_url, "cache_clear", lambda: None)()
+
+
+
 def test_is_from_migrate_db():
     """Test migrate-db detection"""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import _is_from_migrate_db
 
     with patch.dict("os.environ", {"MWAA_AIRFLOW_COMPONENT": "migrate-db"}):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import _is_from_migrate_db
-
         assert _is_from_migrate_db() is True
 
     with patch.dict("os.environ", {"MWAA_AIRFLOW_COMPONENT": "scheduler"}):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import _is_from_migrate_db
-
         assert _is_from_migrate_db() is False
 
     with patch.dict("os.environ", {}, clear=True):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import _is_from_migrate_db
-
         assert _is_from_migrate_db() is False
 
 
@@ -166,8 +165,7 @@ def test_install_rds_iam_patch_not_installed_no_rds_proxy():
 
 def test_install_rds_iam_patch_not_installed_migrate_db():
     """Test patch not installed for migrate-db process"""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
     with patch.dict(
         "os.environ",
@@ -177,9 +175,7 @@ def test_install_rds_iam_patch_not_installed_migrate_db():
             "MWAA_AIRFLOW_COMPONENT": "migrate-db",
         },
     ):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-
+        _reset_patch_state()
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             mock_listen.assert_not_called()
@@ -187,8 +183,7 @@ def test_install_rds_iam_patch_not_installed_migrate_db():
 
 def test_install_rds_iam_patch_installed():
     """Test patch installed when all conditions are met"""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
     with patch.dict(
         "os.environ",
@@ -198,9 +193,7 @@ def test_install_rds_iam_patch_installed():
             "MWAA_AIRFLOW_COMPONENT": "scheduler",
         },
     ):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-
+        _reset_patch_state()
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             mock_listen.assert_called_once()
@@ -265,11 +258,9 @@ def test_get_metadata_url_returns_none_on_missing_config():
 
 def test_end_to_end_metadata_db_detected_without_airflow_conn_var():
     """The patch must recognise the metadata DB using only MWAA__DB__* vars."""
-    import importlib
     import mwaa.config.rds_iam_patch
 
     with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
-        importlib.reload(mwaa.config.rds_iam_patch)
         _clear_metadata_url_cache(mwaa.config.rds_iam_patch)
         cparams = {
             "host": "test.rds.amazonaws.com",
@@ -287,15 +278,12 @@ def test_end_to_end_metadata_db_detected_without_airflow_conn_var():
 
 def test_install_rds_iam_patch_not_installed_local_runner():
     """Test patch not installed when running as the local runner."""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
     with patch.dict(
         "os.environ", {**_RDS_PROXY_ENV, "MWAA_LOCAL_RUNNER": "true"}, clear=True
     ):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-
+        _reset_patch_state()
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             mock_listen.assert_not_called()
@@ -303,13 +291,10 @@ def test_install_rds_iam_patch_not_installed_local_runner():
 
 def test_install_rds_iam_patch_is_idempotent():
     """Installing twice in one process must register only one listener."""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
     with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-
+        _reset_patch_state()
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             install_rds_iam_patch()

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py
@@ -333,3 +333,240 @@ def test_airflow_local_settings_installs_the_patch():
 
     # Must not leak names into the airflow.settings namespace.
     assert module.__all__ == []
+
+
+# --- Coverage for the customer-settings loading and the listener body ---
+
+_LS_VERSION = "3.0.6"
+
+
+def _local_settings_file():
+    import os
+
+    path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..", "..", "..", "..", "..", "..", "..",
+            "images", "airflow", _LS_VERSION, "airflow_local_settings.py",
+        )
+    )
+    assert os.path.exists(path), f"missing override: {path}"
+    return path
+
+
+def _exec_local_settings(airflow_home=None):
+    """Execute the shipped airflow_local_settings.py with the patch stubbed out."""
+    import importlib.util
+
+    env = {"AIRFLOW_HOME": airflow_home} if airflow_home else {}
+    with patch.dict("os.environ", env), patch(
+        "mwaa.config.rds_iam_patch.install_rds_iam_patch"
+    ):
+        spec = importlib.util.spec_from_file_location(
+            "mwaa_test_local_settings_cov", _local_settings_file()
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+def _write_customer_file(home, subdir, body):
+    import os
+
+    os.makedirs(os.path.join(home, subdir), exist_ok=True)
+    with open(os.path.join(home, subdir, "airflow_local_settings.py"), "w") as f:
+        f.write(body)
+
+
+def test_customer_settings_in_dags_are_executed(tmp_path):
+    """A customer file in dags/ must be loaded, so its side effects apply."""
+    marker = tmp_path / "dags_ran"
+    _write_customer_file(
+        str(tmp_path),
+        "dags",
+        f"open({str(marker)!r}, 'w').write('ran')\n",
+    )
+
+    _exec_local_settings(str(tmp_path))
+
+    assert marker.exists(), "dags/airflow_local_settings.py was not executed"
+
+
+def test_customer_settings_in_plugins_are_executed(tmp_path):
+    """A customer file in plugins/ must be loaded too."""
+    marker = tmp_path / "plugins_ran"
+    _write_customer_file(
+        str(tmp_path),
+        "plugins",
+        f"open({str(marker)!r}, 'w').write('ran')\n",
+    )
+
+    _exec_local_settings(str(tmp_path))
+
+    assert marker.exists(), "plugins/airflow_local_settings.py was not executed"
+
+
+def test_broken_customer_settings_propagate(tmp_path):
+    """A customer file that fails to load must surface, not be swallowed.
+
+    Matches what Airflow does natively when a local settings file raises.
+    """
+    _write_customer_file(str(tmp_path), "plugins", "raise ValueError('customer bug')\n")
+
+    with pytest.raises(ValueError, match="customer bug"):
+        _exec_local_settings(str(tmp_path))
+
+
+def test_patch_install_failure_propagates():
+    """A failure installing the RDS IAM patch must not be silently ignored."""
+    import importlib.util
+
+    with patch(
+        "mwaa.config.rds_iam_patch.install_rds_iam_patch",
+        side_effect=RuntimeError("patch install blew up"),
+    ):
+        spec = importlib.util.spec_from_file_location(
+            "mwaa_test_local_settings_fail", _local_settings_file()
+        )
+        module = importlib.util.module_from_spec(spec)
+        with pytest.raises(RuntimeError, match="patch install blew up"):
+            spec.loader.exec_module(module)
+
+
+def test_do_connect_listener_injects_the_token():
+    """Exercise the registered listener body, not just its registration."""
+    from mwaa.config import rds_iam_patch as m
+
+    captured = {}
+
+    def fake_listen(target, name, fn):
+        captured["fn"] = fn
+
+    env = {
+        "USE_IAM_CREDENTIALS": "true",
+        "MWAA__DB__POSTGRES_HOST": "proxy.rds.amazonaws.com",
+        "MWAA__DB__POSTGRES_PORT": "5432",
+        "MWAA__DB__POSTGRES_DB": "AirflowMetadata",
+        "MWAA__DB__POSTGRES_SSLMODE": "require",
+        "MWAA__DB__CREDENTIALS": '{"username": "airflow_user", "password": "pw"}',
+        "MWAA_AIRFLOW_COMPONENT": "scheduler",
+    }
+
+    with patch.dict("os.environ", env, clear=True), patch(
+        "sqlalchemy.event.listen", side_effect=fake_listen
+    ):
+        _reset_patch_state()
+        m.install_rds_iam_patch()
+
+    assert "fn" in captured, "listener was not registered"
+
+    token_url = (
+        "postgresql+psycopg2://airflow_user:tok"
+        "@proxy.rds.amazonaws.com:5432/AirflowMetadata?sslmode=require"
+    )
+    cparams = {
+        "host": "proxy.rds.amazonaws.com",
+        "dbname": "AirflowMetadata",
+        "port": 5432,
+        "user": "airflow_user",
+        "stale": "should be cleared",
+    }
+
+    with patch.dict("os.environ", env, clear=True), patch.object(
+        m.RDSIAMCredentialProvider, "get_token", return_value="tok"
+    ), patch.object(
+        m.RDSIAMCredentialProvider, "create_db_connection_url", return_value=token_url
+    ):
+        _clear_metadata_url_cache(m)
+        captured["fn"]("postgresql", None, [], cparams)
+
+    # cparams was rebuilt from the IAM URL, and the pre-existing key is gone.
+    assert "stale" not in cparams
+    assert cparams["password"] == "tok"
+    assert cparams["host"] == "proxy.rds.amazonaws.com"
+    # 'dbname'/'database' must not both be present (psycopg2 rejects that).
+    assert not ("dbname" in cparams and "database" in cparams)
+
+
+def test_do_connect_listener_ignores_other_databases():
+    """Connections that are not the metadata DB must be left untouched."""
+    from mwaa.config import rds_iam_patch as m
+
+    captured = {}
+    env = {
+        "USE_IAM_CREDENTIALS": "true",
+        "MWAA__DB__POSTGRES_HOST": "proxy.rds.amazonaws.com",
+        "MWAA__DB__POSTGRES_PORT": "5432",
+        "MWAA__DB__POSTGRES_DB": "AirflowMetadata",
+        "MWAA__DB__POSTGRES_SSLMODE": "require",
+        "MWAA__DB__CREDENTIALS": '{"username": "airflow_user", "password": "pw"}',
+        "MWAA_AIRFLOW_COMPONENT": "scheduler",
+    }
+
+    with patch.dict("os.environ", env, clear=True), patch(
+        "sqlalchemy.event.listen", side_effect=lambda t, n, fn: captured.update(fn=fn)
+    ):
+        _reset_patch_state()
+        m.install_rds_iam_patch()
+
+    other = {"host": "someone-elses-db", "dbname": "other", "port": 5432, "user": "x"}
+    before = dict(other)
+
+    with patch.dict("os.environ", env, clear=True), patch.object(
+        m.RDSIAMCredentialProvider, "get_token"
+    ) as get_token:
+        _clear_metadata_url_cache(m)
+        captured["fn"]("postgresql", None, [], other)
+        get_token.assert_not_called()
+
+    assert other == before
+
+
+def test_metadata_detection_tolerates_unparseable_cargs():
+    """A malformed DSN in cargs must not raise out of the listener."""
+    from mwaa.config import rds_iam_patch as m
+
+    with patch.object(m, "_get_metadata_url") as mock_url:
+        mock_url.return_value = MagicMock(
+            host="h", database="d", port=5432, username="airflow_user"
+        )
+        # Not a URL at all; the cargs branch must swallow the parse error and
+        # fall through to the cparams check.
+        assert m._is_accessing_metadata_db("postgresql", ["not-a-dsn"], {}) is False
+
+
+def test_dblock_connect_uses_iam_token_when_enabled():
+    """dblock's maintenance connection must use IAM when the feature is on."""
+    from mwaa.utils import dblock
+
+    env = {
+        "USE_IAM_CREDENTIALS": "true",
+        "MWAA__DB__POSTGRES_SSLMODE": "require",
+    }
+    with patch.dict("os.environ", env, clear=True), patch.object(
+        dblock, "create_engine"
+    ) as create_engine, patch(
+        "mwaa.config.rds_iam_credentials.RDSIAMCredentialProvider.get_token",
+        return_value="tok",
+    ), patch(
+        "mwaa.config.rds_iam_credentials.RDSIAMCredentialProvider."
+        "create_db_connection_url",
+        return_value="postgresql+psycopg2://airflow_user:tok@h:5432/d",
+    ):
+        dblock._connect_with_retry()
+
+    assert create_engine.call_args.args[0].endswith("@h:5432/d")
+
+
+def test_dblock_connect_uses_static_credentials_when_disabled():
+    """With the flag off it must fall back to the static connection string."""
+    from mwaa.utils import dblock
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}, clear=True), \
+            patch.object(dblock, "create_engine") as create_engine, \
+            patch.object(
+                dblock, "get_db_connection_string", return_value="postgresql://static"
+            ):
+        dblock._connect_with_retry()
+
+    assert create_engine.call_args.args[0] == "postgresql://static"

--- a/tests/images/airflow/3.0.6/python/mwaa/database/test_migrate_with_downgrade_3_0_6.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/database/test_migrate_with_downgrade_3_0_6.py
@@ -1,0 +1,126 @@
+"""Tests for _ensure_rds_iam_user credential-failure semantics.
+
+migrate_with_downgrade.py deliberately refuses to be imported (it ends in an
+``else: sys.exit(1)`` guard so it can only be run as a script), so these tests
+execute the module body up to that guard in a throwaway namespace.
+
+The static connection is failed by patching ``get_db_connection_string``, which
+both module shapes route through: 3.0.6 builds the engine in an inline
+``_connect_static()``, while 3.2.1 and 3.3.0 use a shared
+``_create_engine_with_retry()``.
+"""
+
+import os
+import types
+
+import pytest
+from unittest.mock import patch
+
+_AIRFLOW_VERSION = "3.0.6"
+
+_BASE_ENV = {
+    "MWAA__DB__POSTGRES_HOST": "test.rds.amazonaws.com",
+    "MWAA__DB__POSTGRES_PORT": "5432",
+    "MWAA__DB__POSTGRES_DB": "AirflowMetadata",
+    "MWAA__DB__POSTGRES_SSLMODE": "require",
+    "MWAA__DB__CREDENTIALS": '{"username": "adminuser", "password": "pw"}',
+    "AWS_EXECUTION_ENV": "Amazon_MWAA_test",
+}
+
+
+def _load_module():
+    """Execute migrate_with_downgrade.py up to its no-import guard."""
+    path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..", "..", "..", "..", "..", "..", "..",
+            "images", "airflow", _AIRFLOW_VERSION,
+            "python", "mwaa", "database", "migrate_with_downgrade.py",
+        )
+    )
+    assert os.path.exists(path), f"missing module: {path}"
+    source = open(path).read()
+    guard = source.index('if __name__ == "__main__":')
+    module = types.ModuleType("mwaa_migrate_with_downgrade_probe")
+    module.__file__ = path
+    exec(compile(source[:guard], path, "exec"), module.__dict__)
+    return module
+
+
+def test_raises_when_static_and_iam_both_fail():
+    """Neither credential path working must fail loudly, not skip.
+
+    The grants cannot be applied without a connection, so migrate-db must not
+    continue: the container should fail. Asserted explicitly because every other
+    failure path in this function logs a warning and returns.
+    """
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ), patch.object(
+            module.RDSIAMCredentialProvider,
+            "get_token",
+            side_effect=Exception("could not mint IAM token"),
+        ):
+            with pytest.raises(RuntimeError, match="static or RDS IAM credentials"):
+                module._ensure_rds_iam_user()
+
+
+def test_chains_the_underlying_iam_error():
+    """The original IAM failure must be preserved for debugging."""
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ), patch.object(
+            module.RDSIAMCredentialProvider,
+            "get_token",
+            side_effect=Exception("could not mint IAM token"),
+        ):
+            with pytest.raises(RuntimeError) as excinfo:
+                module._ensure_rds_iam_user()
+
+    assert "could not mint IAM token" in str(excinfo.value.__cause__)
+
+
+def test_skips_without_raising_when_iam_is_disabled():
+    """With the feature flag off, a static failure stays best-effort.
+
+    This preserves the pre-existing contract for non-IAM environments: the
+    function logs and returns so migrate-db can carry on.
+    """
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "false"}):
+        module = _load_module()
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ):
+            module._ensure_rds_iam_user()  # must not raise
+
+
+def test_no_iam_fallback_attempted_when_not_using_rds_proxy():
+    """IAM auth is only supported through RDS Proxy, so don't try otherwise."""
+    env = {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}
+    env["MWAA__DB__POSTGRES_SSLMODE"] = "prefer"
+
+    with patch.dict("os.environ", env):
+        module = _load_module()
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ), patch.object(
+            module.RDSIAMCredentialProvider, "get_token"
+        ) as mock_get_token:
+            module._ensure_rds_iam_user()  # must not raise
+            mock_get_token.assert_not_called()

--- a/tests/images/airflow/3.0.6/python/mwaa/database/test_migrate_with_downgrade_3_0_6.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/database/test_migrate_with_downgrade_3_0_6.py
@@ -14,7 +14,7 @@ import os
 import types
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 _AIRFLOW_VERSION = "3.0.6"
 
@@ -124,3 +124,130 @@ def test_no_iam_fallback_attempted_when_not_using_rds_proxy():
         ) as mock_get_token:
             module._ensure_rds_iam_user()  # must not raise
             mock_get_token.assert_not_called()
+
+
+# --- Grant application paths ---
+
+
+def _mock_engine(current_user, role_exists=True, fail_on=None):
+    """Build a mock engine whose connection answers the role queries.
+
+    Patched in at ``create_engine``, which both module shapes route through:
+    3.0.6 builds the engine in an inline ``_connect_static()`` while 3.2.1 and
+    3.3.0 use a shared ``_create_engine_with_retry()``.
+
+    :param fail_on: substring of a statement that should raise instead of
+        returning, used to exercise the grant-failure path.
+    """
+    conn = MagicMock()
+
+    def execute(statement, params=None):
+        text = str(statement)
+        if fail_on and fail_on in text:
+            raise Exception(f"failed executing {fail_on}")
+        result = MagicMock()
+        if "pg_roles" in text:
+            result.fetchone.return_value = (1,) if role_exists else None
+        elif "current_user" in text:
+            result.scalar.return_value = current_user
+        return result
+
+    conn.execute.side_effect = execute
+    engine = MagicMock()
+    engine.connect.return_value.__enter__.return_value = conn
+    return engine, conn
+
+
+def _executed_statements(conn):
+    return [str(call.args[0]) for call in conn.execute.call_args_list]
+
+
+def test_grants_are_applied_when_connected_as_adminuser():
+    """The full grant block must run when the current role can grant."""
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, conn = _mock_engine(current_user="adminuser")
+
+        with patch.object(module, "create_engine", return_value=engine):
+            module._ensure_rds_iam_user()
+
+    statements = " | ".join(_executed_statements(conn))
+    assert "GRANT rds_iam TO airflow_user" in statements
+    assert 'GRANT ALL PRIVILEGES ON DATABASE "AirflowMetadata" TO airflow_user' in statements
+    assert "GRANT ALL ON SCHEMA public TO airflow_user" in statements
+    assert "GRANT ALL ON ALL TABLES IN SCHEMA public TO airflow_user" in statements
+    assert "GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO airflow_user" in statements
+    assert "GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO airflow_user" in statements
+    assert "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES" in statements
+    assert "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES" in statements
+    assert "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS" in statements
+    # The grant that lets airflow_user inherit objects created by adminuser.
+    assert "GRANT adminuser TO airflow_user" in statements
+
+
+def test_iam_user_is_created_when_missing():
+    """A missing role must be created before the grants are applied."""
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, conn = _mock_engine(current_user="adminuser", role_exists=False)
+
+        with patch.object(module, "create_engine", return_value=engine):
+            module._ensure_rds_iam_user()
+
+    assert "CREATE USER airflow_user" in " | ".join(_executed_statements(conn))
+
+
+def test_grants_are_skipped_when_connected_as_airflow_user():
+    """airflow_user cannot grant, so the block must be skipped, not attempted.
+
+    Note this is also how grants end up never applied when only the IAM path
+    works, since that connects as airflow_user -- tracked separately.
+    """
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, conn = _mock_engine(current_user="airflow_user")
+
+        with patch.object(module, "create_engine", return_value=engine):
+            module._ensure_rds_iam_user()
+
+    statements = " | ".join(_executed_statements(conn))
+    assert "GRANT" not in statements
+
+
+def test_grant_failure_is_swallowed():
+    """Errors while applying grants log and return; they must not propagate."""
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, _ = _mock_engine(current_user="adminuser", fail_on="pg_roles")
+
+        with patch.object(module, "create_engine", return_value=engine):
+            module._ensure_rds_iam_user()  # must not raise
+
+
+def test_iam_fallback_succeeds_and_applies_grants():
+    """A working IAM fallback must proceed to the role handling.
+
+    Exercises the fallback engine construction, which otherwise only runs on the
+    failure paths.
+    """
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, conn = _mock_engine(current_user="airflow_user")
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ), patch.object(
+            module.RDSIAMCredentialProvider, "get_token", return_value="tok"
+        ), patch.object(
+            module.RDSIAMCredentialProvider,
+            "create_db_connection_url",
+            return_value="postgresql+psycopg2://airflow_user:tok@h:5432/d",
+        ), patch.object(
+            module, "create_engine", return_value=engine
+        ):
+            module._ensure_rds_iam_user()
+
+    # Reached the role query via the IAM engine.
+    assert any("current_user" in s for s in _executed_statements(conn))

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_credentials_3_2_1.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_credentials_3_2_1.py
@@ -1,0 +1,290 @@
+import pytest
+import json
+import time
+from unittest.mock import patch, MagicMock
+
+
+def test_get_ecs_credentials_success():
+    """Test successful ECS credentials retrieval"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "test_key",
+        "SecretAccessKey": "test_secret",
+        "Token": "test_token",
+    }
+
+    with patch.dict(
+        "os.environ",
+        {
+            "AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/test",
+            "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/containers/test",
+        },
+    ), patch("urllib.request.build_opener") as mock_build_opener:
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(mock_credentials).encode("utf-8")
+
+        mock_opener = MagicMock()
+        mock_opener.open.return_value.__enter__.return_value = mock_response
+        mock_build_opener.return_value = mock_opener
+
+        result = RDSIAMCredentialProvider.get_ecs_credentials()
+        assert result == mock_credentials
+
+
+def test_get_ecs_credentials_missing_env():
+    """Test ECS credentials with missing environment variables"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(
+            ValueError, match="AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI not set"
+        ):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+
+
+def test_get_ecs_credentials_missing_metadata_uri():
+    """Test ECS credentials with missing ECS_CONTAINER_METADATA_URI"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict(
+        "os.environ",
+        {"AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/test"},
+        clear=True,
+    ):
+        with pytest.raises(ValueError, match="ECS_CONTAINER_METADATA_URI not set"):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+
+
+def test_get_ecs_credentials_ignores_proxy_env_vars():
+    """Test that proxy environment variables don't affect ECS metadata requests"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "test_key",
+        "SecretAccessKey": "test_secret",
+        "Token": "test_token",
+    }
+
+    with patch.dict(
+        "os.environ",
+        {
+            "AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/test",
+            "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/containers/test",
+            "HTTP_PROXY": "http://should-not-be-used:8080",
+            "HTTPS_PROXY": "http://should-not-be-used:8080",
+        },
+    ), patch("urllib.request.build_opener") as mock_build_opener, patch(
+        "urllib.request.ProxyHandler"
+    ) as mock_proxy_handler:
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(mock_credentials).encode("utf-8")
+
+        mock_opener = MagicMock()
+        mock_opener.open.return_value.__enter__.return_value = mock_response
+        mock_build_opener.return_value = mock_opener
+
+        result = RDSIAMCredentialProvider.get_ecs_credentials()
+
+        mock_proxy_handler.assert_called_once_with({})
+        mock_build_opener.assert_called_once()
+        assert result == mock_credentials
+
+
+def test_get_rds_iam_token_hostname_success():
+    """Test successful RDS IAM token hostname retrieval"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict("os.environ", {"RDS_IAM_TOKEN_HOSTNAME": "test.rds.amazonaws.com"}):
+        result = RDSIAMCredentialProvider.get_rds_iam_token_hostname()
+        assert result == "test.rds.amazonaws.com"
+
+
+def test_get_rds_iam_token_hostname_missing():
+    """Test RDS IAM token hostname with missing environment variable"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(
+            ValueError,
+            match="RDS_IAM_TOKEN_HOSTNAME environment variable is required",
+        ):
+            RDSIAMCredentialProvider.get_rds_iam_token_hostname()
+
+
+def test_generate_rds_auth_token():
+    """Test RDS auth token generation"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "test_key",
+        "SecretAccessKey": "test_secret",
+        "Token": "test_token",
+    }
+
+    with patch("boto3.client") as mock_boto3:
+        mock_rds_client = MagicMock()
+        mock_rds_client.generate_db_auth_token.return_value = "test_auth_token"
+        mock_boto3.return_value = mock_rds_client
+
+        result = RDSIAMCredentialProvider.generate_rds_auth_token(
+            mock_credentials, "test.rds.amazonaws.com", 5432, "airflow_user"
+        )
+
+        assert result == "test_auth_token"
+        mock_rds_client.generate_db_auth_token.assert_called_once()
+
+
+def test_generate_rds_auth_token_failure():
+    """Test RDS auth token generation failure"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "test_key",
+        "SecretAccessKey": "test_secret",
+        "Token": "test_token",
+    }
+
+    with patch("boto3.client") as mock_boto3:
+        mock_rds_client = MagicMock()
+        mock_rds_client.generate_db_auth_token.side_effect = Exception(
+            "Token generation failed"
+        )
+        mock_boto3.return_value = mock_rds_client
+
+        with pytest.raises(Exception, match="Token generation failed"):
+            RDSIAMCredentialProvider.generate_rds_auth_token(
+                mock_credentials, "test.rds.amazonaws.com", 5432, "airflow_user"
+            )
+
+
+def test_get_token_cached():
+    """Test cached token retrieval"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    RDSIAMCredentialProvider._token = "cached_token"
+    RDSIAMCredentialProvider._expires_at = time.time() + 600
+
+    result = RDSIAMCredentialProvider.get_token()
+    assert result == "cached_token"
+
+
+def test_get_token_refresh_needed():
+    """Test token refresh when expired"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    RDSIAMCredentialProvider._token = "old_token"
+    RDSIAMCredentialProvider._expires_at = time.time() - 100
+
+    with patch.object(
+        RDSIAMCredentialProvider, "generate_credentials", return_value="new_token"
+    ):
+        result = RDSIAMCredentialProvider.get_token()
+        assert result == "new_token"
+        assert RDSIAMCredentialProvider._token == "new_token"
+
+
+def test_generate_credentials_success():
+    """Test successful credential generation"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "key",
+        "SecretAccessKey": "secret",
+        "Token": "token",
+    }
+
+    with patch.object(
+        RDSIAMCredentialProvider, "get_ecs_credentials", return_value=mock_credentials
+    ), patch.object(
+        RDSIAMCredentialProvider,
+        "get_rds_iam_token_hostname",
+        return_value="test.rds.amazonaws.com",
+    ), patch.object(
+        RDSIAMCredentialProvider, "generate_rds_auth_token", return_value="auth_token"
+    ):
+        result = RDSIAMCredentialProvider.generate_credentials()
+        assert result == "auth_token"
+
+
+def test_generate_credentials_failure():
+    """Test credential generation failure"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.object(
+        RDSIAMCredentialProvider,
+        "get_ecs_credentials",
+        side_effect=Exception("ECS error"),
+    ):
+        with pytest.raises(Exception, match="ECS error"):
+            RDSIAMCredentialProvider.generate_credentials()
+
+
+def test_create_db_connection_url():
+    """Test database connection URL creation"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict(
+        "os.environ",
+        {
+            "MWAA__DB__POSTGRES_HOST": "test.rds.amazonaws.com",
+            "MWAA__DB__POSTGRES_PORT": "5432",
+            "MWAA__DB__POSTGRES_DB": "airflow",
+            "MWAA__DB__POSTGRES_SSLMODE": "require",
+        },
+    ):
+        result = RDSIAMCredentialProvider.create_db_connection_url("test_token")
+        assert (
+            "postgresql+psycopg2://airflow_user:test_token"
+            "@test.rds.amazonaws.com:5432/airflow?sslmode=require" in result
+        )
+
+
+def test_create_db_connection_url_generate_token():
+    """Test database connection URL creation with token generation"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict(
+        "os.environ",
+        {
+            "MWAA__DB__POSTGRES_HOST": "test.rds.amazonaws.com",
+            "MWAA__DB__POSTGRES_PORT": "5432",
+            "MWAA__DB__POSTGRES_DB": "airflow",
+            "MWAA__DB__POSTGRES_SSLMODE": "require",
+        },
+    ), patch.object(
+        RDSIAMCredentialProvider, "generate_credentials", return_value="generated_token"
+    ):
+        result = RDSIAMCredentialProvider.create_db_connection_url()
+        assert (
+            "postgresql+psycopg2://airflow_user:generated_token"
+            "@test.rds.amazonaws.com:5432/airflow?sslmode=require" in result
+        )
+
+
+def test_use_iam_credentials():
+    """Test IAM credentials flag detection"""
+    from mwaa.config.rds_iam_credentials import use_iam_credentials
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "true"}):
+        assert use_iam_credentials() is True
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}):
+        assert use_iam_credentials() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert use_iam_credentials() is False
+
+
+def test_is_using_rds_proxy():
+    """Test RDS proxy detection"""
+    from mwaa.config.rds_iam_credentials import is_using_rds_proxy
+
+    with patch.dict("os.environ", {"MWAA__DB__POSTGRES_SSLMODE": "require"}):
+        assert is_using_rds_proxy() is True
+
+    with patch.dict("os.environ", {"MWAA__DB__POSTGRES_SSLMODE": "disable"}):
+        assert is_using_rds_proxy() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert is_using_rds_proxy() is False

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py
@@ -204,3 +204,147 @@ def test_install_rds_iam_patch_installed():
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             mock_listen.assert_called_once()
+
+
+def _clear_metadata_url_cache(module=None):
+    """Clear the cached metadata URL, tolerating an uncached implementation."""
+    if module is None:
+        from mwaa.config import rds_iam_patch as module
+    getattr(module._get_metadata_url, "cache_clear", lambda: None)()
+
+
+# --- Regression tests for the aspects restored from the 2.x implementation ---
+
+# Environment describing a metadata DB reachable through an RDS Proxy. Note the
+# deliberate absence of AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: that variable is
+# only injected into the environment dict handed to the Airflow subprocesses, so
+# code running in-process must not depend on it.
+_RDS_PROXY_ENV = {
+    "USE_IAM_CREDENTIALS": "true",
+    "MWAA__DB__POSTGRES_HOST": "test.rds.amazonaws.com",
+    "MWAA__DB__POSTGRES_PORT": "5432",
+    "MWAA__DB__POSTGRES_DB": "AirflowMetadata",
+    "MWAA__DB__POSTGRES_SSLMODE": "require",
+    "MWAA__DB__CREDENTIALS": '{"username": "airflow_user", "password": "pw"}',
+    "MWAA_AIRFLOW_COMPONENT": "scheduler",
+}
+
+
+def test_get_metadata_url_derived_from_mwaa_db_env_vars():
+    """The metadata URL must come from MWAA__DB__*, not from the Airflow conn var.
+
+    Regression test: sourcing it from AIRFLOW__DATABASE__SQL_ALCHEMY_CONN made
+    _get_metadata_url() return None in every process, which silently disabled
+    token injection.
+    """
+    from mwaa.config.rds_iam_patch import _get_metadata_url
+
+    with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
+        _clear_metadata_url_cache()
+        try:
+            url = _get_metadata_url()
+            assert url is not None
+            assert url.host == "test.rds.amazonaws.com"
+            assert url.database == "AirflowMetadata"
+            assert url.port == 5432
+        finally:
+            _clear_metadata_url_cache()
+
+
+def test_get_metadata_url_returns_none_on_missing_config():
+    """A misconfigured environment must not raise into the do_connect listener."""
+    from mwaa.config.rds_iam_patch import _get_metadata_url
+
+    with patch.dict("os.environ", {}, clear=True):
+        _clear_metadata_url_cache()
+        try:
+            assert _get_metadata_url() is None
+        finally:
+            _clear_metadata_url_cache()
+
+
+def test_end_to_end_metadata_db_detected_without_airflow_conn_var():
+    """The patch must recognise the metadata DB using only MWAA__DB__* vars."""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        _clear_metadata_url_cache(mwaa.config.rds_iam_patch)
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "dbname": "AirflowMetadata",
+            "port": 5432,
+            "user": "airflow_user",
+        }
+        assert (
+            mwaa.config.rds_iam_patch._is_accessing_metadata_db(
+                "postgresql", [], cparams
+            )
+            is True
+        )
+
+
+def test_install_rds_iam_patch_not_installed_local_runner():
+    """Test patch not installed when running as the local runner."""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict(
+        "os.environ", {**_RDS_PROXY_ENV, "MWAA_LOCAL_RUNNER": "true"}, clear=True
+    ):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_not_called()
+
+
+def test_install_rds_iam_patch_is_idempotent():
+    """Installing twice in one process must register only one listener."""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            install_rds_iam_patch()
+            install_rds_iam_patch()
+            mock_listen.assert_called_once()
+
+
+def test_airflow_local_settings_installs_the_patch():
+    """airflow_local_settings.py is the hook Airflow loads in every process.
+
+    Regression test for the dropped override: without this file the do_connect
+    listener is never registered in the scheduler/worker/api-server processes,
+    which are separate Popen children of the entrypoint.
+    """
+    import importlib.util
+    import os
+
+    settings_path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..", "..", "..", "..", "..", "..", "..",
+            "images", "airflow", "3.2.1", "airflow_local_settings.py",
+        )
+    )
+    assert os.path.exists(settings_path), f"missing override: {settings_path}"
+
+    with patch(
+        "mwaa.config.rds_iam_patch.install_rds_iam_patch"
+    ) as mock_install:
+        spec = importlib.util.spec_from_file_location(
+            "mwaa_test_airflow_local_settings", settings_path
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        mock_install.assert_called_once()
+
+    # Must not leak names into the airflow.settings namespace.
+    assert module.__all__ == []

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py
@@ -144,11 +144,11 @@ def test_install_rds_iam_patch_not_installed_no_iam():
     """Test patch not installed when USE_IAM_CREDENTIALS is not true"""
     from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
-    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}, clear=True), patch(
-        "sqlalchemy.event.listen"
-    ) as mock_listen:
-        install_rds_iam_patch()
-        mock_listen.assert_not_called()
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}, clear=True):
+        _reset_patch_state()
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_not_called()
 
 
 def test_install_rds_iam_patch_not_installed_no_rds_proxy():
@@ -158,9 +158,11 @@ def test_install_rds_iam_patch_not_installed_no_rds_proxy():
     with patch.dict(
         "os.environ",
         {"USE_IAM_CREDENTIALS": "true", "MWAA__DB__POSTGRES_SSLMODE": "disable"},
-    ), patch("sqlalchemy.event.listen") as mock_listen:
-        install_rds_iam_patch()
-        mock_listen.assert_not_called()
+    ):
+        _reset_patch_state()
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_not_called()
 
 
 def test_install_rds_iam_patch_not_installed_migrate_db():
@@ -469,7 +471,9 @@ def test_do_connect_listener_injects_the_token():
         "dbname": "AirflowMetadata",
         "port": 5432,
         "user": "airflow_user",
-        "stale": "should be cleared",
+        # Engine connect_args (MWAA_CONNECT_ARGS) arrive via cparams.
+        "connect_timeout": 15,
+        "keepalives": 1,
     }
 
     with patch.dict("os.environ", env, clear=True), patch.object(
@@ -480,12 +484,16 @@ def test_do_connect_listener_injects_the_token():
         _clear_metadata_url_cache(m)
         captured["fn"]("postgresql", None, [], cparams)
 
-    # cparams was rebuilt from the IAM URL, and the pre-existing key is gone.
-    assert "stale" not in cparams
+    # Credentials were rebuilt from the IAM URL.
     assert cparams["password"] == "tok"
     assert cparams["host"] == "proxy.rds.amazonaws.com"
     # 'dbname'/'database' must not both be present (psycopg2 rejects that).
     assert not ("dbname" in cparams and "database" in cparams)
+    # Engine connect_args that arrive via cparams (connect_timeout and the
+    # keepalives* settings from MWAA_CONNECT_ARGS) must survive the token
+    # injection; only the aliased credential keys are replaced.
+    assert cparams["connect_timeout"] == 15
+    assert cparams["keepalives"] == 1
 
 
 def test_do_connect_listener_ignores_other_databases():

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py
@@ -1,0 +1,206 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def test_is_from_migrate_db():
+    """Test migrate-db detection"""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict("os.environ", {"MWAA_AIRFLOW_COMPONENT": "migrate-db"}):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import _is_from_migrate_db
+
+        assert _is_from_migrate_db() is True
+
+    with patch.dict("os.environ", {"MWAA_AIRFLOW_COMPONENT": "scheduler"}):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import _is_from_migrate_db
+
+        assert _is_from_migrate_db() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import _is_from_migrate_db
+
+        assert _is_from_migrate_db() is False
+
+
+def test_is_using_rds_proxy():
+    """Test RDS proxy detection via is_using_rds_proxy helper"""
+    from mwaa.config.rds_iam_credentials import is_using_rds_proxy
+
+    with patch.dict("os.environ", {"MWAA__DB__POSTGRES_SSLMODE": "require"}):
+        assert is_using_rds_proxy() is True
+
+    with patch.dict("os.environ", {"MWAA__DB__POSTGRES_SSLMODE": "disable"}):
+        assert is_using_rds_proxy() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert is_using_rds_proxy() is False
+
+
+def test_use_iam_credentials():
+    """Test IAM credentials flag detection"""
+    from mwaa.config.rds_iam_credentials import use_iam_credentials
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "true"}):
+        assert use_iam_credentials() is True
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}):
+        assert use_iam_credentials() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert use_iam_credentials() is False
+
+
+def test_is_accessing_metadata_db():
+    """Test metadata database detection"""
+    from mwaa.config.rds_iam_patch import _is_accessing_metadata_db
+
+    with patch(
+        "mwaa.config.rds_iam_patch._get_metadata_url"
+    ) as mock_get_url:
+        mock_url = MagicMock()
+        mock_url.host = "test.rds.amazonaws.com"
+        mock_url.database = "airflow"
+        mock_url.port = 5432
+        mock_get_url.return_value = mock_url
+
+        # Test with matching parameters including username
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "database": "airflow",
+            "port": 5432,
+            "username": "airflow_user",
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is True
+
+        # Test with adminuser username
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "database": "airflow",
+            "port": 5432,
+            "username": "adminuser",
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is True
+
+        # Test with non-matching parameters
+        cparams = {
+            "host": "other.rds.amazonaws.com",
+            "database": "other",
+            "port": 3306,
+            "username": "airflow_user",
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is False
+
+        # Test with missing username
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "database": "airflow",
+            "port": 5432,
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is False
+
+
+def test_is_accessing_metadata_db_with_cargs():
+    """Test metadata database detection using cargs"""
+    from mwaa.config.rds_iam_patch import _is_accessing_metadata_db
+
+    with patch(
+        "mwaa.config.rds_iam_patch._get_metadata_url"
+    ) as mock_get_url:
+        mock_url = MagicMock()
+        mock_url.host = "test.rds.amazonaws.com"
+        mock_url.database = "airflow"
+        mock_url.port = 5432
+        mock_get_url.return_value = mock_url
+
+        # Test with matching cargs including airflow_user
+        cargs = ["postgresql://airflow_user:pass@test.rds.amazonaws.com:5432/airflow"]
+        assert _is_accessing_metadata_db("postgresql", cargs, {}) is True
+
+        # Test with matching cargs including adminuser
+        cargs = ["postgresql://adminuser:pass@test.rds.amazonaws.com:5432/airflow"]
+        assert _is_accessing_metadata_db("postgresql", cargs, {}) is True
+
+
+def test_is_accessing_metadata_db_no_conn_str():
+    """Test metadata database detection when no connection string is set"""
+    from mwaa.config.rds_iam_patch import _is_accessing_metadata_db
+
+    with patch(
+        "mwaa.config.rds_iam_patch._get_metadata_url", return_value=None
+    ):
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "database": "airflow",
+            "port": 5432,
+            "username": "airflow_user",
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is False
+
+
+def test_install_rds_iam_patch_not_installed_no_iam():
+    """Test patch not installed when USE_IAM_CREDENTIALS is not true"""
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}, clear=True), patch(
+        "sqlalchemy.event.listen"
+    ) as mock_listen:
+        install_rds_iam_patch()
+        mock_listen.assert_not_called()
+
+
+def test_install_rds_iam_patch_not_installed_no_rds_proxy():
+    """Test patch not installed when not using RDS Proxy"""
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+    with patch.dict(
+        "os.environ",
+        {"USE_IAM_CREDENTIALS": "true", "MWAA__DB__POSTGRES_SSLMODE": "disable"},
+    ), patch("sqlalchemy.event.listen") as mock_listen:
+        install_rds_iam_patch()
+        mock_listen.assert_not_called()
+
+
+def test_install_rds_iam_patch_not_installed_migrate_db():
+    """Test patch not installed for migrate-db process"""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict(
+        "os.environ",
+        {
+            "USE_IAM_CREDENTIALS": "true",
+            "MWAA__DB__POSTGRES_SSLMODE": "require",
+            "MWAA_AIRFLOW_COMPONENT": "migrate-db",
+        },
+    ):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_not_called()
+
+
+def test_install_rds_iam_patch_installed():
+    """Test patch installed when all conditions are met"""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict(
+        "os.environ",
+        {
+            "USE_IAM_CREDENTIALS": "true",
+            "MWAA__DB__POSTGRES_SSLMODE": "require",
+            "MWAA_AIRFLOW_COMPONENT": "scheduler",
+        },
+    ):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_called_once()

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py
@@ -333,3 +333,240 @@ def test_airflow_local_settings_installs_the_patch():
 
     # Must not leak names into the airflow.settings namespace.
     assert module.__all__ == []
+
+
+# --- Coverage for the customer-settings loading and the listener body ---
+
+_LS_VERSION = "3.2.1"
+
+
+def _local_settings_file():
+    import os
+
+    path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..", "..", "..", "..", "..", "..", "..",
+            "images", "airflow", _LS_VERSION, "airflow_local_settings.py",
+        )
+    )
+    assert os.path.exists(path), f"missing override: {path}"
+    return path
+
+
+def _exec_local_settings(airflow_home=None):
+    """Execute the shipped airflow_local_settings.py with the patch stubbed out."""
+    import importlib.util
+
+    env = {"AIRFLOW_HOME": airflow_home} if airflow_home else {}
+    with patch.dict("os.environ", env), patch(
+        "mwaa.config.rds_iam_patch.install_rds_iam_patch"
+    ):
+        spec = importlib.util.spec_from_file_location(
+            "mwaa_test_local_settings_cov", _local_settings_file()
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+def _write_customer_file(home, subdir, body):
+    import os
+
+    os.makedirs(os.path.join(home, subdir), exist_ok=True)
+    with open(os.path.join(home, subdir, "airflow_local_settings.py"), "w") as f:
+        f.write(body)
+
+
+def test_customer_settings_in_dags_are_executed(tmp_path):
+    """A customer file in dags/ must be loaded, so its side effects apply."""
+    marker = tmp_path / "dags_ran"
+    _write_customer_file(
+        str(tmp_path),
+        "dags",
+        f"open({str(marker)!r}, 'w').write('ran')\n",
+    )
+
+    _exec_local_settings(str(tmp_path))
+
+    assert marker.exists(), "dags/airflow_local_settings.py was not executed"
+
+
+def test_customer_settings_in_plugins_are_executed(tmp_path):
+    """A customer file in plugins/ must be loaded too."""
+    marker = tmp_path / "plugins_ran"
+    _write_customer_file(
+        str(tmp_path),
+        "plugins",
+        f"open({str(marker)!r}, 'w').write('ran')\n",
+    )
+
+    _exec_local_settings(str(tmp_path))
+
+    assert marker.exists(), "plugins/airflow_local_settings.py was not executed"
+
+
+def test_broken_customer_settings_propagate(tmp_path):
+    """A customer file that fails to load must surface, not be swallowed.
+
+    Matches what Airflow does natively when a local settings file raises.
+    """
+    _write_customer_file(str(tmp_path), "plugins", "raise ValueError('customer bug')\n")
+
+    with pytest.raises(ValueError, match="customer bug"):
+        _exec_local_settings(str(tmp_path))
+
+
+def test_patch_install_failure_propagates():
+    """A failure installing the RDS IAM patch must not be silently ignored."""
+    import importlib.util
+
+    with patch(
+        "mwaa.config.rds_iam_patch.install_rds_iam_patch",
+        side_effect=RuntimeError("patch install blew up"),
+    ):
+        spec = importlib.util.spec_from_file_location(
+            "mwaa_test_local_settings_fail", _local_settings_file()
+        )
+        module = importlib.util.module_from_spec(spec)
+        with pytest.raises(RuntimeError, match="patch install blew up"):
+            spec.loader.exec_module(module)
+
+
+def test_do_connect_listener_injects_the_token():
+    """Exercise the registered listener body, not just its registration."""
+    from mwaa.config import rds_iam_patch as m
+
+    captured = {}
+
+    def fake_listen(target, name, fn):
+        captured["fn"] = fn
+
+    env = {
+        "USE_IAM_CREDENTIALS": "true",
+        "MWAA__DB__POSTGRES_HOST": "proxy.rds.amazonaws.com",
+        "MWAA__DB__POSTGRES_PORT": "5432",
+        "MWAA__DB__POSTGRES_DB": "AirflowMetadata",
+        "MWAA__DB__POSTGRES_SSLMODE": "require",
+        "MWAA__DB__CREDENTIALS": '{"username": "airflow_user", "password": "pw"}',
+        "MWAA_AIRFLOW_COMPONENT": "scheduler",
+    }
+
+    with patch.dict("os.environ", env, clear=True), patch(
+        "sqlalchemy.event.listen", side_effect=fake_listen
+    ):
+        _reset_patch_state()
+        m.install_rds_iam_patch()
+
+    assert "fn" in captured, "listener was not registered"
+
+    token_url = (
+        "postgresql+psycopg2://airflow_user:tok"
+        "@proxy.rds.amazonaws.com:5432/AirflowMetadata?sslmode=require"
+    )
+    cparams = {
+        "host": "proxy.rds.amazonaws.com",
+        "dbname": "AirflowMetadata",
+        "port": 5432,
+        "user": "airflow_user",
+        "stale": "should be cleared",
+    }
+
+    with patch.dict("os.environ", env, clear=True), patch.object(
+        m.RDSIAMCredentialProvider, "get_token", return_value="tok"
+    ), patch.object(
+        m.RDSIAMCredentialProvider, "create_db_connection_url", return_value=token_url
+    ):
+        _clear_metadata_url_cache(m)
+        captured["fn"]("postgresql", None, [], cparams)
+
+    # cparams was rebuilt from the IAM URL, and the pre-existing key is gone.
+    assert "stale" not in cparams
+    assert cparams["password"] == "tok"
+    assert cparams["host"] == "proxy.rds.amazonaws.com"
+    # 'dbname'/'database' must not both be present (psycopg2 rejects that).
+    assert not ("dbname" in cparams and "database" in cparams)
+
+
+def test_do_connect_listener_ignores_other_databases():
+    """Connections that are not the metadata DB must be left untouched."""
+    from mwaa.config import rds_iam_patch as m
+
+    captured = {}
+    env = {
+        "USE_IAM_CREDENTIALS": "true",
+        "MWAA__DB__POSTGRES_HOST": "proxy.rds.amazonaws.com",
+        "MWAA__DB__POSTGRES_PORT": "5432",
+        "MWAA__DB__POSTGRES_DB": "AirflowMetadata",
+        "MWAA__DB__POSTGRES_SSLMODE": "require",
+        "MWAA__DB__CREDENTIALS": '{"username": "airflow_user", "password": "pw"}',
+        "MWAA_AIRFLOW_COMPONENT": "scheduler",
+    }
+
+    with patch.dict("os.environ", env, clear=True), patch(
+        "sqlalchemy.event.listen", side_effect=lambda t, n, fn: captured.update(fn=fn)
+    ):
+        _reset_patch_state()
+        m.install_rds_iam_patch()
+
+    other = {"host": "someone-elses-db", "dbname": "other", "port": 5432, "user": "x"}
+    before = dict(other)
+
+    with patch.dict("os.environ", env, clear=True), patch.object(
+        m.RDSIAMCredentialProvider, "get_token"
+    ) as get_token:
+        _clear_metadata_url_cache(m)
+        captured["fn"]("postgresql", None, [], other)
+        get_token.assert_not_called()
+
+    assert other == before
+
+
+def test_metadata_detection_tolerates_unparseable_cargs():
+    """A malformed DSN in cargs must not raise out of the listener."""
+    from mwaa.config import rds_iam_patch as m
+
+    with patch.object(m, "_get_metadata_url") as mock_url:
+        mock_url.return_value = MagicMock(
+            host="h", database="d", port=5432, username="airflow_user"
+        )
+        # Not a URL at all; the cargs branch must swallow the parse error and
+        # fall through to the cparams check.
+        assert m._is_accessing_metadata_db("postgresql", ["not-a-dsn"], {}) is False
+
+
+def test_dblock_connect_uses_iam_token_when_enabled():
+    """dblock's maintenance connection must use IAM when the feature is on."""
+    from mwaa.utils import dblock
+
+    env = {
+        "USE_IAM_CREDENTIALS": "true",
+        "MWAA__DB__POSTGRES_SSLMODE": "require",
+    }
+    with patch.dict("os.environ", env, clear=True), patch.object(
+        dblock, "create_engine"
+    ) as create_engine, patch(
+        "mwaa.config.rds_iam_credentials.RDSIAMCredentialProvider.get_token",
+        return_value="tok",
+    ), patch(
+        "mwaa.config.rds_iam_credentials.RDSIAMCredentialProvider."
+        "create_db_connection_url",
+        return_value="postgresql+psycopg2://airflow_user:tok@h:5432/d",
+    ):
+        dblock._connect_with_retry()
+
+    assert create_engine.call_args.args[0].endswith("@h:5432/d")
+
+
+def test_dblock_connect_uses_static_credentials_when_disabled():
+    """With the flag off it must fall back to the static connection string."""
+    from mwaa.utils import dblock
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}, clear=True), \
+            patch.object(dblock, "create_engine") as create_engine, \
+            patch.object(
+                dblock, "get_db_connection_string", return_value="postgresql://static"
+            ):
+        dblock._connect_with_retry()
+
+    assert create_engine.call_args.args[0] == "postgresql://static"

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py
@@ -2,27 +2,26 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 
+def _reset_patch_state():
+    """Reset the one-shot install flag so a test can install the patch again."""
+    from mwaa.config import rds_iam_patch
+
+    rds_iam_patch._patch_installed = False
+    getattr(rds_iam_patch._get_metadata_url, "cache_clear", lambda: None)()
+
+
+
 def test_is_from_migrate_db():
     """Test migrate-db detection"""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import _is_from_migrate_db
 
     with patch.dict("os.environ", {"MWAA_AIRFLOW_COMPONENT": "migrate-db"}):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import _is_from_migrate_db
-
         assert _is_from_migrate_db() is True
 
     with patch.dict("os.environ", {"MWAA_AIRFLOW_COMPONENT": "scheduler"}):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import _is_from_migrate_db
-
         assert _is_from_migrate_db() is False
 
     with patch.dict("os.environ", {}, clear=True):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import _is_from_migrate_db
-
         assert _is_from_migrate_db() is False
 
 
@@ -166,8 +165,7 @@ def test_install_rds_iam_patch_not_installed_no_rds_proxy():
 
 def test_install_rds_iam_patch_not_installed_migrate_db():
     """Test patch not installed for migrate-db process"""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
     with patch.dict(
         "os.environ",
@@ -177,9 +175,7 @@ def test_install_rds_iam_patch_not_installed_migrate_db():
             "MWAA_AIRFLOW_COMPONENT": "migrate-db",
         },
     ):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-
+        _reset_patch_state()
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             mock_listen.assert_not_called()
@@ -187,8 +183,7 @@ def test_install_rds_iam_patch_not_installed_migrate_db():
 
 def test_install_rds_iam_patch_installed():
     """Test patch installed when all conditions are met"""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
     with patch.dict(
         "os.environ",
@@ -198,9 +193,7 @@ def test_install_rds_iam_patch_installed():
             "MWAA_AIRFLOW_COMPONENT": "scheduler",
         },
     ):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-
+        _reset_patch_state()
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             mock_listen.assert_called_once()
@@ -265,11 +258,9 @@ def test_get_metadata_url_returns_none_on_missing_config():
 
 def test_end_to_end_metadata_db_detected_without_airflow_conn_var():
     """The patch must recognise the metadata DB using only MWAA__DB__* vars."""
-    import importlib
     import mwaa.config.rds_iam_patch
 
     with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
-        importlib.reload(mwaa.config.rds_iam_patch)
         _clear_metadata_url_cache(mwaa.config.rds_iam_patch)
         cparams = {
             "host": "test.rds.amazonaws.com",
@@ -287,15 +278,12 @@ def test_end_to_end_metadata_db_detected_without_airflow_conn_var():
 
 def test_install_rds_iam_patch_not_installed_local_runner():
     """Test patch not installed when running as the local runner."""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
     with patch.dict(
         "os.environ", {**_RDS_PROXY_ENV, "MWAA_LOCAL_RUNNER": "true"}, clear=True
     ):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-
+        _reset_patch_state()
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             mock_listen.assert_not_called()
@@ -303,13 +291,10 @@ def test_install_rds_iam_patch_not_installed_local_runner():
 
 def test_install_rds_iam_patch_is_idempotent():
     """Installing twice in one process must register only one listener."""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
     with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-
+        _reset_patch_state()
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             install_rds_iam_patch()

--- a/tests/images/airflow/3.2.1/python/mwaa/database/test_migrate_with_downgrade_3_2_1.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/database/test_migrate_with_downgrade_3_2_1.py
@@ -1,0 +1,126 @@
+"""Tests for _ensure_rds_iam_user credential-failure semantics.
+
+migrate_with_downgrade.py deliberately refuses to be imported (it ends in an
+``else: sys.exit(1)`` guard so it can only be run as a script), so these tests
+execute the module body up to that guard in a throwaway namespace.
+
+The static connection is failed by patching ``get_db_connection_string``, which
+both module shapes route through: 3.0.6 builds the engine in an inline
+``_connect_static()``, while 3.2.1 and 3.3.0 use a shared
+``_create_engine_with_retry()``.
+"""
+
+import os
+import types
+
+import pytest
+from unittest.mock import patch
+
+_AIRFLOW_VERSION = "3.2.1"
+
+_BASE_ENV = {
+    "MWAA__DB__POSTGRES_HOST": "test.rds.amazonaws.com",
+    "MWAA__DB__POSTGRES_PORT": "5432",
+    "MWAA__DB__POSTGRES_DB": "AirflowMetadata",
+    "MWAA__DB__POSTGRES_SSLMODE": "require",
+    "MWAA__DB__CREDENTIALS": '{"username": "adminuser", "password": "pw"}',
+    "AWS_EXECUTION_ENV": "Amazon_MWAA_test",
+}
+
+
+def _load_module():
+    """Execute migrate_with_downgrade.py up to its no-import guard."""
+    path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..", "..", "..", "..", "..", "..", "..",
+            "images", "airflow", _AIRFLOW_VERSION,
+            "python", "mwaa", "database", "migrate_with_downgrade.py",
+        )
+    )
+    assert os.path.exists(path), f"missing module: {path}"
+    source = open(path).read()
+    guard = source.index('if __name__ == "__main__":')
+    module = types.ModuleType("mwaa_migrate_with_downgrade_probe")
+    module.__file__ = path
+    exec(compile(source[:guard], path, "exec"), module.__dict__)
+    return module
+
+
+def test_raises_when_static_and_iam_both_fail():
+    """Neither credential path working must fail loudly, not skip.
+
+    The grants cannot be applied without a connection, so migrate-db must not
+    continue: the container should fail. Asserted explicitly because every other
+    failure path in this function logs a warning and returns.
+    """
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ), patch.object(
+            module.RDSIAMCredentialProvider,
+            "get_token",
+            side_effect=Exception("could not mint IAM token"),
+        ):
+            with pytest.raises(RuntimeError, match="static or RDS IAM credentials"):
+                module._ensure_rds_iam_user()
+
+
+def test_chains_the_underlying_iam_error():
+    """The original IAM failure must be preserved for debugging."""
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ), patch.object(
+            module.RDSIAMCredentialProvider,
+            "get_token",
+            side_effect=Exception("could not mint IAM token"),
+        ):
+            with pytest.raises(RuntimeError) as excinfo:
+                module._ensure_rds_iam_user()
+
+    assert "could not mint IAM token" in str(excinfo.value.__cause__)
+
+
+def test_skips_without_raising_when_iam_is_disabled():
+    """With the feature flag off, a static failure stays best-effort.
+
+    This preserves the pre-existing contract for non-IAM environments: the
+    function logs and returns so migrate-db can carry on.
+    """
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "false"}):
+        module = _load_module()
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ):
+            module._ensure_rds_iam_user()  # must not raise
+
+
+def test_no_iam_fallback_attempted_when_not_using_rds_proxy():
+    """IAM auth is only supported through RDS Proxy, so don't try otherwise."""
+    env = {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}
+    env["MWAA__DB__POSTGRES_SSLMODE"] = "prefer"
+
+    with patch.dict("os.environ", env):
+        module = _load_module()
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ), patch.object(
+            module.RDSIAMCredentialProvider, "get_token"
+        ) as mock_get_token:
+            module._ensure_rds_iam_user()  # must not raise
+            mock_get_token.assert_not_called()

--- a/tests/images/airflow/3.2.1/python/mwaa/database/test_migrate_with_downgrade_3_2_1.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/database/test_migrate_with_downgrade_3_2_1.py
@@ -14,7 +14,7 @@ import os
 import types
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 _AIRFLOW_VERSION = "3.2.1"
 
@@ -124,3 +124,130 @@ def test_no_iam_fallback_attempted_when_not_using_rds_proxy():
         ) as mock_get_token:
             module._ensure_rds_iam_user()  # must not raise
             mock_get_token.assert_not_called()
+
+
+# --- Grant application paths ---
+
+
+def _mock_engine(current_user, role_exists=True, fail_on=None):
+    """Build a mock engine whose connection answers the role queries.
+
+    Patched in at ``create_engine``, which both module shapes route through:
+    3.0.6 builds the engine in an inline ``_connect_static()`` while 3.2.1 and
+    3.3.0 use a shared ``_create_engine_with_retry()``.
+
+    :param fail_on: substring of a statement that should raise instead of
+        returning, used to exercise the grant-failure path.
+    """
+    conn = MagicMock()
+
+    def execute(statement, params=None):
+        text = str(statement)
+        if fail_on and fail_on in text:
+            raise Exception(f"failed executing {fail_on}")
+        result = MagicMock()
+        if "pg_roles" in text:
+            result.fetchone.return_value = (1,) if role_exists else None
+        elif "current_user" in text:
+            result.scalar.return_value = current_user
+        return result
+
+    conn.execute.side_effect = execute
+    engine = MagicMock()
+    engine.connect.return_value.__enter__.return_value = conn
+    return engine, conn
+
+
+def _executed_statements(conn):
+    return [str(call.args[0]) for call in conn.execute.call_args_list]
+
+
+def test_grants_are_applied_when_connected_as_adminuser():
+    """The full grant block must run when the current role can grant."""
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, conn = _mock_engine(current_user="adminuser")
+
+        with patch.object(module, "create_engine", return_value=engine):
+            module._ensure_rds_iam_user()
+
+    statements = " | ".join(_executed_statements(conn))
+    assert "GRANT rds_iam TO airflow_user" in statements
+    assert 'GRANT ALL PRIVILEGES ON DATABASE "AirflowMetadata" TO airflow_user' in statements
+    assert "GRANT ALL ON SCHEMA public TO airflow_user" in statements
+    assert "GRANT ALL ON ALL TABLES IN SCHEMA public TO airflow_user" in statements
+    assert "GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO airflow_user" in statements
+    assert "GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO airflow_user" in statements
+    assert "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES" in statements
+    assert "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES" in statements
+    assert "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS" in statements
+    # The grant that lets airflow_user inherit objects created by adminuser.
+    assert "GRANT adminuser TO airflow_user" in statements
+
+
+def test_iam_user_is_created_when_missing():
+    """A missing role must be created before the grants are applied."""
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, conn = _mock_engine(current_user="adminuser", role_exists=False)
+
+        with patch.object(module, "create_engine", return_value=engine):
+            module._ensure_rds_iam_user()
+
+    assert "CREATE USER airflow_user" in " | ".join(_executed_statements(conn))
+
+
+def test_grants_are_skipped_when_connected_as_airflow_user():
+    """airflow_user cannot grant, so the block must be skipped, not attempted.
+
+    Note this is also how grants end up never applied when only the IAM path
+    works, since that connects as airflow_user -- tracked separately.
+    """
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, conn = _mock_engine(current_user="airflow_user")
+
+        with patch.object(module, "create_engine", return_value=engine):
+            module._ensure_rds_iam_user()
+
+    statements = " | ".join(_executed_statements(conn))
+    assert "GRANT" not in statements
+
+
+def test_grant_failure_is_swallowed():
+    """Errors while applying grants log and return; they must not propagate."""
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, _ = _mock_engine(current_user="adminuser", fail_on="pg_roles")
+
+        with patch.object(module, "create_engine", return_value=engine):
+            module._ensure_rds_iam_user()  # must not raise
+
+
+def test_iam_fallback_succeeds_and_applies_grants():
+    """A working IAM fallback must proceed to the role handling.
+
+    Exercises the fallback engine construction, which otherwise only runs on the
+    failure paths.
+    """
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, conn = _mock_engine(current_user="airflow_user")
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ), patch.object(
+            module.RDSIAMCredentialProvider, "get_token", return_value="tok"
+        ), patch.object(
+            module.RDSIAMCredentialProvider,
+            "create_db_connection_url",
+            return_value="postgresql+psycopg2://airflow_user:tok@h:5432/d",
+        ), patch.object(
+            module, "create_engine", return_value=engine
+        ):
+            module._ensure_rds_iam_user()
+
+    # Reached the role query via the IAM engine.
+    assert any("current_user" in s for s in _executed_statements(conn))

--- a/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_credentials_3_3_0.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_credentials_3_3_0.py
@@ -1,0 +1,290 @@
+import pytest
+import json
+import time
+from unittest.mock import patch, MagicMock
+
+
+def test_get_ecs_credentials_success():
+    """Test successful ECS credentials retrieval"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "test_key",
+        "SecretAccessKey": "test_secret",
+        "Token": "test_token",
+    }
+
+    with patch.dict(
+        "os.environ",
+        {
+            "AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/test",
+            "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/containers/test",
+        },
+    ), patch("urllib.request.build_opener") as mock_build_opener:
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(mock_credentials).encode("utf-8")
+
+        mock_opener = MagicMock()
+        mock_opener.open.return_value.__enter__.return_value = mock_response
+        mock_build_opener.return_value = mock_opener
+
+        result = RDSIAMCredentialProvider.get_ecs_credentials()
+        assert result == mock_credentials
+
+
+def test_get_ecs_credentials_missing_env():
+    """Test ECS credentials with missing environment variables"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(
+            ValueError, match="AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI not set"
+        ):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+
+
+def test_get_ecs_credentials_missing_metadata_uri():
+    """Test ECS credentials with missing ECS_CONTAINER_METADATA_URI"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict(
+        "os.environ",
+        {"AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/test"},
+        clear=True,
+    ):
+        with pytest.raises(ValueError, match="ECS_CONTAINER_METADATA_URI not set"):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+
+
+def test_get_ecs_credentials_ignores_proxy_env_vars():
+    """Test that proxy environment variables don't affect ECS metadata requests"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "test_key",
+        "SecretAccessKey": "test_secret",
+        "Token": "test_token",
+    }
+
+    with patch.dict(
+        "os.environ",
+        {
+            "AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/test",
+            "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/containers/test",
+            "HTTP_PROXY": "http://should-not-be-used:8080",
+            "HTTPS_PROXY": "http://should-not-be-used:8080",
+        },
+    ), patch("urllib.request.build_opener") as mock_build_opener, patch(
+        "urllib.request.ProxyHandler"
+    ) as mock_proxy_handler:
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(mock_credentials).encode("utf-8")
+
+        mock_opener = MagicMock()
+        mock_opener.open.return_value.__enter__.return_value = mock_response
+        mock_build_opener.return_value = mock_opener
+
+        result = RDSIAMCredentialProvider.get_ecs_credentials()
+
+        mock_proxy_handler.assert_called_once_with({})
+        mock_build_opener.assert_called_once()
+        assert result == mock_credentials
+
+
+def test_get_rds_iam_token_hostname_success():
+    """Test successful RDS IAM token hostname retrieval"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict("os.environ", {"RDS_IAM_TOKEN_HOSTNAME": "test.rds.amazonaws.com"}):
+        result = RDSIAMCredentialProvider.get_rds_iam_token_hostname()
+        assert result == "test.rds.amazonaws.com"
+
+
+def test_get_rds_iam_token_hostname_missing():
+    """Test RDS IAM token hostname with missing environment variable"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(
+            ValueError,
+            match="RDS_IAM_TOKEN_HOSTNAME environment variable is required",
+        ):
+            RDSIAMCredentialProvider.get_rds_iam_token_hostname()
+
+
+def test_generate_rds_auth_token():
+    """Test RDS auth token generation"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "test_key",
+        "SecretAccessKey": "test_secret",
+        "Token": "test_token",
+    }
+
+    with patch("boto3.client") as mock_boto3:
+        mock_rds_client = MagicMock()
+        mock_rds_client.generate_db_auth_token.return_value = "test_auth_token"
+        mock_boto3.return_value = mock_rds_client
+
+        result = RDSIAMCredentialProvider.generate_rds_auth_token(
+            mock_credentials, "test.rds.amazonaws.com", 5432, "airflow_user"
+        )
+
+        assert result == "test_auth_token"
+        mock_rds_client.generate_db_auth_token.assert_called_once()
+
+
+def test_generate_rds_auth_token_failure():
+    """Test RDS auth token generation failure"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "test_key",
+        "SecretAccessKey": "test_secret",
+        "Token": "test_token",
+    }
+
+    with patch("boto3.client") as mock_boto3:
+        mock_rds_client = MagicMock()
+        mock_rds_client.generate_db_auth_token.side_effect = Exception(
+            "Token generation failed"
+        )
+        mock_boto3.return_value = mock_rds_client
+
+        with pytest.raises(Exception, match="Token generation failed"):
+            RDSIAMCredentialProvider.generate_rds_auth_token(
+                mock_credentials, "test.rds.amazonaws.com", 5432, "airflow_user"
+            )
+
+
+def test_get_token_cached():
+    """Test cached token retrieval"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    RDSIAMCredentialProvider._token = "cached_token"
+    RDSIAMCredentialProvider._expires_at = time.time() + 600
+
+    result = RDSIAMCredentialProvider.get_token()
+    assert result == "cached_token"
+
+
+def test_get_token_refresh_needed():
+    """Test token refresh when expired"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    RDSIAMCredentialProvider._token = "old_token"
+    RDSIAMCredentialProvider._expires_at = time.time() - 100
+
+    with patch.object(
+        RDSIAMCredentialProvider, "generate_credentials", return_value="new_token"
+    ):
+        result = RDSIAMCredentialProvider.get_token()
+        assert result == "new_token"
+        assert RDSIAMCredentialProvider._token == "new_token"
+
+
+def test_generate_credentials_success():
+    """Test successful credential generation"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    mock_credentials = {
+        "AccessKeyId": "key",
+        "SecretAccessKey": "secret",
+        "Token": "token",
+    }
+
+    with patch.object(
+        RDSIAMCredentialProvider, "get_ecs_credentials", return_value=mock_credentials
+    ), patch.object(
+        RDSIAMCredentialProvider,
+        "get_rds_iam_token_hostname",
+        return_value="test.rds.amazonaws.com",
+    ), patch.object(
+        RDSIAMCredentialProvider, "generate_rds_auth_token", return_value="auth_token"
+    ):
+        result = RDSIAMCredentialProvider.generate_credentials()
+        assert result == "auth_token"
+
+
+def test_generate_credentials_failure():
+    """Test credential generation failure"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.object(
+        RDSIAMCredentialProvider,
+        "get_ecs_credentials",
+        side_effect=Exception("ECS error"),
+    ):
+        with pytest.raises(Exception, match="ECS error"):
+            RDSIAMCredentialProvider.generate_credentials()
+
+
+def test_create_db_connection_url():
+    """Test database connection URL creation"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict(
+        "os.environ",
+        {
+            "MWAA__DB__POSTGRES_HOST": "test.rds.amazonaws.com",
+            "MWAA__DB__POSTGRES_PORT": "5432",
+            "MWAA__DB__POSTGRES_DB": "airflow",
+            "MWAA__DB__POSTGRES_SSLMODE": "require",
+        },
+    ):
+        result = RDSIAMCredentialProvider.create_db_connection_url("test_token")
+        assert (
+            "postgresql+psycopg2://airflow_user:test_token"
+            "@test.rds.amazonaws.com:5432/airflow?sslmode=require" in result
+        )
+
+
+def test_create_db_connection_url_generate_token():
+    """Test database connection URL creation with token generation"""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    with patch.dict(
+        "os.environ",
+        {
+            "MWAA__DB__POSTGRES_HOST": "test.rds.amazonaws.com",
+            "MWAA__DB__POSTGRES_PORT": "5432",
+            "MWAA__DB__POSTGRES_DB": "airflow",
+            "MWAA__DB__POSTGRES_SSLMODE": "require",
+        },
+    ), patch.object(
+        RDSIAMCredentialProvider, "generate_credentials", return_value="generated_token"
+    ):
+        result = RDSIAMCredentialProvider.create_db_connection_url()
+        assert (
+            "postgresql+psycopg2://airflow_user:generated_token"
+            "@test.rds.amazonaws.com:5432/airflow?sslmode=require" in result
+        )
+
+
+def test_use_iam_credentials():
+    """Test IAM credentials flag detection"""
+    from mwaa.config.rds_iam_credentials import use_iam_credentials
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "true"}):
+        assert use_iam_credentials() is True
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}):
+        assert use_iam_credentials() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert use_iam_credentials() is False
+
+
+def test_is_using_rds_proxy():
+    """Test RDS proxy detection"""
+    from mwaa.config.rds_iam_credentials import is_using_rds_proxy
+
+    with patch.dict("os.environ", {"MWAA__DB__POSTGRES_SSLMODE": "require"}):
+        assert is_using_rds_proxy() is True
+
+    with patch.dict("os.environ", {"MWAA__DB__POSTGRES_SSLMODE": "disable"}):
+        assert is_using_rds_proxy() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert is_using_rds_proxy() is False

--- a/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py
@@ -144,11 +144,11 @@ def test_install_rds_iam_patch_not_installed_no_iam():
     """Test patch not installed when USE_IAM_CREDENTIALS is not true"""
     from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
-    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}, clear=True), patch(
-        "sqlalchemy.event.listen"
-    ) as mock_listen:
-        install_rds_iam_patch()
-        mock_listen.assert_not_called()
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}, clear=True):
+        _reset_patch_state()
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_not_called()
 
 
 def test_install_rds_iam_patch_not_installed_no_rds_proxy():
@@ -158,9 +158,11 @@ def test_install_rds_iam_patch_not_installed_no_rds_proxy():
     with patch.dict(
         "os.environ",
         {"USE_IAM_CREDENTIALS": "true", "MWAA__DB__POSTGRES_SSLMODE": "disable"},
-    ), patch("sqlalchemy.event.listen") as mock_listen:
-        install_rds_iam_patch()
-        mock_listen.assert_not_called()
+    ):
+        _reset_patch_state()
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_not_called()
 
 
 def test_install_rds_iam_patch_not_installed_migrate_db():
@@ -469,7 +471,9 @@ def test_do_connect_listener_injects_the_token():
         "dbname": "AirflowMetadata",
         "port": 5432,
         "user": "airflow_user",
-        "stale": "should be cleared",
+        # Engine connect_args (MWAA_CONNECT_ARGS) arrive via cparams.
+        "connect_timeout": 15,
+        "keepalives": 1,
     }
 
     with patch.dict("os.environ", env, clear=True), patch.object(
@@ -480,12 +484,16 @@ def test_do_connect_listener_injects_the_token():
         _clear_metadata_url_cache(m)
         captured["fn"]("postgresql", None, [], cparams)
 
-    # cparams was rebuilt from the IAM URL, and the pre-existing key is gone.
-    assert "stale" not in cparams
+    # Credentials were rebuilt from the IAM URL.
     assert cparams["password"] == "tok"
     assert cparams["host"] == "proxy.rds.amazonaws.com"
     # 'dbname'/'database' must not both be present (psycopg2 rejects that).
     assert not ("dbname" in cparams and "database" in cparams)
+    # Engine connect_args that arrive via cparams (connect_timeout and the
+    # keepalives* settings from MWAA_CONNECT_ARGS) must survive the token
+    # injection; only the aliased credential keys are replaced.
+    assert cparams["connect_timeout"] == 15
+    assert cparams["keepalives"] == 1
 
 
 def test_do_connect_listener_ignores_other_databases():

--- a/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py
@@ -333,3 +333,240 @@ def test_airflow_local_settings_installs_the_patch():
 
     # Must not leak names into the airflow.settings namespace.
     assert module.__all__ == []
+
+
+# --- Coverage for the customer-settings loading and the listener body ---
+
+_LS_VERSION = "3.3.0"
+
+
+def _local_settings_file():
+    import os
+
+    path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..", "..", "..", "..", "..", "..", "..",
+            "images", "airflow", _LS_VERSION, "airflow_local_settings.py",
+        )
+    )
+    assert os.path.exists(path), f"missing override: {path}"
+    return path
+
+
+def _exec_local_settings(airflow_home=None):
+    """Execute the shipped airflow_local_settings.py with the patch stubbed out."""
+    import importlib.util
+
+    env = {"AIRFLOW_HOME": airflow_home} if airflow_home else {}
+    with patch.dict("os.environ", env), patch(
+        "mwaa.config.rds_iam_patch.install_rds_iam_patch"
+    ):
+        spec = importlib.util.spec_from_file_location(
+            "mwaa_test_local_settings_cov", _local_settings_file()
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+def _write_customer_file(home, subdir, body):
+    import os
+
+    os.makedirs(os.path.join(home, subdir), exist_ok=True)
+    with open(os.path.join(home, subdir, "airflow_local_settings.py"), "w") as f:
+        f.write(body)
+
+
+def test_customer_settings_in_dags_are_executed(tmp_path):
+    """A customer file in dags/ must be loaded, so its side effects apply."""
+    marker = tmp_path / "dags_ran"
+    _write_customer_file(
+        str(tmp_path),
+        "dags",
+        f"open({str(marker)!r}, 'w').write('ran')\n",
+    )
+
+    _exec_local_settings(str(tmp_path))
+
+    assert marker.exists(), "dags/airflow_local_settings.py was not executed"
+
+
+def test_customer_settings_in_plugins_are_executed(tmp_path):
+    """A customer file in plugins/ must be loaded too."""
+    marker = tmp_path / "plugins_ran"
+    _write_customer_file(
+        str(tmp_path),
+        "plugins",
+        f"open({str(marker)!r}, 'w').write('ran')\n",
+    )
+
+    _exec_local_settings(str(tmp_path))
+
+    assert marker.exists(), "plugins/airflow_local_settings.py was not executed"
+
+
+def test_broken_customer_settings_propagate(tmp_path):
+    """A customer file that fails to load must surface, not be swallowed.
+
+    Matches what Airflow does natively when a local settings file raises.
+    """
+    _write_customer_file(str(tmp_path), "plugins", "raise ValueError('customer bug')\n")
+
+    with pytest.raises(ValueError, match="customer bug"):
+        _exec_local_settings(str(tmp_path))
+
+
+def test_patch_install_failure_propagates():
+    """A failure installing the RDS IAM patch must not be silently ignored."""
+    import importlib.util
+
+    with patch(
+        "mwaa.config.rds_iam_patch.install_rds_iam_patch",
+        side_effect=RuntimeError("patch install blew up"),
+    ):
+        spec = importlib.util.spec_from_file_location(
+            "mwaa_test_local_settings_fail", _local_settings_file()
+        )
+        module = importlib.util.module_from_spec(spec)
+        with pytest.raises(RuntimeError, match="patch install blew up"):
+            spec.loader.exec_module(module)
+
+
+def test_do_connect_listener_injects_the_token():
+    """Exercise the registered listener body, not just its registration."""
+    from mwaa.config import rds_iam_patch as m
+
+    captured = {}
+
+    def fake_listen(target, name, fn):
+        captured["fn"] = fn
+
+    env = {
+        "USE_IAM_CREDENTIALS": "true",
+        "MWAA__DB__POSTGRES_HOST": "proxy.rds.amazonaws.com",
+        "MWAA__DB__POSTGRES_PORT": "5432",
+        "MWAA__DB__POSTGRES_DB": "AirflowMetadata",
+        "MWAA__DB__POSTGRES_SSLMODE": "require",
+        "MWAA__DB__CREDENTIALS": '{"username": "airflow_user", "password": "pw"}',
+        "MWAA_AIRFLOW_COMPONENT": "scheduler",
+    }
+
+    with patch.dict("os.environ", env, clear=True), patch(
+        "sqlalchemy.event.listen", side_effect=fake_listen
+    ):
+        _reset_patch_state()
+        m.install_rds_iam_patch()
+
+    assert "fn" in captured, "listener was not registered"
+
+    token_url = (
+        "postgresql+psycopg2://airflow_user:tok"
+        "@proxy.rds.amazonaws.com:5432/AirflowMetadata?sslmode=require"
+    )
+    cparams = {
+        "host": "proxy.rds.amazonaws.com",
+        "dbname": "AirflowMetadata",
+        "port": 5432,
+        "user": "airflow_user",
+        "stale": "should be cleared",
+    }
+
+    with patch.dict("os.environ", env, clear=True), patch.object(
+        m.RDSIAMCredentialProvider, "get_token", return_value="tok"
+    ), patch.object(
+        m.RDSIAMCredentialProvider, "create_db_connection_url", return_value=token_url
+    ):
+        _clear_metadata_url_cache(m)
+        captured["fn"]("postgresql", None, [], cparams)
+
+    # cparams was rebuilt from the IAM URL, and the pre-existing key is gone.
+    assert "stale" not in cparams
+    assert cparams["password"] == "tok"
+    assert cparams["host"] == "proxy.rds.amazonaws.com"
+    # 'dbname'/'database' must not both be present (psycopg2 rejects that).
+    assert not ("dbname" in cparams and "database" in cparams)
+
+
+def test_do_connect_listener_ignores_other_databases():
+    """Connections that are not the metadata DB must be left untouched."""
+    from mwaa.config import rds_iam_patch as m
+
+    captured = {}
+    env = {
+        "USE_IAM_CREDENTIALS": "true",
+        "MWAA__DB__POSTGRES_HOST": "proxy.rds.amazonaws.com",
+        "MWAA__DB__POSTGRES_PORT": "5432",
+        "MWAA__DB__POSTGRES_DB": "AirflowMetadata",
+        "MWAA__DB__POSTGRES_SSLMODE": "require",
+        "MWAA__DB__CREDENTIALS": '{"username": "airflow_user", "password": "pw"}',
+        "MWAA_AIRFLOW_COMPONENT": "scheduler",
+    }
+
+    with patch.dict("os.environ", env, clear=True), patch(
+        "sqlalchemy.event.listen", side_effect=lambda t, n, fn: captured.update(fn=fn)
+    ):
+        _reset_patch_state()
+        m.install_rds_iam_patch()
+
+    other = {"host": "someone-elses-db", "dbname": "other", "port": 5432, "user": "x"}
+    before = dict(other)
+
+    with patch.dict("os.environ", env, clear=True), patch.object(
+        m.RDSIAMCredentialProvider, "get_token"
+    ) as get_token:
+        _clear_metadata_url_cache(m)
+        captured["fn"]("postgresql", None, [], other)
+        get_token.assert_not_called()
+
+    assert other == before
+
+
+def test_metadata_detection_tolerates_unparseable_cargs():
+    """A malformed DSN in cargs must not raise out of the listener."""
+    from mwaa.config import rds_iam_patch as m
+
+    with patch.object(m, "_get_metadata_url") as mock_url:
+        mock_url.return_value = MagicMock(
+            host="h", database="d", port=5432, username="airflow_user"
+        )
+        # Not a URL at all; the cargs branch must swallow the parse error and
+        # fall through to the cparams check.
+        assert m._is_accessing_metadata_db("postgresql", ["not-a-dsn"], {}) is False
+
+
+def test_dblock_connect_uses_iam_token_when_enabled():
+    """dblock's maintenance connection must use IAM when the feature is on."""
+    from mwaa.utils import dblock
+
+    env = {
+        "USE_IAM_CREDENTIALS": "true",
+        "MWAA__DB__POSTGRES_SSLMODE": "require",
+    }
+    with patch.dict("os.environ", env, clear=True), patch.object(
+        dblock, "create_engine"
+    ) as create_engine, patch(
+        "mwaa.config.rds_iam_credentials.RDSIAMCredentialProvider.get_token",
+        return_value="tok",
+    ), patch(
+        "mwaa.config.rds_iam_credentials.RDSIAMCredentialProvider."
+        "create_db_connection_url",
+        return_value="postgresql+psycopg2://airflow_user:tok@h:5432/d",
+    ):
+        dblock._connect_with_retry()
+
+    assert create_engine.call_args.args[0].endswith("@h:5432/d")
+
+
+def test_dblock_connect_uses_static_credentials_when_disabled():
+    """With the flag off it must fall back to the static connection string."""
+    from mwaa.utils import dblock
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}, clear=True), \
+            patch.object(dblock, "create_engine") as create_engine, \
+            patch.object(
+                dblock, "get_db_connection_string", return_value="postgresql://static"
+            ):
+        dblock._connect_with_retry()
+
+    assert create_engine.call_args.args[0] == "postgresql://static"

--- a/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py
@@ -1,0 +1,206 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def test_is_from_migrate_db():
+    """Test migrate-db detection"""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict("os.environ", {"MWAA_AIRFLOW_COMPONENT": "migrate-db"}):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import _is_from_migrate_db
+
+        assert _is_from_migrate_db() is True
+
+    with patch.dict("os.environ", {"MWAA_AIRFLOW_COMPONENT": "scheduler"}):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import _is_from_migrate_db
+
+        assert _is_from_migrate_db() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import _is_from_migrate_db
+
+        assert _is_from_migrate_db() is False
+
+
+def test_is_using_rds_proxy():
+    """Test RDS proxy detection via is_using_rds_proxy helper"""
+    from mwaa.config.rds_iam_credentials import is_using_rds_proxy
+
+    with patch.dict("os.environ", {"MWAA__DB__POSTGRES_SSLMODE": "require"}):
+        assert is_using_rds_proxy() is True
+
+    with patch.dict("os.environ", {"MWAA__DB__POSTGRES_SSLMODE": "disable"}):
+        assert is_using_rds_proxy() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert is_using_rds_proxy() is False
+
+
+def test_use_iam_credentials():
+    """Test IAM credentials flag detection"""
+    from mwaa.config.rds_iam_credentials import use_iam_credentials
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "true"}):
+        assert use_iam_credentials() is True
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}):
+        assert use_iam_credentials() is False
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert use_iam_credentials() is False
+
+
+def test_is_accessing_metadata_db():
+    """Test metadata database detection"""
+    from mwaa.config.rds_iam_patch import _is_accessing_metadata_db
+
+    with patch(
+        "mwaa.config.rds_iam_patch._get_metadata_url"
+    ) as mock_get_url:
+        mock_url = MagicMock()
+        mock_url.host = "test.rds.amazonaws.com"
+        mock_url.database = "airflow"
+        mock_url.port = 5432
+        mock_get_url.return_value = mock_url
+
+        # Test with matching parameters including username
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "database": "airflow",
+            "port": 5432,
+            "username": "airflow_user",
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is True
+
+        # Test with adminuser username
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "database": "airflow",
+            "port": 5432,
+            "username": "adminuser",
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is True
+
+        # Test with non-matching parameters
+        cparams = {
+            "host": "other.rds.amazonaws.com",
+            "database": "other",
+            "port": 3306,
+            "username": "airflow_user",
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is False
+
+        # Test with missing username
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "database": "airflow",
+            "port": 5432,
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is False
+
+
+def test_is_accessing_metadata_db_with_cargs():
+    """Test metadata database detection using cargs"""
+    from mwaa.config.rds_iam_patch import _is_accessing_metadata_db
+
+    with patch(
+        "mwaa.config.rds_iam_patch._get_metadata_url"
+    ) as mock_get_url:
+        mock_url = MagicMock()
+        mock_url.host = "test.rds.amazonaws.com"
+        mock_url.database = "airflow"
+        mock_url.port = 5432
+        mock_get_url.return_value = mock_url
+
+        # Test with matching cargs including airflow_user
+        cargs = ["postgresql://airflow_user:pass@test.rds.amazonaws.com:5432/airflow"]
+        assert _is_accessing_metadata_db("postgresql", cargs, {}) is True
+
+        # Test with matching cargs including adminuser
+        cargs = ["postgresql://adminuser:pass@test.rds.amazonaws.com:5432/airflow"]
+        assert _is_accessing_metadata_db("postgresql", cargs, {}) is True
+
+
+def test_is_accessing_metadata_db_no_conn_str():
+    """Test metadata database detection when no connection string is set"""
+    from mwaa.config.rds_iam_patch import _is_accessing_metadata_db
+
+    with patch(
+        "mwaa.config.rds_iam_patch._get_metadata_url", return_value=None
+    ):
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "database": "airflow",
+            "port": 5432,
+            "username": "airflow_user",
+        }
+        assert _is_accessing_metadata_db("postgresql", [], cparams) is False
+
+
+def test_install_rds_iam_patch_not_installed_no_iam():
+    """Test patch not installed when USE_IAM_CREDENTIALS is not true"""
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+    with patch.dict("os.environ", {"USE_IAM_CREDENTIALS": "false"}, clear=True), patch(
+        "sqlalchemy.event.listen"
+    ) as mock_listen:
+        install_rds_iam_patch()
+        mock_listen.assert_not_called()
+
+
+def test_install_rds_iam_patch_not_installed_no_rds_proxy():
+    """Test patch not installed when not using RDS Proxy"""
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+    with patch.dict(
+        "os.environ",
+        {"USE_IAM_CREDENTIALS": "true", "MWAA__DB__POSTGRES_SSLMODE": "disable"},
+    ), patch("sqlalchemy.event.listen") as mock_listen:
+        install_rds_iam_patch()
+        mock_listen.assert_not_called()
+
+
+def test_install_rds_iam_patch_not_installed_migrate_db():
+    """Test patch not installed for migrate-db process"""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict(
+        "os.environ",
+        {
+            "USE_IAM_CREDENTIALS": "true",
+            "MWAA__DB__POSTGRES_SSLMODE": "require",
+            "MWAA_AIRFLOW_COMPONENT": "migrate-db",
+        },
+    ):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_not_called()
+
+
+def test_install_rds_iam_patch_installed():
+    """Test patch installed when all conditions are met"""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict(
+        "os.environ",
+        {
+            "USE_IAM_CREDENTIALS": "true",
+            "MWAA__DB__POSTGRES_SSLMODE": "require",
+            "MWAA_AIRFLOW_COMPONENT": "scheduler",
+        },
+    ):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_called_once()

--- a/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py
@@ -2,27 +2,26 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 
+def _reset_patch_state():
+    """Reset the one-shot install flag so a test can install the patch again."""
+    from mwaa.config import rds_iam_patch
+
+    rds_iam_patch._patch_installed = False
+    getattr(rds_iam_patch._get_metadata_url, "cache_clear", lambda: None)()
+
+
+
 def test_is_from_migrate_db():
     """Test migrate-db detection"""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import _is_from_migrate_db
 
     with patch.dict("os.environ", {"MWAA_AIRFLOW_COMPONENT": "migrate-db"}):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import _is_from_migrate_db
-
         assert _is_from_migrate_db() is True
 
     with patch.dict("os.environ", {"MWAA_AIRFLOW_COMPONENT": "scheduler"}):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import _is_from_migrate_db
-
         assert _is_from_migrate_db() is False
 
     with patch.dict("os.environ", {}, clear=True):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import _is_from_migrate_db
-
         assert _is_from_migrate_db() is False
 
 
@@ -166,8 +165,7 @@ def test_install_rds_iam_patch_not_installed_no_rds_proxy():
 
 def test_install_rds_iam_patch_not_installed_migrate_db():
     """Test patch not installed for migrate-db process"""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
     with patch.dict(
         "os.environ",
@@ -177,9 +175,7 @@ def test_install_rds_iam_patch_not_installed_migrate_db():
             "MWAA_AIRFLOW_COMPONENT": "migrate-db",
         },
     ):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-
+        _reset_patch_state()
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             mock_listen.assert_not_called()
@@ -187,8 +183,7 @@ def test_install_rds_iam_patch_not_installed_migrate_db():
 
 def test_install_rds_iam_patch_installed():
     """Test patch installed when all conditions are met"""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
     with patch.dict(
         "os.environ",
@@ -198,9 +193,7 @@ def test_install_rds_iam_patch_installed():
             "MWAA_AIRFLOW_COMPONENT": "scheduler",
         },
     ):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-
+        _reset_patch_state()
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             mock_listen.assert_called_once()
@@ -265,11 +258,9 @@ def test_get_metadata_url_returns_none_on_missing_config():
 
 def test_end_to_end_metadata_db_detected_without_airflow_conn_var():
     """The patch must recognise the metadata DB using only MWAA__DB__* vars."""
-    import importlib
     import mwaa.config.rds_iam_patch
 
     with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
-        importlib.reload(mwaa.config.rds_iam_patch)
         _clear_metadata_url_cache(mwaa.config.rds_iam_patch)
         cparams = {
             "host": "test.rds.amazonaws.com",
@@ -287,15 +278,12 @@ def test_end_to_end_metadata_db_detected_without_airflow_conn_var():
 
 def test_install_rds_iam_patch_not_installed_local_runner():
     """Test patch not installed when running as the local runner."""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
     with patch.dict(
         "os.environ", {**_RDS_PROXY_ENV, "MWAA_LOCAL_RUNNER": "true"}, clear=True
     ):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-
+        _reset_patch_state()
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             mock_listen.assert_not_called()
@@ -303,13 +291,10 @@ def test_install_rds_iam_patch_not_installed_local_runner():
 
 def test_install_rds_iam_patch_is_idempotent():
     """Installing twice in one process must register only one listener."""
-    import importlib
-    import mwaa.config.rds_iam_patch
+    from mwaa.config.rds_iam_patch import install_rds_iam_patch
 
     with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
-        importlib.reload(mwaa.config.rds_iam_patch)
-        from mwaa.config.rds_iam_patch import install_rds_iam_patch
-
+        _reset_patch_state()
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             install_rds_iam_patch()

--- a/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py
@@ -204,3 +204,147 @@ def test_install_rds_iam_patch_installed():
         with patch("sqlalchemy.event.listen") as mock_listen:
             install_rds_iam_patch()
             mock_listen.assert_called_once()
+
+
+def _clear_metadata_url_cache(module=None):
+    """Clear the cached metadata URL, tolerating an uncached implementation."""
+    if module is None:
+        from mwaa.config import rds_iam_patch as module
+    getattr(module._get_metadata_url, "cache_clear", lambda: None)()
+
+
+# --- Regression tests for the aspects restored from the 2.x implementation ---
+
+# Environment describing a metadata DB reachable through an RDS Proxy. Note the
+# deliberate absence of AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: that variable is
+# only injected into the environment dict handed to the Airflow subprocesses, so
+# code running in-process must not depend on it.
+_RDS_PROXY_ENV = {
+    "USE_IAM_CREDENTIALS": "true",
+    "MWAA__DB__POSTGRES_HOST": "test.rds.amazonaws.com",
+    "MWAA__DB__POSTGRES_PORT": "5432",
+    "MWAA__DB__POSTGRES_DB": "AirflowMetadata",
+    "MWAA__DB__POSTGRES_SSLMODE": "require",
+    "MWAA__DB__CREDENTIALS": '{"username": "airflow_user", "password": "pw"}',
+    "MWAA_AIRFLOW_COMPONENT": "scheduler",
+}
+
+
+def test_get_metadata_url_derived_from_mwaa_db_env_vars():
+    """The metadata URL must come from MWAA__DB__*, not from the Airflow conn var.
+
+    Regression test: sourcing it from AIRFLOW__DATABASE__SQL_ALCHEMY_CONN made
+    _get_metadata_url() return None in every process, which silently disabled
+    token injection.
+    """
+    from mwaa.config.rds_iam_patch import _get_metadata_url
+
+    with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
+        _clear_metadata_url_cache()
+        try:
+            url = _get_metadata_url()
+            assert url is not None
+            assert url.host == "test.rds.amazonaws.com"
+            assert url.database == "AirflowMetadata"
+            assert url.port == 5432
+        finally:
+            _clear_metadata_url_cache()
+
+
+def test_get_metadata_url_returns_none_on_missing_config():
+    """A misconfigured environment must not raise into the do_connect listener."""
+    from mwaa.config.rds_iam_patch import _get_metadata_url
+
+    with patch.dict("os.environ", {}, clear=True):
+        _clear_metadata_url_cache()
+        try:
+            assert _get_metadata_url() is None
+        finally:
+            _clear_metadata_url_cache()
+
+
+def test_end_to_end_metadata_db_detected_without_airflow_conn_var():
+    """The patch must recognise the metadata DB using only MWAA__DB__* vars."""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        _clear_metadata_url_cache(mwaa.config.rds_iam_patch)
+        cparams = {
+            "host": "test.rds.amazonaws.com",
+            "dbname": "AirflowMetadata",
+            "port": 5432,
+            "user": "airflow_user",
+        }
+        assert (
+            mwaa.config.rds_iam_patch._is_accessing_metadata_db(
+                "postgresql", [], cparams
+            )
+            is True
+        )
+
+
+def test_install_rds_iam_patch_not_installed_local_runner():
+    """Test patch not installed when running as the local runner."""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict(
+        "os.environ", {**_RDS_PROXY_ENV, "MWAA_LOCAL_RUNNER": "true"}, clear=True
+    ):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            mock_listen.assert_not_called()
+
+
+def test_install_rds_iam_patch_is_idempotent():
+    """Installing twice in one process must register only one listener."""
+    import importlib
+    import mwaa.config.rds_iam_patch
+
+    with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
+        importlib.reload(mwaa.config.rds_iam_patch)
+        from mwaa.config.rds_iam_patch import install_rds_iam_patch
+
+        with patch("sqlalchemy.event.listen") as mock_listen:
+            install_rds_iam_patch()
+            install_rds_iam_patch()
+            install_rds_iam_patch()
+            mock_listen.assert_called_once()
+
+
+def test_airflow_local_settings_installs_the_patch():
+    """airflow_local_settings.py is the hook Airflow loads in every process.
+
+    Regression test for the dropped override: without this file the do_connect
+    listener is never registered in the scheduler/worker/api-server processes,
+    which are separate Popen children of the entrypoint.
+    """
+    import importlib.util
+    import os
+
+    settings_path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..", "..", "..", "..", "..", "..", "..",
+            "images", "airflow", "3.3.0", "airflow_local_settings.py",
+        )
+    )
+    assert os.path.exists(settings_path), f"missing override: {settings_path}"
+
+    with patch(
+        "mwaa.config.rds_iam_patch.install_rds_iam_patch"
+    ) as mock_install:
+        spec = importlib.util.spec_from_file_location(
+            "mwaa_test_airflow_local_settings", settings_path
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        mock_install.assert_called_once()
+
+    # Must not leak names into the airflow.settings namespace.
+    assert module.__all__ == []

--- a/tests/images/airflow/3.3.0/python/mwaa/database/test_migrate_with_downgrade_3_3_0.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/database/test_migrate_with_downgrade_3_3_0.py
@@ -14,7 +14,7 @@ import os
 import types
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 _AIRFLOW_VERSION = "3.3.0"
 
@@ -124,3 +124,130 @@ def test_no_iam_fallback_attempted_when_not_using_rds_proxy():
         ) as mock_get_token:
             module._ensure_rds_iam_user()  # must not raise
             mock_get_token.assert_not_called()
+
+
+# --- Grant application paths ---
+
+
+def _mock_engine(current_user, role_exists=True, fail_on=None):
+    """Build a mock engine whose connection answers the role queries.
+
+    Patched in at ``create_engine``, which both module shapes route through:
+    3.0.6 builds the engine in an inline ``_connect_static()`` while 3.2.1 and
+    3.3.0 use a shared ``_create_engine_with_retry()``.
+
+    :param fail_on: substring of a statement that should raise instead of
+        returning, used to exercise the grant-failure path.
+    """
+    conn = MagicMock()
+
+    def execute(statement, params=None):
+        text = str(statement)
+        if fail_on and fail_on in text:
+            raise Exception(f"failed executing {fail_on}")
+        result = MagicMock()
+        if "pg_roles" in text:
+            result.fetchone.return_value = (1,) if role_exists else None
+        elif "current_user" in text:
+            result.scalar.return_value = current_user
+        return result
+
+    conn.execute.side_effect = execute
+    engine = MagicMock()
+    engine.connect.return_value.__enter__.return_value = conn
+    return engine, conn
+
+
+def _executed_statements(conn):
+    return [str(call.args[0]) for call in conn.execute.call_args_list]
+
+
+def test_grants_are_applied_when_connected_as_adminuser():
+    """The full grant block must run when the current role can grant."""
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, conn = _mock_engine(current_user="adminuser")
+
+        with patch.object(module, "create_engine", return_value=engine):
+            module._ensure_rds_iam_user()
+
+    statements = " | ".join(_executed_statements(conn))
+    assert "GRANT rds_iam TO airflow_user" in statements
+    assert 'GRANT ALL PRIVILEGES ON DATABASE "AirflowMetadata" TO airflow_user' in statements
+    assert "GRANT ALL ON SCHEMA public TO airflow_user" in statements
+    assert "GRANT ALL ON ALL TABLES IN SCHEMA public TO airflow_user" in statements
+    assert "GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO airflow_user" in statements
+    assert "GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO airflow_user" in statements
+    assert "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES" in statements
+    assert "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES" in statements
+    assert "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS" in statements
+    # The grant that lets airflow_user inherit objects created by adminuser.
+    assert "GRANT adminuser TO airflow_user" in statements
+
+
+def test_iam_user_is_created_when_missing():
+    """A missing role must be created before the grants are applied."""
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, conn = _mock_engine(current_user="adminuser", role_exists=False)
+
+        with patch.object(module, "create_engine", return_value=engine):
+            module._ensure_rds_iam_user()
+
+    assert "CREATE USER airflow_user" in " | ".join(_executed_statements(conn))
+
+
+def test_grants_are_skipped_when_connected_as_airflow_user():
+    """airflow_user cannot grant, so the block must be skipped, not attempted.
+
+    Note this is also how grants end up never applied when only the IAM path
+    works, since that connects as airflow_user -- tracked separately.
+    """
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, conn = _mock_engine(current_user="airflow_user")
+
+        with patch.object(module, "create_engine", return_value=engine):
+            module._ensure_rds_iam_user()
+
+    statements = " | ".join(_executed_statements(conn))
+    assert "GRANT" not in statements
+
+
+def test_grant_failure_is_swallowed():
+    """Errors while applying grants log and return; they must not propagate."""
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, _ = _mock_engine(current_user="adminuser", fail_on="pg_roles")
+
+        with patch.object(module, "create_engine", return_value=engine):
+            module._ensure_rds_iam_user()  # must not raise
+
+
+def test_iam_fallback_succeeds_and_applies_grants():
+    """A working IAM fallback must proceed to the role handling.
+
+    Exercises the fallback engine construction, which otherwise only runs on the
+    failure paths.
+    """
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+        engine, conn = _mock_engine(current_user="airflow_user")
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ), patch.object(
+            module.RDSIAMCredentialProvider, "get_token", return_value="tok"
+        ), patch.object(
+            module.RDSIAMCredentialProvider,
+            "create_db_connection_url",
+            return_value="postgresql+psycopg2://airflow_user:tok@h:5432/d",
+        ), patch.object(
+            module, "create_engine", return_value=engine
+        ):
+            module._ensure_rds_iam_user()
+
+    # Reached the role query via the IAM engine.
+    assert any("current_user" in s for s in _executed_statements(conn))

--- a/tests/images/airflow/3.3.0/python/mwaa/database/test_migrate_with_downgrade_3_3_0.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/database/test_migrate_with_downgrade_3_3_0.py
@@ -1,0 +1,126 @@
+"""Tests for _ensure_rds_iam_user credential-failure semantics.
+
+migrate_with_downgrade.py deliberately refuses to be imported (it ends in an
+``else: sys.exit(1)`` guard so it can only be run as a script), so these tests
+execute the module body up to that guard in a throwaway namespace.
+
+The static connection is failed by patching ``get_db_connection_string``, which
+both module shapes route through: 3.0.6 builds the engine in an inline
+``_connect_static()``, while 3.2.1 and 3.3.0 use a shared
+``_create_engine_with_retry()``.
+"""
+
+import os
+import types
+
+import pytest
+from unittest.mock import patch
+
+_AIRFLOW_VERSION = "3.3.0"
+
+_BASE_ENV = {
+    "MWAA__DB__POSTGRES_HOST": "test.rds.amazonaws.com",
+    "MWAA__DB__POSTGRES_PORT": "5432",
+    "MWAA__DB__POSTGRES_DB": "AirflowMetadata",
+    "MWAA__DB__POSTGRES_SSLMODE": "require",
+    "MWAA__DB__CREDENTIALS": '{"username": "adminuser", "password": "pw"}',
+    "AWS_EXECUTION_ENV": "Amazon_MWAA_test",
+}
+
+
+def _load_module():
+    """Execute migrate_with_downgrade.py up to its no-import guard."""
+    path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..", "..", "..", "..", "..", "..", "..",
+            "images", "airflow", _AIRFLOW_VERSION,
+            "python", "mwaa", "database", "migrate_with_downgrade.py",
+        )
+    )
+    assert os.path.exists(path), f"missing module: {path}"
+    source = open(path).read()
+    guard = source.index('if __name__ == "__main__":')
+    module = types.ModuleType("mwaa_migrate_with_downgrade_probe")
+    module.__file__ = path
+    exec(compile(source[:guard], path, "exec"), module.__dict__)
+    return module
+
+
+def test_raises_when_static_and_iam_both_fail():
+    """Neither credential path working must fail loudly, not skip.
+
+    The grants cannot be applied without a connection, so migrate-db must not
+    continue: the container should fail. Asserted explicitly because every other
+    failure path in this function logs a warning and returns.
+    """
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ), patch.object(
+            module.RDSIAMCredentialProvider,
+            "get_token",
+            side_effect=Exception("could not mint IAM token"),
+        ):
+            with pytest.raises(RuntimeError, match="static or RDS IAM credentials"):
+                module._ensure_rds_iam_user()
+
+
+def test_chains_the_underlying_iam_error():
+    """The original IAM failure must be preserved for debugging."""
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}):
+        module = _load_module()
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ), patch.object(
+            module.RDSIAMCredentialProvider,
+            "get_token",
+            side_effect=Exception("could not mint IAM token"),
+        ):
+            with pytest.raises(RuntimeError) as excinfo:
+                module._ensure_rds_iam_user()
+
+    assert "could not mint IAM token" in str(excinfo.value.__cause__)
+
+
+def test_skips_without_raising_when_iam_is_disabled():
+    """With the feature flag off, a static failure stays best-effort.
+
+    This preserves the pre-existing contract for non-IAM environments: the
+    function logs and returns so migrate-db can carry on.
+    """
+    with patch.dict("os.environ", {**_BASE_ENV, "USE_IAM_CREDENTIALS": "false"}):
+        module = _load_module()
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ):
+            module._ensure_rds_iam_user()  # must not raise
+
+
+def test_no_iam_fallback_attempted_when_not_using_rds_proxy():
+    """IAM auth is only supported through RDS Proxy, so don't try otherwise."""
+    env = {**_BASE_ENV, "USE_IAM_CREDENTIALS": "true"}
+    env["MWAA__DB__POSTGRES_SSLMODE"] = "prefer"
+
+    with patch.dict("os.environ", env):
+        module = _load_module()
+
+        with patch.object(
+            module,
+            "get_db_connection_string",
+            side_effect=Exception("static credentials rejected"),
+        ), patch.object(
+            module.RDSIAMCredentialProvider, "get_token"
+        ) as mock_get_token:
+            module._ensure_rds_iam_user()  # must not raise
+            mock_get_token.assert_not_called()


### PR DESCRIPTION
## Summary

Ports RDS IAM credential rotation from the 2.x images to Airflow 3.0.6, 3.2.1, and 3.3.0. This enables IAM-based authentication for metadata DB connections when connecting through RDS Proxy.

The 2.x implementation (`mwaa/utils/get_rds_iam_credentials.py`, `mwaa/config/airflow_rds_iam_patch.py`) is restructured into the 3.x `mwaa.config` package.

**Scope:** this is a port, so it stays behaviourally equivalent to 2.x. Several defects that exist identically in the 2.x images were found while reviewing it; those are listed under Known gaps and are being fixed in cross-version follow-ups rather than only for 3.x. The only intentional divergences are the ones 3.x structurally requires, called out below.

### New modules (per version)

- `mwaa/config/rds_iam_credentials.py` — `RDSIAMCredentialProvider` with thread-safe token caching (5-minute refresh buffer on the 15-minute token expiry), ECS task-credential fetching, boto3 RDS token generation, and connection URL construction from the `MWAA__DB__POSTGRES_*` environment variables.
- `mwaa/config/rds_iam_patch.py` — SQLAlchemy `Engine` `do_connect` event listener that intercepts metadata DB connections and swaps in a fresh IAM token.

### How the patch is loaded

`airflow_local_settings.py`, installed to `${AIRFLOW_USER_HOME}/config` by the Dockerfile, installs the patch — the same mechanism as 2.x. Airflow appends `$AIRFLOW_HOME/config` to `sys.path` and `import_local_settings()` imports `airflow_local_settings` from `settings.initialize()`, which `airflow/__init__.py` runs on every `import airflow`. That makes it the only correct install site: the patch registers a SQLAlchemy `do_connect` listener, and a listener only affects the process that registered it. The Airflow components are spawned by the entrypoint as separate `subprocess.Popen(["airflow", ...])` children with a fresh interpreter, so installing from the entrypoint alone leaves every process that actually talks to the metadata database unpatched.

As in 2.x, customer-provided `dags/airflow_local_settings.py` and `plugins/airflow_local_settings.py` are loaded so their side effects still apply. See Known gaps for the limitation this carries over.

### Intentional divergences from 2.x

Only where 3.x requires it:

- **`make_url` import.** 3.0.6 ships SQLAlchemy 1.4, where `make_url` is only importable from `sqlalchemy.engine`; 3.2.1 and 3.3.0 ship SQLAlchemy 2.0 and import it from `sqlalchemy`.
- **`cparams.clear()`.** SQLAlchemy 2.0's psycopg2 dialect puts `dbname` in `cparams` while `translate_connect_args()` returns `database`. Both present makes psycopg2 raise `you can't specify both 'database' and 'dbname' arguments`, so the listener clears `cparams` before rebuilding from the IAM URL. Not needed on 1.4.
- **`install_rds_iam_patch()` as a function** rather than 2.x's import side effect, which is what makes it testable. It carries an idempotency guard so repeated calls cannot stack listeners, matching the natural idempotency of 2.x's module import.
- **Lazy, fail-safe metadata URL.** 2.x resolves the metadata URL at module import time and raises if the `MWAA__DB__*` variables are absent, which would abort any Airflow process. Here it is resolved on demand, cached, and returns `None` rather than raising into the `do_connect` listener.
- **Explicit failure when no credential path works.** `_ensure_rds_iam_user()` tries static credentials then falls back to an IAM token; if neither opens a connection it raises a `RuntimeError` chained to the underlying error, failing migrate-db and therefore the container. Without a connection the grants cannot be applied, so continuing would bring the environment up in an unknown permission state. 2.x logs and skips. This is deliberate — the unguarded fallback was introduced by this port, so it had to be addressed here either way, and failing loudly was chosen over restoring the silent skip.

### Activation

Off by default. The patch installs only when all of the following hold:

- `USE_IAM_CREDENTIALS=true`
- `MWAA__DB__POSTGRES_SSLMODE=require` (set only for RDS Proxy environments; IAM auth is unsupported without the proxy)
- the process is not `migrate-db`, which uses admin credentials for schema migrations
- the process is not the local runner (`MWAA_LOCAL_RUNNER`)

## Revision history

The later commits fix the initial port, which was not functional. Reviewers looking at the first commits in isolation should note:

- The original port installed the patch from `entrypoint.py`, in the wrong process. An earlier version of this description presented that as an intentional improvement over the 2.x import side effect; that was incorrect, and the `airflow_local_settings.py` override it replaced was load-bearing.
- `_get_metadata_url()` read `AIRFLOW__DATABASE__SQL_ALCHEMY_CONN`. That variable is only placed in the environment dict handed to the Airflow subprocesses and is absent from `os.environ`, so it returned `None`, `_is_accessing_metadata_db()` returned `False`, and token injection was skipped even where the listener was present. It now derives from `get_db_connection_string()`, as 2.x does.
- The `is_local_runner()` guard, the IAM branch in `dblock.py`, and `GRANT adminuser TO airflow_user` had all been dropped.
- The IAM fallback in `_ensure_rds_iam_user()` was unguarded, so a failure propagated out of a function whose every other path logs and returns. A reply on an earlier revision defended this as 2.x parity; that was inaccurate — 2.x wraps the whole body in one `try/except`.

The branch also contains add/revert pairs where fixes for cross-version defects were implemented and then reverted once we settled on keeping this PR a straight port. Those are the Known gaps below.

## Testing

- 36 RDS IAM tests per version (108 total) pass on all three versions. Full suites: 351 on 3.0.6, 370 on 3.2.1, 369 on 3.3.0.
- Verified on SQLAlchemy 1.4.54 (3.0.6) and 2.0.51 (3.2.1, 3.3.0).
- `ruff check .` clean as CI runs it, and clean against each image's own config.

Coverage includes ECS credential retrieval, token generation and caching/refresh, connection URL construction, metadata DB detection via both `cargs` and `cparams`, every `install_rds_iam_patch()` decision branch, and the credential-failure semantics in `_ensure_rds_iam_user()`.

Regression tests cover each defect listed above and were confirmed to fail against the pre-fix code, individually rather than in aggregate. The pre-existing tests mocked `_get_metadata_url` wholesale, which is why the original defect shipped green.

## Known gaps — cross-version, tracked for follow-up

All of these exist identically in the five 2.x images. They are deliberately not fixed here so this PR stays a port and the fixes land uniformly.

- **Customer cluster policies are not registered.** Because `$AIRFLOW_HOME/config` precedes the plugins folder on `sys.path`, this file wins the `import airflow_local_settings` that Airflow performs, and Airflow reads policy names off the module it imported. The customer's file is executed but its names are never re-exported, so `task_policy`, `dag_policy`, `pod_mutation_hook` and settings overrides such as `STATE_COLORS` are silently dropped; only side effects apply. Verified against Airflow 3.0.6: with no MWAA file present the customer's policy registers with 1 hookimpl, with it present the count is 0. This is a regression introduced when `config/airflow_local_settings.py` was added in #381/#392, and #429 was intended to prevent it but only restored execution, not registration.
- **The ECS task credential fetch is unbounded and unretried.** `urllib` is called with no `timeout` and `socket.getdefaulttimeout()` is `None`, so it can block indefinitely — inside the `do_connect` listener. There is no retry, and `with_db_retry` does not help since it only covers `OperationalError` and `InterfaceError`. Per the Fargate Data Plane analysis in P481207036, connect timeouts to `169.254.170.2` are caused by client-side resource contention (a TMDS throttle breach would return HTTP 429 on a completed connection), so the mitigation is client-side timeouts and retries. Note botocore's `AWS_METADATA_SERVICE_TIMEOUT` does not apply, as this fetch is plain `urllib`.
- **Token refresh sits on the connection critical path.** The 15-minute lifetime with a 10-minute refresh exists so a refresh can happen off the critical path, but `get_token()` performs the fetch on the calling thread and holds the lock across it, so a slow fetch blocks every caller in the process. The refresh should be handed off while the still-valid cached token is served immediately.
- **`create_db_connection_url()` bypasses the token cache** on its default `token=None` path. No caller uses that path today, so it is a latent trap rather than an active regression.

Two further items, not cross-version:

- **`cparams.clear()` and non-URL connect args.** `AIRFLOW__DATABASE__SQL_ALCHEMY_CONNECT_ARGS` points at `mwaa.config.database.MWAA_CONNECT_ARGS` (`connect_timeout` and the `keepalives*` settings), which arrive via `cparams` rather than the URL. Clearing `cparams` drops them on IAM-patched connections. Worth confirming whether they need re-applying.
- **Grants are skipped when only IAM works.** If static credentials fail and the IAM fallback succeeds, the connection is as `airflow_user`, so the `current_user` gate skips every grant and the function returns successfully. Pre-existing 2.x behaviour.

For the 2.x follow-up, note that 2.9.2 relies on a `PYTHONPATH` override forcing `config` ahead of `dags`, because Airflow 2.9's single `prepare_syspath()` adds the DAGs folder first; removing it there would stop the patch loading at all. No equivalent is needed in 3.x, where no Airflow version puts the DAGs folder on `sys.path`.

## Compatibility

Backward compatible. With the feature flag unset there is no behavior change: `install_rds_iam_patch()` returns early and no SQLAlchemy listener is registered.

Note that `MWAA_LOCAL_RUNNER` is not forwarded into containers by `docker-compose`, in either 2.x or 3.x, so that guard is inert inside containers. The effective protection for local runs is `MWAA__DB__POSTGRES_SSLMODE: "prefer"` in `docker-compose.yaml`, which makes `is_using_rds_proxy()` false.
