### PR TITLE
Port NCL Airflow 3 task changes to 3.3.0

### DIFF
--- a/images/airflow/3.3.0/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.3.0/python/mwaa/logging/cloudwatch_handlers.py
@@ -392,55 +392,130 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
             handlers. And only the processor attribute from the remote logging class is loaded into the Structlog
             logger used for task logging.
         """
-        from logging import getLogRecordFactory
-
         import structlog.stdlib
-
-        logRecordFactory = getLogRecordFactory()
-        # The handler MUST be initted here, before the processor is actually used to log anything.
-        # Otherwise, logging that occurs during the creation of the handler can create infinite loops.
-        _handler = self.get_handler()
         from airflow.sdk.log import relative_path_from_logger
 
-        def proc(logger: structlog.typing.WrappedLogger, method_name: str, event: structlog.typing.EventDict):
-            if not logger or not (stream_name := relative_path_from_logger(logger)):
-                return event
-            _handler.log_stream_name = stream_name.as_posix().replace(":", "_")
-
-            if self.log_group_name.endswith("-Task") \
-                    and any(re.match(p, _handler.log_stream_name) for p in CloudWatchRemoteTaskLogger.IGNORED_PATTERNS):
-                return event
-
-            name = event.get("logger_name") or event.get("logger", "")
-            level = structlog.stdlib.NAME_TO_LEVEL.get(method_name.lower(), logging.INFO)
-            if level < self.log_level:
-                return event
-
-            msg = copy.copy(event)
-            created = None
-            if ts := msg.pop("timestamp", None):
-                with contextlib.suppress(Exception):
-                    created = datetime.fromisoformat(ts)
-            record = logRecordFactory(
-                name, level, pathname="", lineno=0, msg=msg, args=(), exc_info=None, func=None, sinfo=None
+        if self.NON_CRITICAL_LOGGING_ENABLED:
+            self.logs_source = "Task"
+            queue_overflow_handler, buffer_overflow_handler = _make_overflow_handlers("Task")
+            _handler = ForkSafeFluentHandler(
+                'customer.task.logs',
+                host='localhost',
+                port=24224,
+                queue_maxsize=50000,
+                queue_circular=True,
+                queue_overflow_handler=queue_overflow_handler,
+                buffer_overflow_handler=buffer_overflow_handler,
+                # Nanosecond precision to prevent whole-second ties in timestamp, which causes out of order logs in CloudWatch.
+                nanosecond_precision=True,
             )
-            if created is not None:
-                ct = created.timestamp()
-                record.created = ct
-                record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
-            try:
-                # In Airflow 3.1+, triggerer_job_runner's _process_log_messages_from_subprocess
-                # calls configure_logging() -> dictConfig() which shuts down all existing
-                # handlers, setting watchtower's shutting_down=True and silently dropping
-                # all subsequent log records. Reset it to keep sending.
-                if getattr(_handler, 'shutting_down', False):
-                    _handler.shutting_down = False
-                _handler.handle(record)
-            except Exception as e:
-                self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.emit_error", 1)
-                # TODO maybe consider removing this if we plan to make logging non-critical
-                raise e
-            return event
+            log_group = self.log_group_name
+            # Stash log_stream on the handler so the formatter can access it per-call
+            _handler._current_log_stream = ""
+
+            class _TaskRoutingFormatter(logging.Formatter):
+                def format(self, record) -> Dict[str, str]:  # type: ignore[override]
+                    return {
+                        'log_group': log_group,
+                        'log_stream': _handler._current_log_stream,
+                        'message': json.dumps(record.msg, default=str) if isinstance(record.msg, dict) else record.getMessage(),
+                    }
+
+            _handler.setFormatter(_TaskRoutingFormatter())
+            # Assign to self.handler so close() and upload() -> flush() drain the
+            # sender queue at task exit. The sender's send thread is a daemon thread,
+            # so without a proper close() the last log events of a task can be lost.
+            self.handler = _handler
+
+            def proc(logger: structlog.typing.WrappedLogger, method_name: str, event: structlog.typing.EventDict):
+                if not logger or not (stream_name := relative_path_from_logger(logger)):
+                    return event
+                _handler._current_log_stream = stream_name.as_posix().replace(":", "_")
+
+                if self.log_group_name.endswith("-Task") \
+                        and any(re.match(p, _handler._current_log_stream) for p in CloudWatchRemoteTaskLogger.IGNORED_PATTERNS):
+                    return event
+
+                name = event.get("logger_name") or event.get("logger", "")
+                level = structlog.stdlib.NAME_TO_LEVEL.get(method_name.lower(), logging.INFO)
+                if level < self.log_level:
+                    return event
+
+                msg = copy.copy(event)
+                created = None
+                if ts := msg.pop("timestamp", None):
+                    with contextlib.suppress(Exception):
+                        created = datetime.fromisoformat(ts)
+
+                record = logging.LogRecord(
+                    name=name,
+                    level=level,
+                    pathname="", lineno=0, msg=msg, args=(), exc_info=None,
+                )
+                if created is not None:
+                    ct = created.timestamp()
+                    record.created = ct
+                    record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
+                try:
+                    _handler.emit(record)
+                    # Batch the emitted metric to avoid flooding StatsD with per-record packets.
+                    # Flush on count threshold OR time interval, whichever comes first.
+                    self._emitted_count += 1
+                    if self._emitted_count >= _EMITTED_BATCH_SIZE or \
+                            (time.time() - self._last_emitted_flush) >= _EMITTED_FLUSH_INTERVAL_SECONDS:
+                        self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.ncl_emitted_records", self._emitted_count)
+                        self._emitted_count = 0
+                        self._last_emitted_flush = time.time()
+                except Exception:
+                    self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.emit_error", 1)
+                return event
+
+        else:
+            from logging import getLogRecordFactory
+
+            logRecordFactory = getLogRecordFactory()
+            # The handler MUST be initted here, before the processor is actually used to log anything.
+            # Otherwise, logging that occurs during the creation of the handler can create infinite loops.
+            _handler = self.get_handler()
+
+            def proc(logger: structlog.typing.WrappedLogger, method_name: str, event: structlog.typing.EventDict):
+                if not logger or not (stream_name := relative_path_from_logger(logger)):
+                    return event
+                _handler.log_stream_name = stream_name.as_posix().replace(":", "_")
+
+                if self.log_group_name.endswith("-Task") \
+                        and any(re.match(p, _handler.log_stream_name) for p in CloudWatchRemoteTaskLogger.IGNORED_PATTERNS):
+                    return event
+
+                name = event.get("logger_name") or event.get("logger", "")
+                level = structlog.stdlib.NAME_TO_LEVEL.get(method_name.lower(), logging.INFO)
+                if level < self.log_level:
+                    return event
+
+                msg = copy.copy(event)
+                created = None
+                if ts := msg.pop("timestamp", None):
+                    with contextlib.suppress(Exception):
+                        created = datetime.fromisoformat(ts)
+                record = logRecordFactory(
+                    name, level, pathname="", lineno=0, msg=msg, args=(), exc_info=None, func=None, sinfo=None
+                )
+                if created is not None:
+                    ct = created.timestamp()
+                    record.created = ct
+                    record.msecs = int((ct - int(ct)) * 1000) + 0.0  # Copied from stdlib logging
+                try:
+                    # In Airflow 3.1+, triggerer_job_runner's _process_log_messages_from_subprocess
+                    # calls configure_logging() -> dictConfig() which shuts down all existing
+                    # handlers, setting watchtower's shutting_down=True and silently dropping
+                    # all subsequent log records. Reset it to keep sending.
+                    if getattr(_handler, 'shutting_down', False):
+                        _handler.shutting_down = False
+                    _handler.handle(record)
+                except Exception as e:
+                    self.stats.incr(f"mwaa.logging.{CloudWatchRemoteTaskLogger.LOG_SOURCE}.emit_error", 1)
+                    raise e
+                return event
 
         return (proc,)
 

--- a/tests/images/airflow/3.3.0/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/logging/test_cloudwatch_handler.py
@@ -937,6 +937,42 @@ def test_discover_triggerer_streams_follows_pagination(mock_boto3_client):
         assert len(streams) == 2
         assert logger.hook.conn.describe_log_streams.call_count == 2
 
+def test_cloudwatch_remote_task_logger_uses_fluent_when_non_critical(mock_boto3_client, mock_fluent, mock_watchtower):
+    with patch.dict(os.environ, {'USE_NON_CRITICAL_LOGGING': 'true'}, clear=True):
+        import importlib
+        import mwaa.logging.cloudwatch_handlers
+        importlib.reload(mwaa.logging.cloudwatch_handlers)
+
+        logger = CloudWatchRemoteTaskLogger(
+            log_group_arn='arn:aws:logs:us-west-2:123456789012:log-group:test-Task',
+            kms_key_arn=None,
+            enabled=True,
+            log_level='INFO'
+        )
+
+        # Access processors to trigger the fluent handler creation
+        _ = logger.processors
+
+        assert mock_fluent.called, (
+            "CloudWatchRemoteTaskLogger must use Fluent "
+            "when USE_NON_CRITICAL_LOGGING=true"
+        )
+        mock_fluent.assert_called_once_with(
+            'customer.task.logs',
+            host='localhost',
+            port=24224,
+            queue_maxsize=50000,
+            queue_circular=True,
+            queue_overflow_handler=ANY,
+            buffer_overflow_handler=ANY,
+            nanosecond_precision=True,
+        )
+        assert not mock_watchtower.called, (
+            "CloudWatchRemoteTaskLogger must NOT use watchtower "
+            "when USE_NON_CRITICAL_LOGGING=true"
+        )
+
+
 # --- Tests for NCL observability metrics ---
 
 def test_queue_overflow_handler_emits_metric(mock_boto3_client):


### PR DESCRIPTION
## Port NCL Task Logging to 3.3.0

  ### Summary

  Adds Non-Critical Logging (NCL) support for task logs in Airflow 3.3.0's `CloudWatchRemoteTaskLogger`, matching the existing implementation in 3.0.6 and 3.2.1. Previously, 3.3.0 always used watchtower for task logs regardless of the `USE_NON_CRITICAL_LOGGING` flag.

  ### Changes

  The `processors` property in `CloudWatchRemoteTaskLogger` now has two branches:

  - **`if self.NON_CRITICAL_LOGGING_ENABLED:`** — constructs a `ForkSafeFluentHandler` on `customer.task.logs` tag, routes task log records through Fluent Bit via TCP 24224 (same as 3.2.1)
  - **`else:`** — falls back to watchtower `CloudWatchLogHandler` (preserves existing behavior including the `shutting_down` reset workaround for Airflow 3.1+ triggerer)

  Also includes the NCL observability metrics added in the prior PR:
  - `ncl_emitted_records` (batched counter in the `proc()` closure)
  - `queue_overflow_handler` / `buffer_overflow_handler` callbacks wired to the `ForkSafeFluentHandler`

  ### Testing

  - All 45 unit tests passing (38 existing + 6 NCL observability + 1 new NCL task handler test)
  - `cloudwatch_handlers.py` is now identical to 3.2.1 (verified via diff + checksum)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
