### PR TITLE
Port extra_celery_config overwrite fix to 3.3.0 and add unit tests

### DIFF
--- a/images/airflow/3.3.0/python/mwaa/config/airflow.py
+++ b/images/airflow/3.3.0/python/mwaa/config/airflow.py
@@ -2,7 +2,7 @@
 
 # Python imports
 from functools import cache
-from typing import Dict
+from typing import Any, Dict
 import json
 import logging
 import os
@@ -48,7 +48,46 @@ def _get_essential_airflow_executor_config(executor_type: str) -> Dict[str, str]
             # getjson() and properly preserves nested dict types. This config is
             # merged into the Celery config dict built by get_default_celery_config().
             from mwaa.config.celery import get_broker_transport_config
-            extra_celery_config = get_broker_transport_config()
+            # Merge customer-provided extra_celery_config with MWAA's broker
+            # transport config so the customer's keys survive while MWAA
+            # broker keys win on collision. Customer value comes from the
+            # Airflow config secret (MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS);
+            # the raw env var is only used in local development.
+
+            def _parse_extra_celery_config(raw: str) -> Dict[str, Any]:
+                try:
+                    parsed = json.loads(raw)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "AIRFLOW__CELERY__EXTRA_CELERY_CONFIG is not valid "
+                        "JSON; ignoring it."
+                    )
+                    return {}
+                if not isinstance(parsed, dict):
+                    logger.warning(
+                        "AIRFLOW__CELERY__EXTRA_CELERY_CONFIG is not a JSON "
+                        "object; ignoring it."
+                    )
+                    return {}
+                return parsed
+
+            user_extra_celery_config = {
+                # Raw environment variable (lower priority).
+                **_parse_extra_celery_config(
+                    os.environ.get("AIRFLOW__CELERY__EXTRA_CELERY_CONFIG", "{}")
+                ),
+                # Customer Airflow config secret (higher priority, consistent
+                # with the merge order in setup_environment.py).
+                **_parse_extra_celery_config(
+                    get_user_airflow_config().get(
+                        "AIRFLOW__CELERY__EXTRA_CELERY_CONFIG", "{}"
+                    )
+                ),
+            }
+            extra_celery_config = {
+                **user_extra_celery_config,
+                **get_broker_transport_config(),
+            }
             return {
                 "AIRFLOW__CELERY__BROKER_URL": get_sqs_endpoint(),
                 "AIRFLOW__CELERY__CELERY_CONFIG_OPTIONS": celery_config_module_path,

--- a/quality-checks/diff-coverage_test.sh
+++ b/quality-checks/diff-coverage_test.sh
@@ -193,24 +193,25 @@ main() {
         echo "  - $dir"
     done
 
+    # Coverage checks run for all versions by default. Add a version to
+    # excluded_versions only when necessary (e.g., its test folder is not
+    # yet complete).
+    local excluded_versions=(
+    )
+
     # Check each modified image directory
     for dir in $modified_dirs; do
-        # Only run for images with populated test directories
-        # TODO: Append below line to `if` statement when test folder for 3.0.6 is complete \
-        # || [ "$dir" == "images/airflow/3.0.6" ] \
-        if [ "$dir" == "images/airflow/2.9.2" ] \
-        || [ "$dir" == "images/airflow/2.10.1" ] \
-        || [ "$dir" == "images/airflow/2.10.3" ] \
-        || [ "$dir" == "images/airflow/2.11.0" ] \
-        ; then
-            if [ -d "$dir" ]; then
-                echo -e "\n${BLUE}Checking ${dir}...${NC}"
-                if ! check_coverage "$dir" "$base_branch"; then
-                    status=1
-                fi
+        local version
+        version=$(basename "$dir")
+        if [[ " ${excluded_versions[*]} " == *" ${version} "* ]]; then
+            echo "Skipping directory \"${dir}\" (excluded from coverage checks)..."
+            continue
+        fi
+        if [ -d "$dir" ]; then
+            echo -e "\n${BLUE}Checking ${dir}...${NC}"
+            if ! check_coverage "$dir" "$base_branch"; then
+                status=1
             fi
-        else
-            echo "Skipping directory \"${dir}\" (tests not yet created)..."
         fi
     done
 

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_airflow.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_airflow.py
@@ -80,6 +80,137 @@ def test_invalid_executor(invalid_executor):
     with pytest.raises(ValueError):
         _get_essential_airflow_executor_config(invalid_executor)
 
+# ---------------------------------------------------
+# Customer Extra Celery Config Merge Tests
+# ---------------------------------------------------
+
+MOCK_BROKER_TRANSPORT_CONFIG = {
+    "broker_transport": "mocked.transport.Transport",
+    "broker_transport_options": {
+        "visibility_timeout": 43200,
+        "region": "us-east-1",
+    },
+}
+
+
+def _get_celery_executor_config(monkeypatch):
+    """Call _get_essential_airflow_executor_config with mocked dependencies."""
+    monkeypatch.setattr("mwaa.config.airflow.get_sqs_endpoint", lambda: "sqs://endpoint")
+    monkeypatch.setattr("mwaa.config.airflow.get_sqs_queue_name", lambda: "test-queue")
+    monkeypatch.setattr("mwaa.config.airflow.get_db_connection_string", lambda: "postgresql://db")
+
+    with patch(
+        "mwaa.config.celery.get_broker_transport_config",
+        return_value=dict(MOCK_BROKER_TRANSPORT_CONFIG),
+    ):
+        return _get_essential_airflow_executor_config("CeleryExecutor")
+
+
+def test_customer_extra_celery_config_is_merged(monkeypatch, env_helper):
+    """Customer-provided extra_celery_config keys must survive the merge with
+    MWAA's broker transport config (regression test for GitHub issue #571)."""
+    env_helper.set({
+        "MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS": json.dumps({
+            "AIRFLOW__CELERY__EXTRA_CELERY_CONFIG": json.dumps(
+                {"worker_max_tasks_per_child": 50}
+            )
+        })
+    })
+
+    result = _get_celery_executor_config(monkeypatch)
+
+    extra_config = json.loads(result["AIRFLOW__CELERY__EXTRA_CELERY_CONFIG"])
+    # Customer key survives.
+    assert extra_config["worker_max_tasks_per_child"] == 50
+    # MWAA broker transport config remains intact.
+    assert extra_config["broker_transport"] == "mocked.transport.Transport"
+    assert (
+        extra_config["broker_transport_options"]
+        == MOCK_BROKER_TRANSPORT_CONFIG["broker_transport_options"]
+    )
+
+
+def test_mwaa_broker_config_wins_on_collision(monkeypatch, env_helper):
+    """MWAA broker transport keys must win when the customer tries to override
+    them, while the customer's non-colliding keys survive."""
+    env_helper.set({
+        "MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS": json.dumps({
+            "AIRFLOW__CELERY__EXTRA_CELERY_CONFIG": json.dumps({
+                "broker_transport": "customer.transport.Transport",
+                "broker_transport_options": {"visibility_timeout": 1},
+                "worker_max_tasks_per_child": 50,
+            })
+        })
+    })
+
+    result = _get_celery_executor_config(monkeypatch)
+
+    extra_config = json.loads(result["AIRFLOW__CELERY__EXTRA_CELERY_CONFIG"])
+    # MWAA broker keys win on collision.
+    assert extra_config["broker_transport"] == "mocked.transport.Transport"
+    assert (
+        extra_config["broker_transport_options"]
+        == MOCK_BROKER_TRANSPORT_CONFIG["broker_transport_options"]
+    )
+    # Customer's non-colliding key survives.
+    assert extra_config["worker_max_tasks_per_child"] == 50
+
+
+def test_extra_celery_config_secret_wins_over_env_var(monkeypatch, env_helper):
+    """The Airflow config secret takes priority over the raw environment
+    variable, consistent with the merge order in setup_environment.py."""
+    env_helper.set({
+        "AIRFLOW__CELERY__EXTRA_CELERY_CONFIG": json.dumps(
+            {"worker_max_tasks_per_child": 10, "worker_prefetch_multiplier": 4}
+        ),
+        "MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS": json.dumps({
+            "AIRFLOW__CELERY__EXTRA_CELERY_CONFIG": json.dumps(
+                {"worker_max_tasks_per_child": 50}
+            )
+        }),
+    })
+
+    result = _get_celery_executor_config(monkeypatch)
+
+    extra_config = json.loads(result["AIRFLOW__CELERY__EXTRA_CELERY_CONFIG"])
+    # Secret value wins on collision.
+    assert extra_config["worker_max_tasks_per_child"] == 50
+    # Non-colliding env var key survives.
+    assert extra_config["worker_prefetch_multiplier"] == 4
+
+
+@pytest.mark.parametrize("invalid_value", [
+    "{not-valid-json",
+    '["not", "an", "object"]',
+    '"just a string"',
+    "42",
+])
+def test_invalid_customer_extra_celery_config_ignored(
+    monkeypatch, env_helper, invalid_value
+):
+    """Invalid or non-object JSON values are logged and ignored; the broker
+    transport config remains intact."""
+    env_helper.set({
+        "MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS": json.dumps({
+            "AIRFLOW__CELERY__EXTRA_CELERY_CONFIG": invalid_value
+        })
+    })
+
+    result = _get_celery_executor_config(monkeypatch)
+
+    extra_config = json.loads(result["AIRFLOW__CELERY__EXTRA_CELERY_CONFIG"])
+    assert extra_config == MOCK_BROKER_TRANSPORT_CONFIG
+
+
+def test_no_customer_extra_celery_config(monkeypatch):
+    """Without any customer-provided value, extra_celery_config is exactly the
+    MWAA broker transport config."""
+    result = _get_celery_executor_config(monkeypatch)
+
+    extra_config = json.loads(result["AIRFLOW__CELERY__EXTRA_CELERY_CONFIG"])
+    assert extra_config == MOCK_BROKER_TRANSPORT_CONFIG
+
+
 # ---------------------------
 # Core Config Tests
 # ---------------------------

--- a/tests/images/airflow/3.3.0/python/mwaa/config/test_airflow.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/config/test_airflow.py
@@ -80,6 +80,137 @@ def test_invalid_executor(invalid_executor):
     with pytest.raises(ValueError):
         _get_essential_airflow_executor_config(invalid_executor)
 
+# ---------------------------------------------------
+# Customer Extra Celery Config Merge Tests
+# ---------------------------------------------------
+
+MOCK_BROKER_TRANSPORT_CONFIG = {
+    "broker_transport": "mocked.transport.Transport",
+    "broker_transport_options": {
+        "visibility_timeout": 43200,
+        "region": "us-east-1",
+    },
+}
+
+
+def _get_celery_executor_config(monkeypatch):
+    """Call _get_essential_airflow_executor_config with mocked dependencies."""
+    monkeypatch.setattr("mwaa.config.airflow.get_sqs_endpoint", lambda: "sqs://endpoint")
+    monkeypatch.setattr("mwaa.config.airflow.get_sqs_queue_name", lambda: "test-queue")
+    monkeypatch.setattr("mwaa.config.airflow.get_db_connection_string", lambda: "postgresql://db")
+
+    with patch(
+        "mwaa.config.celery.get_broker_transport_config",
+        return_value=dict(MOCK_BROKER_TRANSPORT_CONFIG),
+    ):
+        return _get_essential_airflow_executor_config("CeleryExecutor")
+
+
+def test_customer_extra_celery_config_is_merged(monkeypatch, env_helper):
+    """Customer-provided extra_celery_config keys must survive the merge with
+    MWAA's broker transport config (regression test for GitHub issue #571)."""
+    env_helper.set({
+        "MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS": json.dumps({
+            "AIRFLOW__CELERY__EXTRA_CELERY_CONFIG": json.dumps(
+                {"worker_max_tasks_per_child": 50}
+            )
+        })
+    })
+
+    result = _get_celery_executor_config(monkeypatch)
+
+    extra_config = json.loads(result["AIRFLOW__CELERY__EXTRA_CELERY_CONFIG"])
+    # Customer key survives.
+    assert extra_config["worker_max_tasks_per_child"] == 50
+    # MWAA broker transport config remains intact.
+    assert extra_config["broker_transport"] == "mocked.transport.Transport"
+    assert (
+        extra_config["broker_transport_options"]
+        == MOCK_BROKER_TRANSPORT_CONFIG["broker_transport_options"]
+    )
+
+
+def test_mwaa_broker_config_wins_on_collision(monkeypatch, env_helper):
+    """MWAA broker transport keys must win when the customer tries to override
+    them, while the customer's non-colliding keys survive."""
+    env_helper.set({
+        "MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS": json.dumps({
+            "AIRFLOW__CELERY__EXTRA_CELERY_CONFIG": json.dumps({
+                "broker_transport": "customer.transport.Transport",
+                "broker_transport_options": {"visibility_timeout": 1},
+                "worker_max_tasks_per_child": 50,
+            })
+        })
+    })
+
+    result = _get_celery_executor_config(monkeypatch)
+
+    extra_config = json.loads(result["AIRFLOW__CELERY__EXTRA_CELERY_CONFIG"])
+    # MWAA broker keys win on collision.
+    assert extra_config["broker_transport"] == "mocked.transport.Transport"
+    assert (
+        extra_config["broker_transport_options"]
+        == MOCK_BROKER_TRANSPORT_CONFIG["broker_transport_options"]
+    )
+    # Customer's non-colliding key survives.
+    assert extra_config["worker_max_tasks_per_child"] == 50
+
+
+def test_extra_celery_config_secret_wins_over_env_var(monkeypatch, env_helper):
+    """The Airflow config secret takes priority over the raw environment
+    variable, consistent with the merge order in setup_environment.py."""
+    env_helper.set({
+        "AIRFLOW__CELERY__EXTRA_CELERY_CONFIG": json.dumps(
+            {"worker_max_tasks_per_child": 10, "worker_prefetch_multiplier": 4}
+        ),
+        "MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS": json.dumps({
+            "AIRFLOW__CELERY__EXTRA_CELERY_CONFIG": json.dumps(
+                {"worker_max_tasks_per_child": 50}
+            )
+        }),
+    })
+
+    result = _get_celery_executor_config(monkeypatch)
+
+    extra_config = json.loads(result["AIRFLOW__CELERY__EXTRA_CELERY_CONFIG"])
+    # Secret value wins on collision.
+    assert extra_config["worker_max_tasks_per_child"] == 50
+    # Non-colliding env var key survives.
+    assert extra_config["worker_prefetch_multiplier"] == 4
+
+
+@pytest.mark.parametrize("invalid_value", [
+    "{not-valid-json",
+    '["not", "an", "object"]',
+    '"just a string"',
+    "42",
+])
+def test_invalid_customer_extra_celery_config_ignored(
+    monkeypatch, env_helper, invalid_value
+):
+    """Invalid or non-object JSON values are logged and ignored; the broker
+    transport config remains intact."""
+    env_helper.set({
+        "MWAA__CORE__CUSTOM_AIRFLOW_CONFIGS": json.dumps({
+            "AIRFLOW__CELERY__EXTRA_CELERY_CONFIG": invalid_value
+        })
+    })
+
+    result = _get_celery_executor_config(monkeypatch)
+
+    extra_config = json.loads(result["AIRFLOW__CELERY__EXTRA_CELERY_CONFIG"])
+    assert extra_config == MOCK_BROKER_TRANSPORT_CONFIG
+
+
+def test_no_customer_extra_celery_config(monkeypatch):
+    """Without any customer-provided value, extra_celery_config is exactly the
+    MWAA broker transport config."""
+    result = _get_celery_executor_config(monkeypatch)
+
+    extra_config = json.loads(result["AIRFLOW__CELERY__EXTRA_CELERY_CONFIG"])
+    assert extra_config == MOCK_BROKER_TRANSPORT_CONFIG
+
+
 # ---------------------------
 # Core Config Tests
 # ---------------------------


### PR DESCRIPTION
*Issue #, if available:*
Follow up on issue: https://github.com/aws/amazon-mwaa-docker-images/issues/571. Need to apply the same fix to 3.3.0 as the source image code is based on 3.2.1. 

*Description of changes:*
- Port the fix from #572 to Airflow 3.3.0: merge customer-provided celery.extra_celery_config underneath MWAA's broker transport config so customer keys survive while MWAA broker keys win on collision. Invalid or non-object JSON values are logged and ignored.
- Add regression unit tests for the merge behavior to both 3.2.1 and 3.3.0 (customer keys survive, broker keys win on collision, config secret takes priority over the raw env var, invalid values ignored).
- Update the quality check to use exclusion list instead of hard-coding Airflow versions.

*Testing*:
+ Checked out the quality check run, it contains `[diff-coverage_test.sh]` execution on the 3.3.0 change lines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
