### PR TITLE
Fix default pool task slot count config reset during migrate-db

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.10.1/python/mwaa/config/setup_environment.py
@@ -204,6 +204,35 @@ def _is_protected_os_environ(key: str) -> bool:
     # Check whether this is an MWAA configuration or a protected variable
     return key.startswith("MWAA__") or key in protected_vars
 
+
+# Configs that are safe to pass through during migrate-db. The full user config is
+# excluded from migrate-db because configs requiring plugin installations can break the
+# migration container (see #360). However, certain configs like the default pool task
+# slot count are needed during migration to ensure the default pool is created with the
+# correct size (see #168, #382, #397).
+_MIGRATE_DB_SAFE_CONFIGS = [
+    "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT",
+]
+
+
+def _filter_migrate_db_safe_config(user_config: Dict[str, str]) -> Dict[str, str]:
+    """
+    Filter user Airflow configs to only the safe subset for the migrate-db command.
+
+    Most user configs are excluded from migrate-db to prevent breakage (e.g. configs
+    that require plugin installations). This function allows through only configs that
+    are known to be safe and necessary during database migration.
+
+    :param user_config: The full user Airflow configuration dictionary.
+    :returns A dictionary containing only the safe environment variables.
+    """
+    return {
+        key: value
+        for key, value in user_config.items()
+        if key in _MIGRATE_DB_SAFE_CONFIGS
+    }
+
+
 def setup_environment_variables(command: str, executor_type: str) -> Dict:
     """Set up and return environment variables for Airflow execution.
 
@@ -223,7 +252,9 @@ def setup_environment_variables(command: str, executor_type: str) -> Dict:
     mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
     mwaa_essential_airflow_environ = get_essential_environ(command)
     mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = {} if command == "migrate-db" else get_user_airflow_config()
+    user_airflow_config = get_user_airflow_config()
+    if command == "migrate-db":
+        user_airflow_config = _filter_migrate_db_safe_config(user_airflow_config)
 
 
     startup_script_environ = _execute_startup_script(

--- a/images/airflow/2.10.3/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.10.3/python/mwaa/config/setup_environment.py
@@ -207,6 +207,35 @@ def _is_protected_os_environ(key: str) -> bool:
     # Check whether this is an MWAA configuration or a protected variable
     return key.startswith("MWAA__") or key in protected_vars
 
+
+# Configs that are safe to pass through during migrate-db. The full user config is
+# excluded from migrate-db because configs requiring plugin installations can break the
+# migration container (see #360). However, certain configs like the default pool task
+# slot count are needed during migration to ensure the default pool is created with the
+# correct size (see #168, #382, #397).
+_MIGRATE_DB_SAFE_CONFIGS = [
+    "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT",
+]
+
+
+def _filter_migrate_db_safe_config(user_config: Dict[str, str]) -> Dict[str, str]:
+    """
+    Filter user Airflow configs to only the safe subset for the migrate-db command.
+
+    Most user configs are excluded from migrate-db to prevent breakage (e.g. configs
+    that require plugin installations). This function allows through only configs that
+    are known to be safe and necessary during database migration.
+
+    :param user_config: The full user Airflow configuration dictionary.
+    :returns A dictionary containing only the safe environment variables.
+    """
+    return {
+        key: value
+        for key, value in user_config.items()
+        if key in _MIGRATE_DB_SAFE_CONFIGS
+    }
+
+
 def setup_environment_variables(command: str, executor_type: str) -> Dict:
     """Set up and return environment variables for Airflow execution.
 
@@ -226,7 +255,9 @@ def setup_environment_variables(command: str, executor_type: str) -> Dict:
     mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
     mwaa_essential_airflow_environ = get_essential_environ(command)
     mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = {} if command == "migrate-db" else get_user_airflow_config()
+    user_airflow_config = get_user_airflow_config()
+    if command == "migrate-db":
+        user_airflow_config = _filter_migrate_db_safe_config(user_airflow_config)
 
 
     startup_script_environ = _execute_startup_script(

--- a/images/airflow/2.11.0/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.11.0/python/mwaa/config/setup_environment.py
@@ -207,6 +207,35 @@ def _is_protected_os_environ(key: str) -> bool:
     # Check whether this is an MWAA configuration or a protected variable
     return key.startswith("MWAA__") or key in protected_vars
 
+
+# Configs that are safe to pass through during migrate-db. The full user config is
+# excluded from migrate-db because configs requiring plugin installations can break the
+# migration container (see #360). However, certain configs like the default pool task
+# slot count are needed during migration to ensure the default pool is created with the
+# correct size (see #168, #382, #397).
+_MIGRATE_DB_SAFE_CONFIGS = [
+    "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT",
+]
+
+
+def _filter_migrate_db_safe_config(user_config: Dict[str, str]) -> Dict[str, str]:
+    """
+    Filter user Airflow configs to only the safe subset for the migrate-db command.
+
+    Most user configs are excluded from migrate-db to prevent breakage (e.g. configs
+    that require plugin installations). This function allows through only configs that
+    are known to be safe and necessary during database migration.
+
+    :param user_config: The full user Airflow configuration dictionary.
+    :returns A dictionary containing only the safe environment variables.
+    """
+    return {
+        key: value
+        for key, value in user_config.items()
+        if key in _MIGRATE_DB_SAFE_CONFIGS
+    }
+
+
 def setup_environment_variables(command: str, executor_type: str) -> Dict:
     """Set up and return environment variables for Airflow execution.
 
@@ -226,7 +255,9 @@ def setup_environment_variables(command: str, executor_type: str) -> Dict:
     mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
     mwaa_essential_airflow_environ = get_essential_environ(command)
     mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = {} if command == "migrate-db" else get_user_airflow_config()
+    user_airflow_config = get_user_airflow_config()
+    if command == "migrate-db":
+        user_airflow_config = _filter_migrate_db_safe_config(user_airflow_config)
 
 
     startup_script_environ = _execute_startup_script(

--- a/images/airflow/2.11.2/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.11.2/python/mwaa/config/setup_environment.py
@@ -207,6 +207,35 @@ def _is_protected_os_environ(key: str) -> bool:
     # Check whether this is an MWAA configuration or a protected variable
     return key.startswith("MWAA__") or key in protected_vars
 
+
+# Configs that are safe to pass through during migrate-db. The full user config is
+# excluded from migrate-db because configs requiring plugin installations can break the
+# migration container (see #360). However, certain configs like the default pool task
+# slot count are needed during migration to ensure the default pool is created with the
+# correct size (see #168, #382, #397).
+_MIGRATE_DB_SAFE_CONFIGS = [
+    "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT",
+]
+
+
+def _filter_migrate_db_safe_config(user_config: Dict[str, str]) -> Dict[str, str]:
+    """
+    Filter user Airflow configs to only the safe subset for the migrate-db command.
+
+    Most user configs are excluded from migrate-db to prevent breakage (e.g. configs
+    that require plugin installations). This function allows through only configs that
+    are known to be safe and necessary during database migration.
+
+    :param user_config: The full user Airflow configuration dictionary.
+    :returns A dictionary containing only the safe environment variables.
+    """
+    return {
+        key: value
+        for key, value in user_config.items()
+        if key in _MIGRATE_DB_SAFE_CONFIGS
+    }
+
+
 def setup_environment_variables(command: str, executor_type: str) -> Dict:
     """Set up and return environment variables for Airflow execution.
 
@@ -226,7 +255,9 @@ def setup_environment_variables(command: str, executor_type: str) -> Dict:
     mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
     mwaa_essential_airflow_environ = get_essential_environ(command)
     mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = {} if command == "migrate-db" else get_user_airflow_config()
+    user_airflow_config = get_user_airflow_config()
+    if command == "migrate-db":
+        user_airflow_config = _filter_migrate_db_safe_config(user_airflow_config)
 
 
     startup_script_environ = _execute_startup_script(

--- a/images/airflow/2.9.2/python/mwaa/config/setup_environment.py
+++ b/images/airflow/2.9.2/python/mwaa/config/setup_environment.py
@@ -204,6 +204,35 @@ def _is_protected_os_environ(key: str) -> bool:
     # Check whether this is an MWAA configuration or a protected variable
     return key.startswith("MWAA__") or key in protected_vars
 
+
+# Configs that are safe to pass through during migrate-db. The full user config is
+# excluded from migrate-db because configs requiring plugin installations can break the
+# migration container (see #360). However, certain configs like the default pool task
+# slot count are needed during migration to ensure the default pool is created with the
+# correct size (see #168, #382, #397).
+_MIGRATE_DB_SAFE_CONFIGS = [
+    "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT",
+]
+
+
+def _filter_migrate_db_safe_config(user_config: Dict[str, str]) -> Dict[str, str]:
+    """
+    Filter user Airflow configs to only the safe subset for the migrate-db command.
+
+    Most user configs are excluded from migrate-db to prevent breakage (e.g. configs
+    that require plugin installations). This function allows through only configs that
+    are known to be safe and necessary during database migration.
+
+    :param user_config: The full user Airflow configuration dictionary.
+    :returns A dictionary containing only the safe environment variables.
+    """
+    return {
+        key: value
+        for key, value in user_config.items()
+        if key in _MIGRATE_DB_SAFE_CONFIGS
+    }
+
+
 def setup_environment_variables(command: str, executor_type: str) -> Dict:
     """Set up and return environment variables for Airflow execution.
 
@@ -223,7 +252,9 @@ def setup_environment_variables(command: str, executor_type: str) -> Dict:
     mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
     mwaa_essential_airflow_environ = get_essential_environ(command)
     mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = {} if command == "migrate-db" else get_user_airflow_config()
+    user_airflow_config = get_user_airflow_config()
+    if command == "migrate-db":
+        user_airflow_config = _filter_migrate_db_safe_config(user_airflow_config)
 
 
     startup_script_environ = _execute_startup_script(

--- a/images/airflow/3.0.6/python/mwaa/config/setup_environment.py
+++ b/images/airflow/3.0.6/python/mwaa/config/setup_environment.py
@@ -213,6 +213,35 @@ def _is_protected_os_environ(key: str) -> bool:
     # Check whether this is an MWAA configuration or a protected variable
     return key.startswith("MWAA__") or key in protected_vars
 
+
+# Configs that are safe to pass through during migrate-db. The full user config is
+# excluded from migrate-db because configs requiring plugin installations can break the
+# migration container (see #360). However, certain configs like the default pool task
+# slot count are needed during migration to ensure the default pool is created with the
+# correct size (see #168, #382, #397).
+_MIGRATE_DB_SAFE_CONFIGS = [
+    "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT",
+]
+
+
+def _filter_migrate_db_safe_config(user_config: Dict[str, str]) -> Dict[str, str]:
+    """
+    Filter user Airflow configs to only the safe subset for the migrate-db command.
+
+    Most user configs are excluded from migrate-db to prevent breakage (e.g. configs
+    that require plugin installations). This function allows through only configs that
+    are known to be safe and necessary during database migration.
+
+    :param user_config: The full user Airflow configuration dictionary.
+    :returns A dictionary containing only the safe environment variables.
+    """
+    return {
+        key: value
+        for key, value in user_config.items()
+        if key in _MIGRATE_DB_SAFE_CONFIGS
+    }
+
+
 def setup_environment_variables(command: str, executor_type: str) -> Dict:
     """Set up and return environment variables for Airflow execution.
 
@@ -232,7 +261,9 @@ def setup_environment_variables(command: str, executor_type: str) -> Dict:
     mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
     mwaa_essential_airflow_environ = get_essential_environ(command)
     mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = {} if command == "migrate-db" else get_user_airflow_config()
+    user_airflow_config = get_user_airflow_config()
+    if command == "migrate-db":
+        user_airflow_config = _filter_migrate_db_safe_config(user_airflow_config)
 
 
     startup_script_environ = _execute_startup_script(

--- a/images/airflow/3.2.1/python/mwaa/config/setup_environment.py
+++ b/images/airflow/3.2.1/python/mwaa/config/setup_environment.py
@@ -215,6 +215,35 @@ def _is_protected_os_environ(key: str) -> bool:
     # Check whether this is an MWAA configuration or a protected variable
     return key.startswith("MWAA__") or key in protected_vars
 
+
+# Configs that are safe to pass through during migrate-db. The full user config is
+# excluded from migrate-db because configs requiring plugin installations can break the
+# migration container (see #360). However, certain configs like the default pool task
+# slot count are needed during migration to ensure the default pool is created with the
+# correct size (see #168, #382, #397).
+_MIGRATE_DB_SAFE_CONFIGS = [
+    "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT",
+]
+
+
+def _filter_migrate_db_safe_config(user_config: Dict[str, str]) -> Dict[str, str]:
+    """
+    Filter user Airflow configs to only the safe subset for the migrate-db command.
+
+    Most user configs are excluded from migrate-db to prevent breakage (e.g. configs
+    that require plugin installations). This function allows through only configs that
+    are known to be safe and necessary during database migration.
+
+    :param user_config: The full user Airflow configuration dictionary.
+    :returns A dictionary containing only the safe environment variables.
+    """
+    return {
+        key: value
+        for key, value in user_config.items()
+        if key in _MIGRATE_DB_SAFE_CONFIGS
+    }
+
+
 def setup_environment_variables(command: str, executor_type: str) -> Dict:
     """Set up and return environment variables for Airflow execution.
 
@@ -234,7 +263,9 @@ def setup_environment_variables(command: str, executor_type: str) -> Dict:
     mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
     mwaa_essential_airflow_environ = get_essential_environ(command)
     mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = {} if command == "migrate-db" else get_user_airflow_config()
+    user_airflow_config = get_user_airflow_config()
+    if command == "migrate-db":
+        user_airflow_config = _filter_migrate_db_safe_config(user_airflow_config)
 
 
     startup_script_environ = _execute_startup_script(

--- a/images/airflow/3.3.0/python/mwaa/config/setup_environment.py
+++ b/images/airflow/3.3.0/python/mwaa/config/setup_environment.py
@@ -215,6 +215,35 @@ def _is_protected_os_environ(key: str) -> bool:
     # Check whether this is an MWAA configuration or a protected variable
     return key.startswith("MWAA__") or key in protected_vars
 
+
+# Configs that are safe to pass through during migrate-db. The full user config is
+# excluded from migrate-db because configs requiring plugin installations can break the
+# migration container (see #360). However, certain configs like the default pool task
+# slot count are needed during migration to ensure the default pool is created with the
+# correct size (see #168, #382, #397).
+_MIGRATE_DB_SAFE_CONFIGS = [
+    "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT",
+]
+
+
+def _filter_migrate_db_safe_config(user_config: Dict[str, str]) -> Dict[str, str]:
+    """
+    Filter user Airflow configs to only the safe subset for the migrate-db command.
+
+    Most user configs are excluded from migrate-db to prevent breakage (e.g. configs
+    that require plugin installations). This function allows through only configs that
+    are known to be safe and necessary during database migration.
+
+    :param user_config: The full user Airflow configuration dictionary.
+    :returns A dictionary containing only the safe environment variables.
+    """
+    return {
+        key: value
+        for key, value in user_config.items()
+        if key in _MIGRATE_DB_SAFE_CONFIGS
+    }
+
+
 def setup_environment_variables(command: str, executor_type: str) -> Dict:
     """Set up and return environment variables for Airflow execution.
 
@@ -234,7 +263,9 @@ def setup_environment_variables(command: str, executor_type: str) -> Dict:
     mwaa_opinionated_airflow_config = get_opinionated_airflow_config()
     mwaa_essential_airflow_environ = get_essential_environ(command)
     mwaa_opinionated_airflow_environ = get_opinionated_environ()
-    user_airflow_config = {} if command == "migrate-db" else get_user_airflow_config()
+    user_airflow_config = get_user_airflow_config()
+    if command == "migrate-db":
+        user_airflow_config = _filter_migrate_db_safe_config(user_airflow_config)
 
 
     startup_script_environ = _execute_startup_script(

--- a/tests/images/airflow/2.10.1/python/mwaa/config/test_setup_environment_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/config/test_setup_environment_2_10_1.py
@@ -9,6 +9,7 @@ from mwaa.config.setup_environment import (
     _execute_startup_script,
     _export_env_variables,
     _is_protected_os_environ,
+    _filter_migrate_db_safe_config,
 )
 from mwaa.subprocess.subprocess import Subprocess  # Add this import
 
@@ -265,3 +266,61 @@ def test_setup_environment_variables_different_commands(
         assert args[0] == command
         # Verify the environment dict was passed (without checking exact contents)
         assert isinstance(args[1], dict)
+
+
+# ------------------------
+# Migrate-DB Safe Config Tests
+# ------------------------
+
+def test_filter_migrate_db_safe_config_passes_pool_config():
+    """Test that default_pool_task_slot_count is passed through for migrate-db"""
+    user_config = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {"AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000"}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_pool_config():
+    """Test that result is empty when user hasn't set pool config"""
+    user_config = {
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_user_config():
+    """Test that result is empty when there's no user config at all"""
+    result = _filter_migrate_db_safe_config({})
+
+    assert result == {}
+
+
+def test_setup_environment_variables_migrate_db_passes_pool_config(
+        mock_environ,
+        mock_config_functions
+):
+    """Test that migrate-db command passes through pool slot config but not other user configs"""
+    mock_config_functions["get_user_airflow_config"].return_value = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__LOAD_EXAMPLES": "True",
+    }
+
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script, \
+            patch("mwaa.config.setup_environment._export_env_variables"):
+        mock_execute_script.return_value = {}
+
+        result = setup_environment_variables("migrate-db", "CeleryExecutor")
+
+        # Pool config should be passed through
+        assert result.get("AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT") == "10000"
+        # Other user configs should NOT be passed through
+        assert result.get("AIRFLOW__CORE__LOAD_EXAMPLES") != "True" or \
+               result.get("AIRFLOW__CORE__LOAD_EXAMPLES") == mock_config_functions[
+                   "get_essential_airflow_config"].return_value.get("AIRFLOW__CORE__LOAD_EXAMPLES")

--- a/tests/images/airflow/2.10.3/python/mwaa/config/test_setup_environment_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/config/test_setup_environment_2_10_3.py
@@ -9,6 +9,7 @@ from mwaa.config.setup_environment import (
     _execute_startup_script,
     _export_env_variables,
     _is_protected_os_environ,
+    _filter_migrate_db_safe_config,
 )
 from mwaa.subprocess.subprocess import Subprocess  # Add this import
 
@@ -265,3 +266,61 @@ def test_setup_environment_variables_different_commands(
         assert args[0] == command
         # Verify the environment dict was passed (without checking exact contents)
         assert isinstance(args[1], dict)
+
+
+# ------------------------
+# Migrate-DB Safe Config Tests
+# ------------------------
+
+def test_filter_migrate_db_safe_config_passes_pool_config():
+    """Test that default_pool_task_slot_count is passed through for migrate-db"""
+    user_config = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {"AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000"}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_pool_config():
+    """Test that result is empty when user hasn't set pool config"""
+    user_config = {
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_user_config():
+    """Test that result is empty when there's no user config at all"""
+    result = _filter_migrate_db_safe_config({})
+
+    assert result == {}
+
+
+def test_setup_environment_variables_migrate_db_passes_pool_config(
+        mock_environ,
+        mock_config_functions
+):
+    """Test that migrate-db command passes through pool slot config but not other user configs"""
+    mock_config_functions["get_user_airflow_config"].return_value = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__LOAD_EXAMPLES": "True",
+    }
+
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script, \
+            patch("mwaa.config.setup_environment._export_env_variables"):
+        mock_execute_script.return_value = {}
+
+        result = setup_environment_variables("migrate-db", "CeleryExecutor")
+
+        # Pool config should be passed through
+        assert result.get("AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT") == "10000"
+        # Other user configs should NOT be passed through
+        assert result.get("AIRFLOW__CORE__LOAD_EXAMPLES") != "True" or \
+               result.get("AIRFLOW__CORE__LOAD_EXAMPLES") == mock_config_functions[
+                   "get_essential_airflow_config"].return_value.get("AIRFLOW__CORE__LOAD_EXAMPLES")

--- a/tests/images/airflow/2.11.0/python/mwaa/config/test_setup_environment_2_11_0.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/config/test_setup_environment_2_11_0.py
@@ -9,6 +9,7 @@ from mwaa.config.setup_environment import (
     _execute_startup_script,
     _export_env_variables,
     _is_protected_os_environ,
+    _filter_migrate_db_safe_config,
 )
 from mwaa.subprocess.subprocess import Subprocess  # Add this import
 
@@ -265,3 +266,61 @@ def test_setup_environment_variables_different_commands(
         assert args[0] == command
         # Verify the environment dict was passed (without checking exact contents)
         assert isinstance(args[1], dict)
+
+
+# ------------------------
+# Migrate-DB Safe Config Tests
+# ------------------------
+
+def test_filter_migrate_db_safe_config_passes_pool_config():
+    """Test that default_pool_task_slot_count is passed through for migrate-db"""
+    user_config = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {"AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000"}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_pool_config():
+    """Test that result is empty when user hasn't set pool config"""
+    user_config = {
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_user_config():
+    """Test that result is empty when there's no user config at all"""
+    result = _filter_migrate_db_safe_config({})
+
+    assert result == {}
+
+
+def test_setup_environment_variables_migrate_db_passes_pool_config(
+        mock_environ,
+        mock_config_functions
+):
+    """Test that migrate-db command passes through pool slot config but not other user configs"""
+    mock_config_functions["get_user_airflow_config"].return_value = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__LOAD_EXAMPLES": "True",
+    }
+
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script, \
+            patch("mwaa.config.setup_environment._export_env_variables"):
+        mock_execute_script.return_value = {}
+
+        result = setup_environment_variables("migrate-db", "CeleryExecutor")
+
+        # Pool config should be passed through
+        assert result.get("AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT") == "10000"
+        # Other user configs should NOT be passed through
+        assert result.get("AIRFLOW__CORE__LOAD_EXAMPLES") != "True" or \
+               result.get("AIRFLOW__CORE__LOAD_EXAMPLES") == mock_config_functions[
+                   "get_essential_airflow_config"].return_value.get("AIRFLOW__CORE__LOAD_EXAMPLES")

--- a/tests/images/airflow/2.11.2/python/mwaa/config/test_setup_environment_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/config/test_setup_environment_2_11_2.py
@@ -9,6 +9,7 @@ from mwaa.config.setup_environment import (
     _execute_startup_script,
     _export_env_variables,
     _is_protected_os_environ,
+    _filter_migrate_db_safe_config,
 )
 from mwaa.subprocess.subprocess import Subprocess  # Add this import
 
@@ -265,3 +266,61 @@ def test_setup_environment_variables_different_commands(
         assert args[0] == command
         # Verify the environment dict was passed (without checking exact contents)
         assert isinstance(args[1], dict)
+
+
+# ------------------------
+# Migrate-DB Safe Config Tests
+# ------------------------
+
+def test_filter_migrate_db_safe_config_passes_pool_config():
+    """Test that default_pool_task_slot_count is passed through for migrate-db"""
+    user_config = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {"AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000"}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_pool_config():
+    """Test that result is empty when user hasn't set pool config"""
+    user_config = {
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_user_config():
+    """Test that result is empty when there's no user config at all"""
+    result = _filter_migrate_db_safe_config({})
+
+    assert result == {}
+
+
+def test_setup_environment_variables_migrate_db_passes_pool_config(
+        mock_environ,
+        mock_config_functions
+):
+    """Test that migrate-db command passes through pool slot config but not other user configs"""
+    mock_config_functions["get_user_airflow_config"].return_value = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__LOAD_EXAMPLES": "True",
+    }
+
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script, \
+            patch("mwaa.config.setup_environment._export_env_variables"):
+        mock_execute_script.return_value = {}
+
+        result = setup_environment_variables("migrate-db", "CeleryExecutor")
+
+        # Pool config should be passed through
+        assert result.get("AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT") == "10000"
+        # Other user configs should NOT be passed through
+        assert result.get("AIRFLOW__CORE__LOAD_EXAMPLES") != "True" or \
+               result.get("AIRFLOW__CORE__LOAD_EXAMPLES") == mock_config_functions[
+                   "get_essential_airflow_config"].return_value.get("AIRFLOW__CORE__LOAD_EXAMPLES")

--- a/tests/images/airflow/2.9.2/python/mwaa/config/test_setup_environment_2_9_2.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/config/test_setup_environment_2_9_2.py
@@ -9,6 +9,7 @@ from mwaa.config.setup_environment import (
     _execute_startup_script,
     _export_env_variables,
     _is_protected_os_environ,
+    _filter_migrate_db_safe_config,
 )
 from mwaa.subprocess.subprocess import Subprocess  # Add this import
 
@@ -265,3 +266,61 @@ def test_setup_environment_variables_different_commands(
         assert args[0] == command
         # Verify the environment dict was passed (without checking exact contents)
         assert isinstance(args[1], dict)
+
+
+# ------------------------
+# Migrate-DB Safe Config Tests
+# ------------------------
+
+def test_filter_migrate_db_safe_config_passes_pool_config():
+    """Test that default_pool_task_slot_count is passed through for migrate-db"""
+    user_config = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {"AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000"}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_pool_config():
+    """Test that result is empty when user hasn't set pool config"""
+    user_config = {
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_user_config():
+    """Test that result is empty when there's no user config at all"""
+    result = _filter_migrate_db_safe_config({})
+
+    assert result == {}
+
+
+def test_setup_environment_variables_migrate_db_passes_pool_config(
+        mock_environ,
+        mock_config_functions
+):
+    """Test that migrate-db command passes through pool slot config but not other user configs"""
+    mock_config_functions["get_user_airflow_config"].return_value = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__LOAD_EXAMPLES": "True",
+    }
+
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script, \
+            patch("mwaa.config.setup_environment._export_env_variables"):
+        mock_execute_script.return_value = {}
+
+        result = setup_environment_variables("migrate-db", "CeleryExecutor")
+
+        # Pool config should be passed through
+        assert result.get("AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT") == "10000"
+        # Other user configs should NOT be passed through
+        assert result.get("AIRFLOW__CORE__LOAD_EXAMPLES") != "True" or \
+               result.get("AIRFLOW__CORE__LOAD_EXAMPLES") == mock_config_functions[
+                   "get_essential_airflow_config"].return_value.get("AIRFLOW__CORE__LOAD_EXAMPLES")

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_setup_environment.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_setup_environment.py
@@ -9,6 +9,7 @@ from mwaa.config.setup_environment import (
     _execute_startup_script,
     _export_env_variables,
     _is_protected_os_environ,
+    _filter_migrate_db_safe_config,
 )
 from mwaa.subprocess.subprocess import Subprocess  # Add this import
 
@@ -265,3 +266,61 @@ def test_setup_environment_variables_different_commands(
         assert args[0] == command
         # Verify the environment dict was passed (without checking exact contents)
         assert isinstance(args[1], dict)
+
+
+# ------------------------
+# Migrate-DB Safe Config Tests
+# ------------------------
+
+def test_filter_migrate_db_safe_config_passes_pool_config():
+    """Test that default_pool_task_slot_count is passed through for migrate-db"""
+    user_config = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {"AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000"}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_pool_config():
+    """Test that result is empty when user hasn't set pool config"""
+    user_config = {
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_user_config():
+    """Test that result is empty when there's no user config at all"""
+    result = _filter_migrate_db_safe_config({})
+
+    assert result == {}
+
+
+def test_setup_environment_variables_migrate_db_passes_pool_config(
+        mock_environ,
+        mock_config_functions
+):
+    """Test that migrate-db command passes through pool slot config but not other user configs"""
+    mock_config_functions["get_user_airflow_config"].return_value = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__LOAD_EXAMPLES": "True",
+    }
+
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script, \
+            patch("mwaa.config.setup_environment._export_env_variables"):
+        mock_execute_script.return_value = {}
+
+        result = setup_environment_variables("migrate-db", "CeleryExecutor")
+
+        # Pool config should be passed through
+        assert result.get("AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT") == "10000"
+        # Other user configs should NOT be passed through
+        assert result.get("AIRFLOW__CORE__LOAD_EXAMPLES") != "True" or \
+               result.get("AIRFLOW__CORE__LOAD_EXAMPLES") == mock_config_functions[
+                   "get_essential_airflow_config"].return_value.get("AIRFLOW__CORE__LOAD_EXAMPLES")

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_environ.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_environ.py
@@ -6,14 +6,14 @@ from mwaa.config.environ import get_essential_environ, get_opinionated_environ
 
 def test_get_essential_environ_sets_correct_vars(env_helper):
     # Set the AIRFLOW_VERSION env var
-    env_helper.set({"AIRFLOW_VERSION": "3.2.0"})
+    env_helper.set({"AIRFLOW_VERSION": "3.2.1"})
 
     command = "webserver"
     result = get_essential_environ(command)
 
     assert result["MWAA_AIRFLOW_COMPONENT"] == command
     assert result["MWAA_COMMAND"] == command
-    assert result["AWS_EXECUTION_ENV"] == "Amazon_MWAA_320"
+    assert result["AWS_EXECUTION_ENV"] == "Amazon_MWAA_321"
 
 
 def test_get_opinionated_environ_includes_logging_args():

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_setup_environment.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_setup_environment.py
@@ -9,6 +9,7 @@ from mwaa.config.setup_environment import (
     _execute_startup_script,
     _export_env_variables,
     _is_protected_os_environ,
+    _filter_migrate_db_safe_config,
 )
 from mwaa.subprocess.subprocess import Subprocess  # Add this import
 
@@ -265,3 +266,61 @@ def test_setup_environment_variables_different_commands(
         assert args[0] == command
         # Verify the environment dict was passed (without checking exact contents)
         assert isinstance(args[1], dict)
+
+
+# ------------------------
+# Migrate-DB Safe Config Tests
+# ------------------------
+
+def test_filter_migrate_db_safe_config_passes_pool_config():
+    """Test that default_pool_task_slot_count is passed through for migrate-db"""
+    user_config = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {"AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000"}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_pool_config():
+    """Test that result is empty when user hasn't set pool config"""
+    user_config = {
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_user_config():
+    """Test that result is empty when there's no user config at all"""
+    result = _filter_migrate_db_safe_config({})
+
+    assert result == {}
+
+
+def test_setup_environment_variables_migrate_db_passes_pool_config(
+        mock_environ,
+        mock_config_functions
+):
+    """Test that migrate-db command passes through pool slot config but not other user configs"""
+    mock_config_functions["get_user_airflow_config"].return_value = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__LOAD_EXAMPLES": "True",
+    }
+
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script, \
+            patch("mwaa.config.setup_environment._export_env_variables"):
+        mock_execute_script.return_value = {}
+
+        result = setup_environment_variables("migrate-db", "CeleryExecutor")
+
+        # Pool config should be passed through
+        assert result.get("AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT") == "10000"
+        # Other user configs should NOT be passed through
+        assert result.get("AIRFLOW__CORE__LOAD_EXAMPLES") != "True" or \
+               result.get("AIRFLOW__CORE__LOAD_EXAMPLES") == mock_config_functions[
+                   "get_essential_airflow_config"].return_value.get("AIRFLOW__CORE__LOAD_EXAMPLES")

--- a/tests/images/airflow/3.3.0/python/mwaa/config/test_setup_environment.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/config/test_setup_environment.py
@@ -9,6 +9,7 @@ from mwaa.config.setup_environment import (
     _execute_startup_script,
     _export_env_variables,
     _is_protected_os_environ,
+    _filter_migrate_db_safe_config,
 )
 from mwaa.subprocess.subprocess import Subprocess  # Add this import
 
@@ -265,3 +266,61 @@ def test_setup_environment_variables_different_commands(
         assert args[0] == command
         # Verify the environment dict was passed (without checking exact contents)
         assert isinstance(args[1], dict)
+
+
+# ------------------------
+# Migrate-DB Safe Config Tests
+# ------------------------
+
+def test_filter_migrate_db_safe_config_passes_pool_config():
+    """Test that default_pool_task_slot_count is passed through for migrate-db"""
+    user_config = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {"AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000"}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_pool_config():
+    """Test that result is empty when user hasn't set pool config"""
+    user_config = {
+        "AIRFLOW__CORE__SOME_OTHER_CONFIG": "value",
+        "AIRFLOW__WEBSERVER__WORKERS": "4",
+    }
+    result = _filter_migrate_db_safe_config(user_config)
+
+    assert result == {}
+
+
+def test_filter_migrate_db_safe_config_empty_when_no_user_config():
+    """Test that result is empty when there's no user config at all"""
+    result = _filter_migrate_db_safe_config({})
+
+    assert result == {}
+
+
+def test_setup_environment_variables_migrate_db_passes_pool_config(
+        mock_environ,
+        mock_config_functions
+):
+    """Test that migrate-db command passes through pool slot config but not other user configs"""
+    mock_config_functions["get_user_airflow_config"].return_value = {
+        "AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT": "10000",
+        "AIRFLOW__CORE__LOAD_EXAMPLES": "True",
+    }
+
+    with patch("mwaa.config.setup_environment._execute_startup_script") as mock_execute_script, \
+            patch("mwaa.config.setup_environment._export_env_variables"):
+        mock_execute_script.return_value = {}
+
+        result = setup_environment_variables("migrate-db", "CeleryExecutor")
+
+        # Pool config should be passed through
+        assert result.get("AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT") == "10000"
+        # Other user configs should NOT be passed through
+        assert result.get("AIRFLOW__CORE__LOAD_EXAMPLES") != "True" or \
+               result.get("AIRFLOW__CORE__LOAD_EXAMPLES") == mock_config_functions[
+                   "get_essential_airflow_config"].return_value.get("AIRFLOW__CORE__LOAD_EXAMPLES")


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Previously, all user Airflow configs were excluded from the migrate-db command to prevent breakage from configs requiring plugin installations. This caused the default pool to always be created with Airflow's built-in default size (128), ignoring any custom configured slot count.

This fix introduces a safe-list mechanism that allows specific configs known to be safe and necessary during migration to pass through. Currently only AIRFLOW__CORE__DEFAULT_POOL_TASK_SLOT_COUNT is on the safe list.

This PR also includes a small misc. fix to update the 3.2.1 tests which incorrectly reference 3.2.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
