### PR TITLE
Harden the RDS IAM token path across all versions

### DIFF
--- a/images/airflow/2.10.1/python/mwaa/utils/get_rds_iam_credentials.py
+++ b/images/airflow/2.10.1/python/mwaa/utils/get_rds_iam_credentials.py
@@ -2,30 +2,92 @@
 import json
 import logging
 import os
-import sys
 import threading
 import time
+import urllib.error
 import urllib.request
 from urllib.parse import quote_plus
 
 import boto3
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
+
+# The ECS task credential endpoint is link-local (169.254.170.2), routed inside
+# the task's own network namespace, and normally answers in milliseconds. It can
+# still fail with a connect timeout, but per the Fargate Data Plane analysis in
+# P481207036 that is not the endpoint being unhealthy or throttling: breaching
+# the TMDS limit (80 req/s steady, 120 burst) returns HTTP 429 on a completed
+# connection, whereas a connect timeout means the *calling* process could not
+# complete connect() in time because it is resource starved. So the call must be
+# bounded and retried rather than left to block.
+#
+# Note botocore's AWS_METADATA_SERVICE_TIMEOUT / _NUM_ATTEMPTS do not apply here:
+# this fetch is plain urllib, not botocore, so the values have to be set
+# explicitly.
+_METADATA_TIMEOUT_SECONDS = float(
+    os.environ.get("MWAA__DB__IAM_METADATA_TIMEOUT", "5")
+)
+_METADATA_ATTEMPTS = int(os.environ.get("MWAA__DB__IAM_METADATA_ATTEMPTS", "3"))
+
+# Tokens are valid for 15 minutes; a refresh is attempted once fewer than 5
+# remain. The buffer exists so the refresh can happen off the critical path:
+# a caller is handed the still-valid cached token immediately while a
+# background thread mints the replacement.
+_TOKEN_LIFETIME_SECONDS = 15 * 60
+_TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60
+
+
+def _is_transient_metadata_error(exception):
+    """Return True for metadata failures that are worth retrying.
+
+    Retries connect/read timeouts and connection errors, plus HTTP 429 (the
+    documented TMDS throttle response) and 5xx. Deliberately does not retry
+    configuration mistakes such as a missing environment variable, or client
+    errors like 404, where retrying only delays the failure.
+    """
+    if isinstance(exception, urllib.error.HTTPError):
+        return exception.code == 429 or exception.code >= 500
+    # socket.timeout is an alias of TimeoutError on Python 3.10+.
+    return isinstance(exception, (urllib.error.URLError, TimeoutError, ConnectionError))
+
+
+_with_metadata_retry = retry(
+    stop=stop_after_attempt(_METADATA_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=1, max=4),
+    retry=retry_if_exception(_is_transient_metadata_error),
+    reraise=True,
+)
+
 
 class RDSIAMCredentialProvider:
     """Provider for RDS IAM authentication tokens with thread-safe caching."""
     _lock = threading.Lock()
+    # Single-flight guard for the background refresh: acquired without
+    # blocking by whichever caller notices the token is due, released by the
+    # refresh thread when it finishes. (threading.Lock permits releasing from
+    # a thread other than the acquirer.)
+    _refresh_lock = threading.Lock()
+    # The last background refresh thread, kept for introspection and tests.
+    _refresh_thread = None
     _token = None
     _expires_at = 0
 
     @staticmethod
+    @_with_metadata_retry
     def get_ecs_credentials():
         """
         Get AWS credentials from ECS task metadata endpoint.
-        
+
+        The request is bounded by MWAA__DB__IAM_METADATA_TIMEOUT and retried up
+        to MWAA__DB__IAM_METADATA_ATTEMPTS times on transient failures. Without
+        a timeout this call can block indefinitely, and it runs inside the
+        SQLAlchemy do_connect listener, so a hang would stall a metadata
+        database connection.
+
         Returns:
             dict: AWS credentials containing AccessKeyId, SecretAccessKey, and Token
-            
+
         Raises:
             ValueError: If required environment variables are not set
         """
@@ -50,7 +112,7 @@ class RDSIAMCredentialProvider:
         no_proxy_handler = urllib.request.ProxyHandler({})
         opener = urllib.request.build_opener(no_proxy_handler)
 
-        with opener.open(request) as response:
+        with opener.open(request, timeout=_METADATA_TIMEOUT_SECONDS) as response:
             if response.status != 200:
                 raise Exception(f"Failed to fetch ECS credentials: {response.status}")
             credentials_data = json.loads(response.read().decode('utf-8'))
@@ -127,10 +189,20 @@ class RDSIAMCredentialProvider:
     @staticmethod
     def generate_credentials():
         """
-        Generate fresh RDS auth token and store in memory
+        Generate fresh RDS auth token.
+
+        Raises on failure rather than returning None. Returning None poisoned
+        the cache: get_token() stored the None with a full 15-minute lifetime,
+        so every caller in the process was handed an unusable credential until
+        the entry aged out. Raising also lets get_token() distinguish a failed
+        refresh (fall back to the still-valid cached token) from a failed cold
+        start (surface the error).
 
         Returns:
-            str or None: RDS auth token if successful, None if generation fails
+            str: RDS auth token
+
+        Raises:
+            Exception: If credential generation fails
         """
         try:
             # Get ECS credentials from task metadata endpoint
@@ -152,44 +224,122 @@ class RDSIAMCredentialProvider:
 
         except Exception as e:
             logger.error(f"Failed to update credentials: {e}")
-            return None
+            raise
 
     @classmethod
     def get_token(cls):
         """
-        Get cached RDS IAM token, refreshing if expired or missing.
-        Uses thread-safe caching with 5-minute refresh buffer before expiration.
-        
+        Get cached RDS IAM token, refreshing if due, expired or missing.
+
+        Tokens are valid for 15 minutes and become due for refresh once fewer
+        than 5 remain. A caller holding a usable token never pays for the
+        refresh: the cached token is returned immediately and the refresh runs
+        on a background thread (see ``_start_background_refresh``). This keeps
+        the ECS metadata fetch off the connection critical path -- the fetch
+        is most likely to be slow exactly when the process is busy
+        (P481207036), which is also when connections are most frequent.
+
+        Only when nothing usable is cached -- cold start, or a token that has
+        actually expired -- is the fetch performed synchronously on the
+        calling thread. That path holds the lock across the mint, which
+        serialises concurrent callers into a single fetch (the shared
+        credential provider shape the Fargate Data Plane team recommends to
+        avoid multiplying connects to the endpoint), and is only safe to hold
+        across the network call because the call is bounded by
+        MWAA__DB__IAM_METADATA_TIMEOUT.
+
         Returns:
             str: Cached or freshly generated RDS auth token
         """
         now = time.time()
+        token = cls._token
 
-        # Refresh token in cache if missing or expires in 5 mins. 
-        if cls._token is None or now > cls._expires_at - 300:
-            with cls._lock:
-                if cls._token is None or now > cls._expires_at - 300:
-                    cls._token = cls.generate_credentials()
-                    cls._expires_at = now + 15 * 60  # 15 mins
-        
-        return cls._token
-    
-    
+        if token is not None and now < cls._expires_at:
+            # The cached token is usable. If it is due for refresh, hand the
+            # refresh to a background thread and serve the cached token
+            # immediately rather than making this caller -- typically a
+            # database connection inside the do_connect listener -- block on
+            # the fetch.
+            if now > cls._expires_at - _TOKEN_REFRESH_BUFFER_SECONDS:
+                cls._start_background_refresh()
+            return token
+
+        # Nothing usable: cold start, or the token has expired. Fetch
+        # synchronously; the double-check returns without a second fetch for
+        # the threads that queued behind the winner.
+        with cls._lock:
+            if cls._token is None or time.time() >= cls._expires_at:
+                token = cls.generate_credentials()
+                cls._token = token
+                # Timed from after the mint, not from before the lock wait,
+                # so a slow refresh cannot overstate the token's lifetime.
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            return cls._token
+
+    @classmethod
+    def _start_background_refresh(cls):
+        """
+        Refresh the token on a background thread, single-flight.
+
+        The non-blocking acquire keeps the refresh single-flight, so
+        concurrent callers noticing a due token do not multiply connects to
+        the ECS credential endpoint -- multiplying connects under contention
+        is the amplification pattern identified in P481207036.
+
+        A refresh failure is logged and the still-valid cached token stays in
+        place: tokens become due at the 10-minute mark of their 15-minute
+        lifetime precisely so a failed attempt leaves a ~5 minute window in
+        which later callers re-trigger the refresh.
+        """
+        if not cls._refresh_lock.acquire(blocking=False):
+            # A refresh is already in flight.
+            return
+
+        def _refresh():
+            try:
+                token = cls.generate_credentials()
+                cls._token = token
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            except Exception as e:
+                logger.warning(
+                    "Could not refresh the RDS IAM token in the background "
+                    "(%s); keeping the cached token, which is still valid.",
+                    e,
+                )
+            finally:
+                cls._refresh_lock.release()
+
+        try:
+            thread = threading.Thread(
+                target=_refresh, name="mwaa-rds-iam-token-refresh", daemon=True
+            )
+            cls._refresh_thread = thread
+            thread.start()
+        except Exception as e:
+            # Could not spawn the thread (e.g. resource exhaustion). Release
+            # the guard so a later caller can try again; the cached token is
+            # still valid, so this caller is unaffected.
+            cls._refresh_lock.release()
+            logger.warning("Could not start the RDS IAM token refresh thread: %s", e)
+
     @classmethod
     def create_db_connection_url(cls, token=None):
         """
         Create a PostgreSQL connection URL for RDS IAM authentication.
         
         Args:
-            token (str, optional): RDS IAM auth token. If None, generates a fresh token.
+            token (str, optional): RDS IAM auth token. If None, the cached
+                token from ``get_token()`` is used.
         
         Returns:
             str: PostgreSQL connection URL with IAM authentication
         """
         if token is None:
-            token = cls.generate_credentials()
-            if token is None:
-                raise Exception("Failed to generate RDS auth token")
+            # Route through get_token() rather than generate_credentials() so
+            # the default path reuses the thread-safe cache. Calling
+            # generate_credentials() directly would mint a new token -- an ECS
+            # metadata fetch plus a signed boto3 call -- on every connection.
+            token = cls.get_token()
 
         IAM_POSTGRES_USER = "airflow_user"
         AUTH_TOKEN = quote_plus(token)
@@ -205,3 +355,21 @@ class RDSIAMCredentialProvider:
         )
 
         return connection_url
+
+
+def _reset_locks_after_fork():
+    """
+    Recreate the provider's locks in a forked child.
+
+    Airflow forks (Celery prefork workers, DAG processors). If the parent
+    forks while a lock is held, the child inherits it locked with no thread
+    alive to release it, which would wedge every future refresh in that child.
+    The cached token itself is plain data and remains valid across the fork,
+    so only the locks are replaced.
+    """
+    RDSIAMCredentialProvider._lock = threading.Lock()
+    RDSIAMCredentialProvider._refresh_lock = threading.Lock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_locks_after_fork)

--- a/images/airflow/2.10.3/python/mwaa/utils/get_rds_iam_credentials.py
+++ b/images/airflow/2.10.3/python/mwaa/utils/get_rds_iam_credentials.py
@@ -2,30 +2,92 @@
 import json
 import logging
 import os
-import sys
 import threading
 import time
+import urllib.error
 import urllib.request
 from urllib.parse import quote_plus
 
 import boto3
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
+
+# The ECS task credential endpoint is link-local (169.254.170.2), routed inside
+# the task's own network namespace, and normally answers in milliseconds. It can
+# still fail with a connect timeout, but per the Fargate Data Plane analysis in
+# P481207036 that is not the endpoint being unhealthy or throttling: breaching
+# the TMDS limit (80 req/s steady, 120 burst) returns HTTP 429 on a completed
+# connection, whereas a connect timeout means the *calling* process could not
+# complete connect() in time because it is resource starved. So the call must be
+# bounded and retried rather than left to block.
+#
+# Note botocore's AWS_METADATA_SERVICE_TIMEOUT / _NUM_ATTEMPTS do not apply here:
+# this fetch is plain urllib, not botocore, so the values have to be set
+# explicitly.
+_METADATA_TIMEOUT_SECONDS = float(
+    os.environ.get("MWAA__DB__IAM_METADATA_TIMEOUT", "5")
+)
+_METADATA_ATTEMPTS = int(os.environ.get("MWAA__DB__IAM_METADATA_ATTEMPTS", "3"))
+
+# Tokens are valid for 15 minutes; a refresh is attempted once fewer than 5
+# remain. The buffer exists so the refresh can happen off the critical path:
+# a caller is handed the still-valid cached token immediately while a
+# background thread mints the replacement.
+_TOKEN_LIFETIME_SECONDS = 15 * 60
+_TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60
+
+
+def _is_transient_metadata_error(exception):
+    """Return True for metadata failures that are worth retrying.
+
+    Retries connect/read timeouts and connection errors, plus HTTP 429 (the
+    documented TMDS throttle response) and 5xx. Deliberately does not retry
+    configuration mistakes such as a missing environment variable, or client
+    errors like 404, where retrying only delays the failure.
+    """
+    if isinstance(exception, urllib.error.HTTPError):
+        return exception.code == 429 or exception.code >= 500
+    # socket.timeout is an alias of TimeoutError on Python 3.10+.
+    return isinstance(exception, (urllib.error.URLError, TimeoutError, ConnectionError))
+
+
+_with_metadata_retry = retry(
+    stop=stop_after_attempt(_METADATA_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=1, max=4),
+    retry=retry_if_exception(_is_transient_metadata_error),
+    reraise=True,
+)
+
 
 class RDSIAMCredentialProvider:
     """Provider for RDS IAM authentication tokens with thread-safe caching."""
     _lock = threading.Lock()
+    # Single-flight guard for the background refresh: acquired without
+    # blocking by whichever caller notices the token is due, released by the
+    # refresh thread when it finishes. (threading.Lock permits releasing from
+    # a thread other than the acquirer.)
+    _refresh_lock = threading.Lock()
+    # The last background refresh thread, kept for introspection and tests.
+    _refresh_thread = None
     _token = None
     _expires_at = 0
 
     @staticmethod
+    @_with_metadata_retry
     def get_ecs_credentials():
         """
         Get AWS credentials from ECS task metadata endpoint.
-        
+
+        The request is bounded by MWAA__DB__IAM_METADATA_TIMEOUT and retried up
+        to MWAA__DB__IAM_METADATA_ATTEMPTS times on transient failures. Without
+        a timeout this call can block indefinitely, and it runs inside the
+        SQLAlchemy do_connect listener, so a hang would stall a metadata
+        database connection.
+
         Returns:
             dict: AWS credentials containing AccessKeyId, SecretAccessKey, and Token
-            
+
         Raises:
             ValueError: If required environment variables are not set
         """
@@ -50,7 +112,7 @@ class RDSIAMCredentialProvider:
         no_proxy_handler = urllib.request.ProxyHandler({})
         opener = urllib.request.build_opener(no_proxy_handler)
 
-        with opener.open(request) as response:
+        with opener.open(request, timeout=_METADATA_TIMEOUT_SECONDS) as response:
             if response.status != 200:
                 raise Exception(f"Failed to fetch ECS credentials: {response.status}")
             credentials_data = json.loads(response.read().decode('utf-8'))
@@ -127,10 +189,20 @@ class RDSIAMCredentialProvider:
     @staticmethod
     def generate_credentials():
         """
-        Generate fresh RDS auth token and store in memory
+        Generate fresh RDS auth token.
+
+        Raises on failure rather than returning None. Returning None poisoned
+        the cache: get_token() stored the None with a full 15-minute lifetime,
+        so every caller in the process was handed an unusable credential until
+        the entry aged out. Raising also lets get_token() distinguish a failed
+        refresh (fall back to the still-valid cached token) from a failed cold
+        start (surface the error).
 
         Returns:
-            str or None: RDS auth token if successful, None if generation fails
+            str: RDS auth token
+
+        Raises:
+            Exception: If credential generation fails
         """
         try:
             # Get ECS credentials from task metadata endpoint
@@ -152,44 +224,122 @@ class RDSIAMCredentialProvider:
 
         except Exception as e:
             logger.error(f"Failed to update credentials: {e}")
-            return None
+            raise
 
     @classmethod
     def get_token(cls):
         """
-        Get cached RDS IAM token, refreshing if expired or missing.
-        Uses thread-safe caching with 5-minute refresh buffer before expiration.
-        
+        Get cached RDS IAM token, refreshing if due, expired or missing.
+
+        Tokens are valid for 15 minutes and become due for refresh once fewer
+        than 5 remain. A caller holding a usable token never pays for the
+        refresh: the cached token is returned immediately and the refresh runs
+        on a background thread (see ``_start_background_refresh``). This keeps
+        the ECS metadata fetch off the connection critical path -- the fetch
+        is most likely to be slow exactly when the process is busy
+        (P481207036), which is also when connections are most frequent.
+
+        Only when nothing usable is cached -- cold start, or a token that has
+        actually expired -- is the fetch performed synchronously on the
+        calling thread. That path holds the lock across the mint, which
+        serialises concurrent callers into a single fetch (the shared
+        credential provider shape the Fargate Data Plane team recommends to
+        avoid multiplying connects to the endpoint), and is only safe to hold
+        across the network call because the call is bounded by
+        MWAA__DB__IAM_METADATA_TIMEOUT.
+
         Returns:
             str: Cached or freshly generated RDS auth token
         """
         now = time.time()
+        token = cls._token
 
-        # Refresh token in cache if missing or expires in 5 mins. 
-        if cls._token is None or now > cls._expires_at - 300:
-            with cls._lock:
-                if cls._token is None or now > cls._expires_at - 300:
-                    cls._token = cls.generate_credentials()
-                    cls._expires_at = now + 15 * 60  # 15 mins
-        
-        return cls._token
-    
-    
+        if token is not None and now < cls._expires_at:
+            # The cached token is usable. If it is due for refresh, hand the
+            # refresh to a background thread and serve the cached token
+            # immediately rather than making this caller -- typically a
+            # database connection inside the do_connect listener -- block on
+            # the fetch.
+            if now > cls._expires_at - _TOKEN_REFRESH_BUFFER_SECONDS:
+                cls._start_background_refresh()
+            return token
+
+        # Nothing usable: cold start, or the token has expired. Fetch
+        # synchronously; the double-check returns without a second fetch for
+        # the threads that queued behind the winner.
+        with cls._lock:
+            if cls._token is None or time.time() >= cls._expires_at:
+                token = cls.generate_credentials()
+                cls._token = token
+                # Timed from after the mint, not from before the lock wait,
+                # so a slow refresh cannot overstate the token's lifetime.
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            return cls._token
+
+    @classmethod
+    def _start_background_refresh(cls):
+        """
+        Refresh the token on a background thread, single-flight.
+
+        The non-blocking acquire keeps the refresh single-flight, so
+        concurrent callers noticing a due token do not multiply connects to
+        the ECS credential endpoint -- multiplying connects under contention
+        is the amplification pattern identified in P481207036.
+
+        A refresh failure is logged and the still-valid cached token stays in
+        place: tokens become due at the 10-minute mark of their 15-minute
+        lifetime precisely so a failed attempt leaves a ~5 minute window in
+        which later callers re-trigger the refresh.
+        """
+        if not cls._refresh_lock.acquire(blocking=False):
+            # A refresh is already in flight.
+            return
+
+        def _refresh():
+            try:
+                token = cls.generate_credentials()
+                cls._token = token
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            except Exception as e:
+                logger.warning(
+                    "Could not refresh the RDS IAM token in the background "
+                    "(%s); keeping the cached token, which is still valid.",
+                    e,
+                )
+            finally:
+                cls._refresh_lock.release()
+
+        try:
+            thread = threading.Thread(
+                target=_refresh, name="mwaa-rds-iam-token-refresh", daemon=True
+            )
+            cls._refresh_thread = thread
+            thread.start()
+        except Exception as e:
+            # Could not spawn the thread (e.g. resource exhaustion). Release
+            # the guard so a later caller can try again; the cached token is
+            # still valid, so this caller is unaffected.
+            cls._refresh_lock.release()
+            logger.warning("Could not start the RDS IAM token refresh thread: %s", e)
+
     @classmethod
     def create_db_connection_url(cls, token=None):
         """
         Create a PostgreSQL connection URL for RDS IAM authentication.
         
         Args:
-            token (str, optional): RDS IAM auth token. If None, generates a fresh token.
+            token (str, optional): RDS IAM auth token. If None, the cached
+                token from ``get_token()`` is used.
         
         Returns:
             str: PostgreSQL connection URL with IAM authentication
         """
         if token is None:
-            token = cls.generate_credentials()
-            if token is None:
-                raise Exception("Failed to generate RDS auth token")
+            # Route through get_token() rather than generate_credentials() so
+            # the default path reuses the thread-safe cache. Calling
+            # generate_credentials() directly would mint a new token -- an ECS
+            # metadata fetch plus a signed boto3 call -- on every connection.
+            token = cls.get_token()
 
         IAM_POSTGRES_USER = "airflow_user"
         AUTH_TOKEN = quote_plus(token)
@@ -205,3 +355,21 @@ class RDSIAMCredentialProvider:
         )
 
         return connection_url
+
+
+def _reset_locks_after_fork():
+    """
+    Recreate the provider's locks in a forked child.
+
+    Airflow forks (Celery prefork workers, DAG processors). If the parent
+    forks while a lock is held, the child inherits it locked with no thread
+    alive to release it, which would wedge every future refresh in that child.
+    The cached token itself is plain data and remains valid across the fork,
+    so only the locks are replaced.
+    """
+    RDSIAMCredentialProvider._lock = threading.Lock()
+    RDSIAMCredentialProvider._refresh_lock = threading.Lock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_locks_after_fork)

--- a/images/airflow/2.11.0/python/mwaa/utils/get_rds_iam_credentials.py
+++ b/images/airflow/2.11.0/python/mwaa/utils/get_rds_iam_credentials.py
@@ -2,30 +2,92 @@
 import json
 import logging
 import os
-import sys
 import threading
 import time
+import urllib.error
 import urllib.request
 from urllib.parse import quote_plus
 
 import boto3
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
+
+# The ECS task credential endpoint is link-local (169.254.170.2), routed inside
+# the task's own network namespace, and normally answers in milliseconds. It can
+# still fail with a connect timeout, but per the Fargate Data Plane analysis in
+# P481207036 that is not the endpoint being unhealthy or throttling: breaching
+# the TMDS limit (80 req/s steady, 120 burst) returns HTTP 429 on a completed
+# connection, whereas a connect timeout means the *calling* process could not
+# complete connect() in time because it is resource starved. So the call must be
+# bounded and retried rather than left to block.
+#
+# Note botocore's AWS_METADATA_SERVICE_TIMEOUT / _NUM_ATTEMPTS do not apply here:
+# this fetch is plain urllib, not botocore, so the values have to be set
+# explicitly.
+_METADATA_TIMEOUT_SECONDS = float(
+    os.environ.get("MWAA__DB__IAM_METADATA_TIMEOUT", "5")
+)
+_METADATA_ATTEMPTS = int(os.environ.get("MWAA__DB__IAM_METADATA_ATTEMPTS", "3"))
+
+# Tokens are valid for 15 minutes; a refresh is attempted once fewer than 5
+# remain. The buffer exists so the refresh can happen off the critical path:
+# a caller is handed the still-valid cached token immediately while a
+# background thread mints the replacement.
+_TOKEN_LIFETIME_SECONDS = 15 * 60
+_TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60
+
+
+def _is_transient_metadata_error(exception):
+    """Return True for metadata failures that are worth retrying.
+
+    Retries connect/read timeouts and connection errors, plus HTTP 429 (the
+    documented TMDS throttle response) and 5xx. Deliberately does not retry
+    configuration mistakes such as a missing environment variable, or client
+    errors like 404, where retrying only delays the failure.
+    """
+    if isinstance(exception, urllib.error.HTTPError):
+        return exception.code == 429 or exception.code >= 500
+    # socket.timeout is an alias of TimeoutError on Python 3.10+.
+    return isinstance(exception, (urllib.error.URLError, TimeoutError, ConnectionError))
+
+
+_with_metadata_retry = retry(
+    stop=stop_after_attempt(_METADATA_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=1, max=4),
+    retry=retry_if_exception(_is_transient_metadata_error),
+    reraise=True,
+)
+
 
 class RDSIAMCredentialProvider:
     """Provider for RDS IAM authentication tokens with thread-safe caching."""
     _lock = threading.Lock()
+    # Single-flight guard for the background refresh: acquired without
+    # blocking by whichever caller notices the token is due, released by the
+    # refresh thread when it finishes. (threading.Lock permits releasing from
+    # a thread other than the acquirer.)
+    _refresh_lock = threading.Lock()
+    # The last background refresh thread, kept for introspection and tests.
+    _refresh_thread = None
     _token = None
     _expires_at = 0
 
     @staticmethod
+    @_with_metadata_retry
     def get_ecs_credentials():
         """
         Get AWS credentials from ECS task metadata endpoint.
-        
+
+        The request is bounded by MWAA__DB__IAM_METADATA_TIMEOUT and retried up
+        to MWAA__DB__IAM_METADATA_ATTEMPTS times on transient failures. Without
+        a timeout this call can block indefinitely, and it runs inside the
+        SQLAlchemy do_connect listener, so a hang would stall a metadata
+        database connection.
+
         Returns:
             dict: AWS credentials containing AccessKeyId, SecretAccessKey, and Token
-            
+
         Raises:
             ValueError: If required environment variables are not set
         """
@@ -50,7 +112,7 @@ class RDSIAMCredentialProvider:
         no_proxy_handler = urllib.request.ProxyHandler({})
         opener = urllib.request.build_opener(no_proxy_handler)
 
-        with opener.open(request) as response:
+        with opener.open(request, timeout=_METADATA_TIMEOUT_SECONDS) as response:
             if response.status != 200:
                 raise Exception(f"Failed to fetch ECS credentials: {response.status}")
             credentials_data = json.loads(response.read().decode('utf-8'))
@@ -127,10 +189,20 @@ class RDSIAMCredentialProvider:
     @staticmethod
     def generate_credentials():
         """
-        Generate fresh RDS auth token and store in memory
+        Generate fresh RDS auth token.
+
+        Raises on failure rather than returning None. Returning None poisoned
+        the cache: get_token() stored the None with a full 15-minute lifetime,
+        so every caller in the process was handed an unusable credential until
+        the entry aged out. Raising also lets get_token() distinguish a failed
+        refresh (fall back to the still-valid cached token) from a failed cold
+        start (surface the error).
 
         Returns:
-            str or None: RDS auth token if successful, None if generation fails
+            str: RDS auth token
+
+        Raises:
+            Exception: If credential generation fails
         """
         try:
             # Get ECS credentials from task metadata endpoint
@@ -152,44 +224,122 @@ class RDSIAMCredentialProvider:
 
         except Exception as e:
             logger.error(f"Failed to update credentials: {e}")
-            return None
+            raise
 
     @classmethod
     def get_token(cls):
         """
-        Get cached RDS IAM token, refreshing if expired or missing.
-        Uses thread-safe caching with 5-minute refresh buffer before expiration.
-        
+        Get cached RDS IAM token, refreshing if due, expired or missing.
+
+        Tokens are valid for 15 minutes and become due for refresh once fewer
+        than 5 remain. A caller holding a usable token never pays for the
+        refresh: the cached token is returned immediately and the refresh runs
+        on a background thread (see ``_start_background_refresh``). This keeps
+        the ECS metadata fetch off the connection critical path -- the fetch
+        is most likely to be slow exactly when the process is busy
+        (P481207036), which is also when connections are most frequent.
+
+        Only when nothing usable is cached -- cold start, or a token that has
+        actually expired -- is the fetch performed synchronously on the
+        calling thread. That path holds the lock across the mint, which
+        serialises concurrent callers into a single fetch (the shared
+        credential provider shape the Fargate Data Plane team recommends to
+        avoid multiplying connects to the endpoint), and is only safe to hold
+        across the network call because the call is bounded by
+        MWAA__DB__IAM_METADATA_TIMEOUT.
+
         Returns:
             str: Cached or freshly generated RDS auth token
         """
         now = time.time()
+        token = cls._token
 
-        # Refresh token in cache if missing or expires in 5 mins. 
-        if cls._token is None or now > cls._expires_at - 300:
-            with cls._lock:
-                if cls._token is None or now > cls._expires_at - 300:
-                    cls._token = cls.generate_credentials()
-                    cls._expires_at = now + 15 * 60  # 15 mins
-        
-        return cls._token
-    
-    
+        if token is not None and now < cls._expires_at:
+            # The cached token is usable. If it is due for refresh, hand the
+            # refresh to a background thread and serve the cached token
+            # immediately rather than making this caller -- typically a
+            # database connection inside the do_connect listener -- block on
+            # the fetch.
+            if now > cls._expires_at - _TOKEN_REFRESH_BUFFER_SECONDS:
+                cls._start_background_refresh()
+            return token
+
+        # Nothing usable: cold start, or the token has expired. Fetch
+        # synchronously; the double-check returns without a second fetch for
+        # the threads that queued behind the winner.
+        with cls._lock:
+            if cls._token is None or time.time() >= cls._expires_at:
+                token = cls.generate_credentials()
+                cls._token = token
+                # Timed from after the mint, not from before the lock wait,
+                # so a slow refresh cannot overstate the token's lifetime.
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            return cls._token
+
+    @classmethod
+    def _start_background_refresh(cls):
+        """
+        Refresh the token on a background thread, single-flight.
+
+        The non-blocking acquire keeps the refresh single-flight, so
+        concurrent callers noticing a due token do not multiply connects to
+        the ECS credential endpoint -- multiplying connects under contention
+        is the amplification pattern identified in P481207036.
+
+        A refresh failure is logged and the still-valid cached token stays in
+        place: tokens become due at the 10-minute mark of their 15-minute
+        lifetime precisely so a failed attempt leaves a ~5 minute window in
+        which later callers re-trigger the refresh.
+        """
+        if not cls._refresh_lock.acquire(blocking=False):
+            # A refresh is already in flight.
+            return
+
+        def _refresh():
+            try:
+                token = cls.generate_credentials()
+                cls._token = token
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            except Exception as e:
+                logger.warning(
+                    "Could not refresh the RDS IAM token in the background "
+                    "(%s); keeping the cached token, which is still valid.",
+                    e,
+                )
+            finally:
+                cls._refresh_lock.release()
+
+        try:
+            thread = threading.Thread(
+                target=_refresh, name="mwaa-rds-iam-token-refresh", daemon=True
+            )
+            cls._refresh_thread = thread
+            thread.start()
+        except Exception as e:
+            # Could not spawn the thread (e.g. resource exhaustion). Release
+            # the guard so a later caller can try again; the cached token is
+            # still valid, so this caller is unaffected.
+            cls._refresh_lock.release()
+            logger.warning("Could not start the RDS IAM token refresh thread: %s", e)
+
     @classmethod
     def create_db_connection_url(cls, token=None):
         """
         Create a PostgreSQL connection URL for RDS IAM authentication.
         
         Args:
-            token (str, optional): RDS IAM auth token. If None, generates a fresh token.
+            token (str, optional): RDS IAM auth token. If None, the cached
+                token from ``get_token()`` is used.
         
         Returns:
             str: PostgreSQL connection URL with IAM authentication
         """
         if token is None:
-            token = cls.generate_credentials()
-            if token is None:
-                raise Exception("Failed to generate RDS auth token")
+            # Route through get_token() rather than generate_credentials() so
+            # the default path reuses the thread-safe cache. Calling
+            # generate_credentials() directly would mint a new token -- an ECS
+            # metadata fetch plus a signed boto3 call -- on every connection.
+            token = cls.get_token()
 
         IAM_POSTGRES_USER = "airflow_user"
         AUTH_TOKEN = quote_plus(token)
@@ -205,3 +355,21 @@ class RDSIAMCredentialProvider:
         )
 
         return connection_url
+
+
+def _reset_locks_after_fork():
+    """
+    Recreate the provider's locks in a forked child.
+
+    Airflow forks (Celery prefork workers, DAG processors). If the parent
+    forks while a lock is held, the child inherits it locked with no thread
+    alive to release it, which would wedge every future refresh in that child.
+    The cached token itself is plain data and remains valid across the fork,
+    so only the locks are replaced.
+    """
+    RDSIAMCredentialProvider._lock = threading.Lock()
+    RDSIAMCredentialProvider._refresh_lock = threading.Lock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_locks_after_fork)

--- a/images/airflow/2.11.2/python/mwaa/utils/get_rds_iam_credentials.py
+++ b/images/airflow/2.11.2/python/mwaa/utils/get_rds_iam_credentials.py
@@ -2,30 +2,92 @@
 import json
 import logging
 import os
-import sys
 import threading
 import time
+import urllib.error
 import urllib.request
 from urllib.parse import quote_plus
 
 import boto3
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
+
+# The ECS task credential endpoint is link-local (169.254.170.2), routed inside
+# the task's own network namespace, and normally answers in milliseconds. It can
+# still fail with a connect timeout, but per the Fargate Data Plane analysis in
+# P481207036 that is not the endpoint being unhealthy or throttling: breaching
+# the TMDS limit (80 req/s steady, 120 burst) returns HTTP 429 on a completed
+# connection, whereas a connect timeout means the *calling* process could not
+# complete connect() in time because it is resource starved. So the call must be
+# bounded and retried rather than left to block.
+#
+# Note botocore's AWS_METADATA_SERVICE_TIMEOUT / _NUM_ATTEMPTS do not apply here:
+# this fetch is plain urllib, not botocore, so the values have to be set
+# explicitly.
+_METADATA_TIMEOUT_SECONDS = float(
+    os.environ.get("MWAA__DB__IAM_METADATA_TIMEOUT", "5")
+)
+_METADATA_ATTEMPTS = int(os.environ.get("MWAA__DB__IAM_METADATA_ATTEMPTS", "3"))
+
+# Tokens are valid for 15 minutes; a refresh is attempted once fewer than 5
+# remain. The buffer exists so the refresh can happen off the critical path:
+# a caller is handed the still-valid cached token immediately while a
+# background thread mints the replacement.
+_TOKEN_LIFETIME_SECONDS = 15 * 60
+_TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60
+
+
+def _is_transient_metadata_error(exception):
+    """Return True for metadata failures that are worth retrying.
+
+    Retries connect/read timeouts and connection errors, plus HTTP 429 (the
+    documented TMDS throttle response) and 5xx. Deliberately does not retry
+    configuration mistakes such as a missing environment variable, or client
+    errors like 404, where retrying only delays the failure.
+    """
+    if isinstance(exception, urllib.error.HTTPError):
+        return exception.code == 429 or exception.code >= 500
+    # socket.timeout is an alias of TimeoutError on Python 3.10+.
+    return isinstance(exception, (urllib.error.URLError, TimeoutError, ConnectionError))
+
+
+_with_metadata_retry = retry(
+    stop=stop_after_attempt(_METADATA_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=1, max=4),
+    retry=retry_if_exception(_is_transient_metadata_error),
+    reraise=True,
+)
+
 
 class RDSIAMCredentialProvider:
     """Provider for RDS IAM authentication tokens with thread-safe caching."""
     _lock = threading.Lock()
+    # Single-flight guard for the background refresh: acquired without
+    # blocking by whichever caller notices the token is due, released by the
+    # refresh thread when it finishes. (threading.Lock permits releasing from
+    # a thread other than the acquirer.)
+    _refresh_lock = threading.Lock()
+    # The last background refresh thread, kept for introspection and tests.
+    _refresh_thread = None
     _token = None
     _expires_at = 0
 
     @staticmethod
+    @_with_metadata_retry
     def get_ecs_credentials():
         """
         Get AWS credentials from ECS task metadata endpoint.
-        
+
+        The request is bounded by MWAA__DB__IAM_METADATA_TIMEOUT and retried up
+        to MWAA__DB__IAM_METADATA_ATTEMPTS times on transient failures. Without
+        a timeout this call can block indefinitely, and it runs inside the
+        SQLAlchemy do_connect listener, so a hang would stall a metadata
+        database connection.
+
         Returns:
             dict: AWS credentials containing AccessKeyId, SecretAccessKey, and Token
-            
+
         Raises:
             ValueError: If required environment variables are not set
         """
@@ -50,7 +112,7 @@ class RDSIAMCredentialProvider:
         no_proxy_handler = urllib.request.ProxyHandler({})
         opener = urllib.request.build_opener(no_proxy_handler)
 
-        with opener.open(request) as response:
+        with opener.open(request, timeout=_METADATA_TIMEOUT_SECONDS) as response:
             if response.status != 200:
                 raise Exception(f"Failed to fetch ECS credentials: {response.status}")
             credentials_data = json.loads(response.read().decode('utf-8'))
@@ -127,10 +189,20 @@ class RDSIAMCredentialProvider:
     @staticmethod
     def generate_credentials():
         """
-        Generate fresh RDS auth token and store in memory
+        Generate fresh RDS auth token.
+
+        Raises on failure rather than returning None. Returning None poisoned
+        the cache: get_token() stored the None with a full 15-minute lifetime,
+        so every caller in the process was handed an unusable credential until
+        the entry aged out. Raising also lets get_token() distinguish a failed
+        refresh (fall back to the still-valid cached token) from a failed cold
+        start (surface the error).
 
         Returns:
-            str or None: RDS auth token if successful, None if generation fails
+            str: RDS auth token
+
+        Raises:
+            Exception: If credential generation fails
         """
         try:
             # Get ECS credentials from task metadata endpoint
@@ -152,44 +224,122 @@ class RDSIAMCredentialProvider:
 
         except Exception as e:
             logger.error(f"Failed to update credentials: {e}")
-            return None
+            raise
 
     @classmethod
     def get_token(cls):
         """
-        Get cached RDS IAM token, refreshing if expired or missing.
-        Uses thread-safe caching with 5-minute refresh buffer before expiration.
-        
+        Get cached RDS IAM token, refreshing if due, expired or missing.
+
+        Tokens are valid for 15 minutes and become due for refresh once fewer
+        than 5 remain. A caller holding a usable token never pays for the
+        refresh: the cached token is returned immediately and the refresh runs
+        on a background thread (see ``_start_background_refresh``). This keeps
+        the ECS metadata fetch off the connection critical path -- the fetch
+        is most likely to be slow exactly when the process is busy
+        (P481207036), which is also when connections are most frequent.
+
+        Only when nothing usable is cached -- cold start, or a token that has
+        actually expired -- is the fetch performed synchronously on the
+        calling thread. That path holds the lock across the mint, which
+        serialises concurrent callers into a single fetch (the shared
+        credential provider shape the Fargate Data Plane team recommends to
+        avoid multiplying connects to the endpoint), and is only safe to hold
+        across the network call because the call is bounded by
+        MWAA__DB__IAM_METADATA_TIMEOUT.
+
         Returns:
             str: Cached or freshly generated RDS auth token
         """
         now = time.time()
+        token = cls._token
 
-        # Refresh token in cache if missing or expires in 5 mins. 
-        if cls._token is None or now > cls._expires_at - 300:
-            with cls._lock:
-                if cls._token is None or now > cls._expires_at - 300:
-                    cls._token = cls.generate_credentials()
-                    cls._expires_at = now + 15 * 60  # 15 mins
-        
-        return cls._token
-    
-    
+        if token is not None and now < cls._expires_at:
+            # The cached token is usable. If it is due for refresh, hand the
+            # refresh to a background thread and serve the cached token
+            # immediately rather than making this caller -- typically a
+            # database connection inside the do_connect listener -- block on
+            # the fetch.
+            if now > cls._expires_at - _TOKEN_REFRESH_BUFFER_SECONDS:
+                cls._start_background_refresh()
+            return token
+
+        # Nothing usable: cold start, or the token has expired. Fetch
+        # synchronously; the double-check returns without a second fetch for
+        # the threads that queued behind the winner.
+        with cls._lock:
+            if cls._token is None or time.time() >= cls._expires_at:
+                token = cls.generate_credentials()
+                cls._token = token
+                # Timed from after the mint, not from before the lock wait,
+                # so a slow refresh cannot overstate the token's lifetime.
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            return cls._token
+
+    @classmethod
+    def _start_background_refresh(cls):
+        """
+        Refresh the token on a background thread, single-flight.
+
+        The non-blocking acquire keeps the refresh single-flight, so
+        concurrent callers noticing a due token do not multiply connects to
+        the ECS credential endpoint -- multiplying connects under contention
+        is the amplification pattern identified in P481207036.
+
+        A refresh failure is logged and the still-valid cached token stays in
+        place: tokens become due at the 10-minute mark of their 15-minute
+        lifetime precisely so a failed attempt leaves a ~5 minute window in
+        which later callers re-trigger the refresh.
+        """
+        if not cls._refresh_lock.acquire(blocking=False):
+            # A refresh is already in flight.
+            return
+
+        def _refresh():
+            try:
+                token = cls.generate_credentials()
+                cls._token = token
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            except Exception as e:
+                logger.warning(
+                    "Could not refresh the RDS IAM token in the background "
+                    "(%s); keeping the cached token, which is still valid.",
+                    e,
+                )
+            finally:
+                cls._refresh_lock.release()
+
+        try:
+            thread = threading.Thread(
+                target=_refresh, name="mwaa-rds-iam-token-refresh", daemon=True
+            )
+            cls._refresh_thread = thread
+            thread.start()
+        except Exception as e:
+            # Could not spawn the thread (e.g. resource exhaustion). Release
+            # the guard so a later caller can try again; the cached token is
+            # still valid, so this caller is unaffected.
+            cls._refresh_lock.release()
+            logger.warning("Could not start the RDS IAM token refresh thread: %s", e)
+
     @classmethod
     def create_db_connection_url(cls, token=None):
         """
         Create a PostgreSQL connection URL for RDS IAM authentication.
         
         Args:
-            token (str, optional): RDS IAM auth token. If None, generates a fresh token.
+            token (str, optional): RDS IAM auth token. If None, the cached
+                token from ``get_token()`` is used.
         
         Returns:
             str: PostgreSQL connection URL with IAM authentication
         """
         if token is None:
-            token = cls.generate_credentials()
-            if token is None:
-                raise Exception("Failed to generate RDS auth token")
+            # Route through get_token() rather than generate_credentials() so
+            # the default path reuses the thread-safe cache. Calling
+            # generate_credentials() directly would mint a new token -- an ECS
+            # metadata fetch plus a signed boto3 call -- on every connection.
+            token = cls.get_token()
 
         IAM_POSTGRES_USER = "airflow_user"
         AUTH_TOKEN = quote_plus(token)
@@ -205,3 +355,21 @@ class RDSIAMCredentialProvider:
         )
 
         return connection_url
+
+
+def _reset_locks_after_fork():
+    """
+    Recreate the provider's locks in a forked child.
+
+    Airflow forks (Celery prefork workers, DAG processors). If the parent
+    forks while a lock is held, the child inherits it locked with no thread
+    alive to release it, which would wedge every future refresh in that child.
+    The cached token itself is plain data and remains valid across the fork,
+    so only the locks are replaced.
+    """
+    RDSIAMCredentialProvider._lock = threading.Lock()
+    RDSIAMCredentialProvider._refresh_lock = threading.Lock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_locks_after_fork)

--- a/images/airflow/2.9.2/python/mwaa/utils/get_rds_iam_credentials.py
+++ b/images/airflow/2.9.2/python/mwaa/utils/get_rds_iam_credentials.py
@@ -2,30 +2,92 @@
 import json
 import logging
 import os
-import sys
 import threading
 import time
+import urllib.error
 import urllib.request
 from urllib.parse import quote_plus
 
 import boto3
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
+
+# The ECS task credential endpoint is link-local (169.254.170.2), routed inside
+# the task's own network namespace, and normally answers in milliseconds. It can
+# still fail with a connect timeout, but per the Fargate Data Plane analysis in
+# P481207036 that is not the endpoint being unhealthy or throttling: breaching
+# the TMDS limit (80 req/s steady, 120 burst) returns HTTP 429 on a completed
+# connection, whereas a connect timeout means the *calling* process could not
+# complete connect() in time because it is resource starved. So the call must be
+# bounded and retried rather than left to block.
+#
+# Note botocore's AWS_METADATA_SERVICE_TIMEOUT / _NUM_ATTEMPTS do not apply here:
+# this fetch is plain urllib, not botocore, so the values have to be set
+# explicitly.
+_METADATA_TIMEOUT_SECONDS = float(
+    os.environ.get("MWAA__DB__IAM_METADATA_TIMEOUT", "5")
+)
+_METADATA_ATTEMPTS = int(os.environ.get("MWAA__DB__IAM_METADATA_ATTEMPTS", "3"))
+
+# Tokens are valid for 15 minutes; a refresh is attempted once fewer than 5
+# remain. The buffer exists so the refresh can happen off the critical path:
+# a caller is handed the still-valid cached token immediately while a
+# background thread mints the replacement.
+_TOKEN_LIFETIME_SECONDS = 15 * 60
+_TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60
+
+
+def _is_transient_metadata_error(exception):
+    """Return True for metadata failures that are worth retrying.
+
+    Retries connect/read timeouts and connection errors, plus HTTP 429 (the
+    documented TMDS throttle response) and 5xx. Deliberately does not retry
+    configuration mistakes such as a missing environment variable, or client
+    errors like 404, where retrying only delays the failure.
+    """
+    if isinstance(exception, urllib.error.HTTPError):
+        return exception.code == 429 or exception.code >= 500
+    # socket.timeout is an alias of TimeoutError on Python 3.10+.
+    return isinstance(exception, (urllib.error.URLError, TimeoutError, ConnectionError))
+
+
+_with_metadata_retry = retry(
+    stop=stop_after_attempt(_METADATA_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=1, max=4),
+    retry=retry_if_exception(_is_transient_metadata_error),
+    reraise=True,
+)
+
 
 class RDSIAMCredentialProvider:
     """Provider for RDS IAM authentication tokens with thread-safe caching."""
     _lock = threading.Lock()
+    # Single-flight guard for the background refresh: acquired without
+    # blocking by whichever caller notices the token is due, released by the
+    # refresh thread when it finishes. (threading.Lock permits releasing from
+    # a thread other than the acquirer.)
+    _refresh_lock = threading.Lock()
+    # The last background refresh thread, kept for introspection and tests.
+    _refresh_thread = None
     _token = None
     _expires_at = 0
 
     @staticmethod
+    @_with_metadata_retry
     def get_ecs_credentials():
         """
         Get AWS credentials from ECS task metadata endpoint.
-        
+
+        The request is bounded by MWAA__DB__IAM_METADATA_TIMEOUT and retried up
+        to MWAA__DB__IAM_METADATA_ATTEMPTS times on transient failures. Without
+        a timeout this call can block indefinitely, and it runs inside the
+        SQLAlchemy do_connect listener, so a hang would stall a metadata
+        database connection.
+
         Returns:
             dict: AWS credentials containing AccessKeyId, SecretAccessKey, and Token
-            
+
         Raises:
             ValueError: If required environment variables are not set
         """
@@ -50,7 +112,7 @@ class RDSIAMCredentialProvider:
         no_proxy_handler = urllib.request.ProxyHandler({})
         opener = urllib.request.build_opener(no_proxy_handler)
 
-        with opener.open(request) as response:
+        with opener.open(request, timeout=_METADATA_TIMEOUT_SECONDS) as response:
             if response.status != 200:
                 raise Exception(f"Failed to fetch ECS credentials: {response.status}")
             credentials_data = json.loads(response.read().decode('utf-8'))
@@ -127,10 +189,20 @@ class RDSIAMCredentialProvider:
     @staticmethod
     def generate_credentials():
         """
-        Generate fresh RDS auth token and store in memory
+        Generate fresh RDS auth token.
+
+        Raises on failure rather than returning None. Returning None poisoned
+        the cache: get_token() stored the None with a full 15-minute lifetime,
+        so every caller in the process was handed an unusable credential until
+        the entry aged out. Raising also lets get_token() distinguish a failed
+        refresh (fall back to the still-valid cached token) from a failed cold
+        start (surface the error).
 
         Returns:
-            str or None: RDS auth token if successful, None if generation fails
+            str: RDS auth token
+
+        Raises:
+            Exception: If credential generation fails
         """
         try:
             # Get ECS credentials from task metadata endpoint
@@ -152,44 +224,122 @@ class RDSIAMCredentialProvider:
 
         except Exception as e:
             logger.error(f"Failed to update credentials: {e}")
-            return None
+            raise
 
     @classmethod
     def get_token(cls):
         """
-        Get cached RDS IAM token, refreshing if expired or missing.
-        Uses thread-safe caching with 5-minute refresh buffer before expiration.
-        
+        Get cached RDS IAM token, refreshing if due, expired or missing.
+
+        Tokens are valid for 15 minutes and become due for refresh once fewer
+        than 5 remain. A caller holding a usable token never pays for the
+        refresh: the cached token is returned immediately and the refresh runs
+        on a background thread (see ``_start_background_refresh``). This keeps
+        the ECS metadata fetch off the connection critical path -- the fetch
+        is most likely to be slow exactly when the process is busy
+        (P481207036), which is also when connections are most frequent.
+
+        Only when nothing usable is cached -- cold start, or a token that has
+        actually expired -- is the fetch performed synchronously on the
+        calling thread. That path holds the lock across the mint, which
+        serialises concurrent callers into a single fetch (the shared
+        credential provider shape the Fargate Data Plane team recommends to
+        avoid multiplying connects to the endpoint), and is only safe to hold
+        across the network call because the call is bounded by
+        MWAA__DB__IAM_METADATA_TIMEOUT.
+
         Returns:
             str: Cached or freshly generated RDS auth token
         """
         now = time.time()
+        token = cls._token
 
-        # Refresh token in cache if missing or expires in 5 mins. 
-        if cls._token is None or now > cls._expires_at - 300:
-            with cls._lock:
-                if cls._token is None or now > cls._expires_at - 300:
-                    cls._token = cls.generate_credentials()
-                    cls._expires_at = now + 15 * 60  # 15 mins
-        
-        return cls._token
-    
-    
+        if token is not None and now < cls._expires_at:
+            # The cached token is usable. If it is due for refresh, hand the
+            # refresh to a background thread and serve the cached token
+            # immediately rather than making this caller -- typically a
+            # database connection inside the do_connect listener -- block on
+            # the fetch.
+            if now > cls._expires_at - _TOKEN_REFRESH_BUFFER_SECONDS:
+                cls._start_background_refresh()
+            return token
+
+        # Nothing usable: cold start, or the token has expired. Fetch
+        # synchronously; the double-check returns without a second fetch for
+        # the threads that queued behind the winner.
+        with cls._lock:
+            if cls._token is None or time.time() >= cls._expires_at:
+                token = cls.generate_credentials()
+                cls._token = token
+                # Timed from after the mint, not from before the lock wait,
+                # so a slow refresh cannot overstate the token's lifetime.
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            return cls._token
+
+    @classmethod
+    def _start_background_refresh(cls):
+        """
+        Refresh the token on a background thread, single-flight.
+
+        The non-blocking acquire keeps the refresh single-flight, so
+        concurrent callers noticing a due token do not multiply connects to
+        the ECS credential endpoint -- multiplying connects under contention
+        is the amplification pattern identified in P481207036.
+
+        A refresh failure is logged and the still-valid cached token stays in
+        place: tokens become due at the 10-minute mark of their 15-minute
+        lifetime precisely so a failed attempt leaves a ~5 minute window in
+        which later callers re-trigger the refresh.
+        """
+        if not cls._refresh_lock.acquire(blocking=False):
+            # A refresh is already in flight.
+            return
+
+        def _refresh():
+            try:
+                token = cls.generate_credentials()
+                cls._token = token
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            except Exception as e:
+                logger.warning(
+                    "Could not refresh the RDS IAM token in the background "
+                    "(%s); keeping the cached token, which is still valid.",
+                    e,
+                )
+            finally:
+                cls._refresh_lock.release()
+
+        try:
+            thread = threading.Thread(
+                target=_refresh, name="mwaa-rds-iam-token-refresh", daemon=True
+            )
+            cls._refresh_thread = thread
+            thread.start()
+        except Exception as e:
+            # Could not spawn the thread (e.g. resource exhaustion). Release
+            # the guard so a later caller can try again; the cached token is
+            # still valid, so this caller is unaffected.
+            cls._refresh_lock.release()
+            logger.warning("Could not start the RDS IAM token refresh thread: %s", e)
+
     @classmethod
     def create_db_connection_url(cls, token=None):
         """
         Create a PostgreSQL connection URL for RDS IAM authentication.
         
         Args:
-            token (str, optional): RDS IAM auth token. If None, generates a fresh token.
+            token (str, optional): RDS IAM auth token. If None, the cached
+                token from ``get_token()`` is used.
         
         Returns:
             str: PostgreSQL connection URL with IAM authentication
         """
         if token is None:
-            token = cls.generate_credentials()
-            if token is None:
-                raise Exception("Failed to generate RDS auth token")
+            # Route through get_token() rather than generate_credentials() so
+            # the default path reuses the thread-safe cache. Calling
+            # generate_credentials() directly would mint a new token -- an ECS
+            # metadata fetch plus a signed boto3 call -- on every connection.
+            token = cls.get_token()
 
         IAM_POSTGRES_USER = "airflow_user"
         AUTH_TOKEN = quote_plus(token)
@@ -205,3 +355,21 @@ class RDSIAMCredentialProvider:
         )
 
         return connection_url
+
+
+def _reset_locks_after_fork():
+    """
+    Recreate the provider's locks in a forked child.
+
+    Airflow forks (Celery prefork workers, DAG processors). If the parent
+    forks while a lock is held, the child inherits it locked with no thread
+    alive to release it, which would wedge every future refresh in that child.
+    The cached token itself is plain data and remains valid across the fork,
+    so only the locks are replaced.
+    """
+    RDSIAMCredentialProvider._lock = threading.Lock()
+    RDSIAMCredentialProvider._refresh_lock = threading.Lock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_locks_after_fork)

--- a/images/airflow/3.0.6/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.0.6/python/mwaa/config/rds_iam_credentials.py
@@ -20,6 +20,13 @@ logger = logging.getLogger(__name__)
 
 DB_IAM_USERNAME = "airflow_user"
 
+# Tokens are valid for 15 minutes; a refresh is attempted once fewer than 5
+# remain. The buffer exists so the refresh can happen off the critical path:
+# a caller is handed the still-valid cached token immediately while a
+# background thread mints the replacement.
+_TOKEN_LIFETIME_SECONDS = 15 * 60
+_TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60
+
 # The ECS task credential endpoint is link-local (169.254.170.2), routed inside
 # the task's own network namespace, and normally answers in milliseconds. It can
 # still fail with a connect timeout, but per the Fargate Data Plane analysis in
@@ -68,6 +75,13 @@ class RDSIAMCredentialProvider:
     """
 
     _lock = threading.Lock()
+    # Single-flight guard for the background refresh: acquired without
+    # blocking by whichever caller notices the token is due, released by the
+    # refresh thread when it finishes. (threading.Lock permits releasing from
+    # a thread other than the acquirer.)
+    _refresh_lock = threading.Lock()
+    # The last background refresh thread, kept for introspection and tests.
+    _refresh_thread: threading.Thread | None = None
     _token: str | None = None
     _expires_at: float = 0
 
@@ -185,47 +199,96 @@ class RDSIAMCredentialProvider:
 
     @classmethod
     def get_token(cls) -> str:
-        """Get cached RDS IAM token, refreshing if expired or missing.
+        """Get cached RDS IAM token, refreshing if due, expired or missing.
 
-        Tokens are valid for 15 minutes and refreshed at the 10-minute mark, so
-        a refresh failure still leaves roughly 5 minutes of usable token. In
-        that window the cached token is reused rather than failing the caller:
-        the endpoint this refresh depends on times out under process contention
-        (P481207036), and a transient blip should not break a metadata database
-        connection.
+        Tokens are valid for 15 minutes and become due for refresh once fewer
+        than 5 remain. A caller holding a usable token never pays for the
+        refresh: the cached token is returned immediately and the refresh runs
+        on a background thread (see ``_start_background_refresh``). This keeps
+        the ECS metadata fetch off the connection critical path -- the fetch
+        is most likely to be slow exactly when the process is busy
+        (P481207036), which is also when connections are most frequent.
 
-        The refresh is deliberately performed while holding the lock. That
-        serialises concurrent refreshes into a single fetch, which is the
-        "shared credential provider" shape the Fargate Data Plane team
-        recommends to avoid multiplying connects to the endpoint. It is only
-        safe to hold the lock across the network call because that call is now
-        bounded by MWAA__DB__IAM_METADATA_TIMEOUT.
+        Only when nothing usable is cached -- cold start, or a token that has
+        actually expired -- is the fetch performed synchronously on the
+        calling thread. That path holds the lock across the mint, which
+        serialises concurrent callers into a single fetch (the shared
+        credential provider shape the Fargate Data Plane team recommends to
+        avoid multiplying connects to the endpoint), and is only safe to hold
+        across the network call because the call is bounded by
+        MWAA__DB__IAM_METADATA_TIMEOUT.
 
         :returns: Cached or freshly generated RDS auth token.
         """
         now = time.time()
+        token = cls._token
 
-        # Refresh token in cache if missing or expires in 5 mins.
-        if cls._token is None or now > cls._expires_at - 300:
-            with cls._lock:
-                if cls._token is None or now > cls._expires_at - 300:
-                    try:
-                        token = cls.generate_credentials()
-                    except Exception as e:
-                        if cls._token is not None and time.time() < cls._expires_at:
-                            logger.warning(
-                                "Could not refresh the RDS IAM token (%s); reusing "
-                                "the cached token, which is still valid.",
-                                e,
-                            )
-                            return cls._token
-                        raise
-                    cls._token = token
-                    # Timed from after the mint, not from before the lock wait,
-                    # so a slow refresh cannot overstate the token's lifetime.
-                    cls._expires_at = time.time() + 15 * 60  # 15 mins
+        if token is not None and now < cls._expires_at:
+            # The cached token is usable. If it is due for refresh, hand the
+            # refresh to a background thread and serve the cached token
+            # immediately rather than making this caller -- typically a
+            # database connection inside the do_connect listener -- block on
+            # the fetch.
+            if now > cls._expires_at - _TOKEN_REFRESH_BUFFER_SECONDS:
+                cls._start_background_refresh()
+            return token
 
-        return cls._token
+        # Nothing usable: cold start, or the token has expired. Fetch
+        # synchronously; the double-check returns without a second fetch for
+        # the threads that queued behind the winner.
+        with cls._lock:
+            if cls._token is None or time.time() >= cls._expires_at:
+                token = cls.generate_credentials()
+                cls._token = token
+                # Timed from after the mint, not from before the lock wait,
+                # so a slow refresh cannot overstate the token's lifetime.
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            return cls._token
+
+    @classmethod
+    def _start_background_refresh(cls) -> None:
+        """Refresh the token on a background thread, single-flight.
+
+        The non-blocking acquire keeps the refresh single-flight, so
+        concurrent callers noticing a due token do not multiply connects to
+        the ECS credential endpoint -- multiplying connects under contention
+        is the amplification pattern identified in P481207036.
+
+        A refresh failure is logged and the still-valid cached token stays in
+        place: tokens become due at the 10-minute mark of their 15-minute
+        lifetime precisely so a failed attempt leaves a ~5 minute window in
+        which later callers re-trigger the refresh.
+        """
+        if not cls._refresh_lock.acquire(blocking=False):
+            # A refresh is already in flight.
+            return
+
+        def _refresh() -> None:
+            try:
+                token = cls.generate_credentials()
+                cls._token = token
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            except Exception as e:
+                logger.warning(
+                    "Could not refresh the RDS IAM token in the background "
+                    "(%s); keeping the cached token, which is still valid.",
+                    e,
+                )
+            finally:
+                cls._refresh_lock.release()
+
+        try:
+            thread = threading.Thread(
+                target=_refresh, name="mwaa-rds-iam-token-refresh", daemon=True
+            )
+            cls._refresh_thread = thread
+            thread.start()
+        except Exception as e:
+            # Could not spawn the thread (e.g. resource exhaustion). Release
+            # the guard so a later caller can try again; the cached token is
+            # still valid, so this caller is unaffected.
+            cls._refresh_lock.release()
+            logger.warning("Could not start the RDS IAM token refresh thread: %s", e)
 
     @classmethod
     def create_db_connection_url(cls, token: str | None = None) -> str:
@@ -282,3 +345,20 @@ def is_using_rds_proxy() -> bool:
         logger.warning("MWAA__DB__POSTGRES_SSLMODE not set in environment.")
         return False
     return ssl_mode == "require"
+
+
+def _reset_locks_after_fork() -> None:
+    """Recreate the provider's locks in a forked child.
+
+    Airflow forks (Celery prefork workers, DAG processors). If the parent
+    forks while a lock is held, the child inherits it locked with no thread
+    alive to release it, which would wedge every future refresh in that child.
+    The cached token itself is plain data and remains valid across the fork,
+    so only the locks are replaced.
+    """
+    RDSIAMCredentialProvider._lock = threading.Lock()
+    RDSIAMCredentialProvider._refresh_lock = threading.Lock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_locks_after_fork)

--- a/images/airflow/3.0.6/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.0.6/python/mwaa/config/rds_iam_credentials.py
@@ -9,14 +9,55 @@ import logging
 import os
 import threading
 import time
+import urllib.error
 import urllib.request
 from urllib.parse import quote_plus, urlparse
 
 import boto3
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
 
 DB_IAM_USERNAME = "airflow_user"
+
+# The ECS task credential endpoint is link-local (169.254.170.2), routed inside
+# the task's own network namespace, and normally answers in milliseconds. It can
+# still fail with a connect timeout, but per the Fargate Data Plane analysis in
+# P481207036 that is not the endpoint being unhealthy or throttling: breaching
+# the TMDS limit (80 req/s steady, 120 burst) returns HTTP 429 on a completed
+# connection, whereas a connect timeout means the *calling* process could not
+# complete connect() in time because it is resource starved. So the call must be
+# bounded and retried rather than left to block.
+#
+# Note botocore's AWS_METADATA_SERVICE_TIMEOUT / _NUM_ATTEMPTS do not apply here:
+# this fetch is plain urllib, not botocore, so the values have to be set
+# explicitly.
+_METADATA_TIMEOUT_SECONDS = float(
+    os.environ.get("MWAA__DB__IAM_METADATA_TIMEOUT", "5")
+)
+_METADATA_ATTEMPTS = int(os.environ.get("MWAA__DB__IAM_METADATA_ATTEMPTS", "3"))
+
+
+def _is_transient_metadata_error(exception: BaseException) -> bool:
+    """Return True for metadata failures that are worth retrying.
+
+    Retries connect/read timeouts and connection errors, plus HTTP 429 (the
+    documented TMDS throttle response) and 5xx. Deliberately does not retry
+    configuration mistakes such as a missing environment variable, or client
+    errors like 404, where retrying only delays the failure.
+    """
+    if isinstance(exception, urllib.error.HTTPError):
+        return exception.code == 429 or exception.code >= 500
+    # socket.timeout is an alias of TimeoutError on Python 3.10+.
+    return isinstance(exception, (urllib.error.URLError, TimeoutError, ConnectionError))
+
+
+_with_metadata_retry = retry(
+    stop=stop_after_attempt(_METADATA_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=1, max=4),
+    retry=retry_if_exception(_is_transient_metadata_error),
+    reraise=True,
+)
 
 
 class RDSIAMCredentialProvider:
@@ -31,11 +72,18 @@ class RDSIAMCredentialProvider:
     _expires_at: float = 0
 
     @staticmethod
+    @_with_metadata_retry
     def get_ecs_credentials() -> dict:
         """Get AWS credentials from ECS task metadata endpoint.
 
         Uses AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI for the credential path
         and ECS_CONTAINER_METADATA_URI for the base URL.
+
+        The request is bounded by MWAA__DB__IAM_METADATA_TIMEOUT and retried up
+        to MWAA__DB__IAM_METADATA_ATTEMPTS times on transient failures. Without
+        a timeout this call can block indefinitely, and it runs inside the
+        SQLAlchemy do_connect listener, so a hang would stall a metadata
+        database connection.
 
         :returns: AWS credentials dict with AccessKeyId, SecretAccessKey, Token.
         :raises ValueError: If required environment variables are not set.
@@ -56,7 +104,7 @@ class RDSIAMCredentialProvider:
         no_proxy_handler = urllib.request.ProxyHandler({})
         opener = urllib.request.build_opener(no_proxy_handler)
 
-        with opener.open(request) as response:
+        with opener.open(request, timeout=_METADATA_TIMEOUT_SECONDS) as response:
             credentials_data = json.loads(response.read().decode("utf-8"))
 
         return credentials_data
@@ -139,8 +187,19 @@ class RDSIAMCredentialProvider:
     def get_token(cls) -> str:
         """Get cached RDS IAM token, refreshing if expired or missing.
 
-        Uses thread-safe caching with 5-minute refresh buffer before
-        the 15-minute token expiration.
+        Tokens are valid for 15 minutes and refreshed at the 10-minute mark, so
+        a refresh failure still leaves roughly 5 minutes of usable token. In
+        that window the cached token is reused rather than failing the caller:
+        the endpoint this refresh depends on times out under process contention
+        (P481207036), and a transient blip should not break a metadata database
+        connection.
+
+        The refresh is deliberately performed while holding the lock. That
+        serialises concurrent refreshes into a single fetch, which is the
+        "shared credential provider" shape the Fargate Data Plane team
+        recommends to avoid multiplying connects to the endpoint. It is only
+        safe to hold the lock across the network call because that call is now
+        bounded by MWAA__DB__IAM_METADATA_TIMEOUT.
 
         :returns: Cached or freshly generated RDS auth token.
         """
@@ -150,8 +209,21 @@ class RDSIAMCredentialProvider:
         if cls._token is None or now > cls._expires_at - 300:
             with cls._lock:
                 if cls._token is None or now > cls._expires_at - 300:
-                    cls._token = cls.generate_credentials()
-                    cls._expires_at = now + 15 * 60  # 15 mins
+                    try:
+                        token = cls.generate_credentials()
+                    except Exception as e:
+                        if cls._token is not None and time.time() < cls._expires_at:
+                            logger.warning(
+                                "Could not refresh the RDS IAM token (%s); reusing "
+                                "the cached token, which is still valid.",
+                                e,
+                            )
+                            return cls._token
+                        raise
+                    cls._token = token
+                    # Timed from after the mint, not from before the lock wait,
+                    # so a slow refresh cannot overstate the token's lifetime.
+                    cls._expires_at = time.time() + 15 * 60  # 15 mins
 
         return cls._token
 

--- a/images/airflow/3.0.6/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.0.6/python/mwaa/config/rds_iam_credentials.py
@@ -231,14 +231,16 @@ class RDSIAMCredentialProvider:
     def create_db_connection_url(cls, token: str | None = None) -> str:
         """Create a PostgreSQL connection URL for RDS IAM authentication.
 
-        :param token: RDS IAM auth token. If None, generates a fresh token.
+        :param token: RDS IAM auth token. If None, the cached token from
+            ``get_token()`` is used.
         :returns: PostgreSQL connection URL with IAM authentication.
         """
         if token is None:
-            # NOTE: bypasses the get_token() cache, matching 2.x. No caller uses
-            # this default path today; the cache bypass is tracked for a
-            # cross-version follow-up rather than diverging from 2.x here.
-            token = cls.generate_credentials()
+            # Route through get_token() rather than generate_credentials() so
+            # the default path reuses the thread-safe cache. Calling
+            # generate_credentials() directly would mint a new token -- an ECS
+            # metadata fetch plus a signed boto3 call -- on every connection.
+            token = cls.get_token()
 
         auth_token = quote_plus(token)
         postgres_host = os.environ.get("MWAA__DB__POSTGRES_HOST", "localhost")

--- a/images/airflow/3.2.1/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.2.1/python/mwaa/config/rds_iam_credentials.py
@@ -20,6 +20,13 @@ logger = logging.getLogger(__name__)
 
 DB_IAM_USERNAME = "airflow_user"
 
+# Tokens are valid for 15 minutes; a refresh is attempted once fewer than 5
+# remain. The buffer exists so the refresh can happen off the critical path:
+# a caller is handed the still-valid cached token immediately while a
+# background thread mints the replacement.
+_TOKEN_LIFETIME_SECONDS = 15 * 60
+_TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60
+
 # The ECS task credential endpoint is link-local (169.254.170.2), routed inside
 # the task's own network namespace, and normally answers in milliseconds. It can
 # still fail with a connect timeout, but per the Fargate Data Plane analysis in
@@ -68,6 +75,13 @@ class RDSIAMCredentialProvider:
     """
 
     _lock = threading.Lock()
+    # Single-flight guard for the background refresh: acquired without
+    # blocking by whichever caller notices the token is due, released by the
+    # refresh thread when it finishes. (threading.Lock permits releasing from
+    # a thread other than the acquirer.)
+    _refresh_lock = threading.Lock()
+    # The last background refresh thread, kept for introspection and tests.
+    _refresh_thread: threading.Thread | None = None
     _token: str | None = None
     _expires_at: float = 0
 
@@ -185,47 +199,96 @@ class RDSIAMCredentialProvider:
 
     @classmethod
     def get_token(cls) -> str:
-        """Get cached RDS IAM token, refreshing if expired or missing.
+        """Get cached RDS IAM token, refreshing if due, expired or missing.
 
-        Tokens are valid for 15 minutes and refreshed at the 10-minute mark, so
-        a refresh failure still leaves roughly 5 minutes of usable token. In
-        that window the cached token is reused rather than failing the caller:
-        the endpoint this refresh depends on times out under process contention
-        (P481207036), and a transient blip should not break a metadata database
-        connection.
+        Tokens are valid for 15 minutes and become due for refresh once fewer
+        than 5 remain. A caller holding a usable token never pays for the
+        refresh: the cached token is returned immediately and the refresh runs
+        on a background thread (see ``_start_background_refresh``). This keeps
+        the ECS metadata fetch off the connection critical path -- the fetch
+        is most likely to be slow exactly when the process is busy
+        (P481207036), which is also when connections are most frequent.
 
-        The refresh is deliberately performed while holding the lock. That
-        serialises concurrent refreshes into a single fetch, which is the
-        "shared credential provider" shape the Fargate Data Plane team
-        recommends to avoid multiplying connects to the endpoint. It is only
-        safe to hold the lock across the network call because that call is now
-        bounded by MWAA__DB__IAM_METADATA_TIMEOUT.
+        Only when nothing usable is cached -- cold start, or a token that has
+        actually expired -- is the fetch performed synchronously on the
+        calling thread. That path holds the lock across the mint, which
+        serialises concurrent callers into a single fetch (the shared
+        credential provider shape the Fargate Data Plane team recommends to
+        avoid multiplying connects to the endpoint), and is only safe to hold
+        across the network call because the call is bounded by
+        MWAA__DB__IAM_METADATA_TIMEOUT.
 
         :returns: Cached or freshly generated RDS auth token.
         """
         now = time.time()
+        token = cls._token
 
-        # Refresh token in cache if missing or expires in 5 mins.
-        if cls._token is None or now > cls._expires_at - 300:
-            with cls._lock:
-                if cls._token is None or now > cls._expires_at - 300:
-                    try:
-                        token = cls.generate_credentials()
-                    except Exception as e:
-                        if cls._token is not None and time.time() < cls._expires_at:
-                            logger.warning(
-                                "Could not refresh the RDS IAM token (%s); reusing "
-                                "the cached token, which is still valid.",
-                                e,
-                            )
-                            return cls._token
-                        raise
-                    cls._token = token
-                    # Timed from after the mint, not from before the lock wait,
-                    # so a slow refresh cannot overstate the token's lifetime.
-                    cls._expires_at = time.time() + 15 * 60  # 15 mins
+        if token is not None and now < cls._expires_at:
+            # The cached token is usable. If it is due for refresh, hand the
+            # refresh to a background thread and serve the cached token
+            # immediately rather than making this caller -- typically a
+            # database connection inside the do_connect listener -- block on
+            # the fetch.
+            if now > cls._expires_at - _TOKEN_REFRESH_BUFFER_SECONDS:
+                cls._start_background_refresh()
+            return token
 
-        return cls._token
+        # Nothing usable: cold start, or the token has expired. Fetch
+        # synchronously; the double-check returns without a second fetch for
+        # the threads that queued behind the winner.
+        with cls._lock:
+            if cls._token is None or time.time() >= cls._expires_at:
+                token = cls.generate_credentials()
+                cls._token = token
+                # Timed from after the mint, not from before the lock wait,
+                # so a slow refresh cannot overstate the token's lifetime.
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            return cls._token
+
+    @classmethod
+    def _start_background_refresh(cls) -> None:
+        """Refresh the token on a background thread, single-flight.
+
+        The non-blocking acquire keeps the refresh single-flight, so
+        concurrent callers noticing a due token do not multiply connects to
+        the ECS credential endpoint -- multiplying connects under contention
+        is the amplification pattern identified in P481207036.
+
+        A refresh failure is logged and the still-valid cached token stays in
+        place: tokens become due at the 10-minute mark of their 15-minute
+        lifetime precisely so a failed attempt leaves a ~5 minute window in
+        which later callers re-trigger the refresh.
+        """
+        if not cls._refresh_lock.acquire(blocking=False):
+            # A refresh is already in flight.
+            return
+
+        def _refresh() -> None:
+            try:
+                token = cls.generate_credentials()
+                cls._token = token
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            except Exception as e:
+                logger.warning(
+                    "Could not refresh the RDS IAM token in the background "
+                    "(%s); keeping the cached token, which is still valid.",
+                    e,
+                )
+            finally:
+                cls._refresh_lock.release()
+
+        try:
+            thread = threading.Thread(
+                target=_refresh, name="mwaa-rds-iam-token-refresh", daemon=True
+            )
+            cls._refresh_thread = thread
+            thread.start()
+        except Exception as e:
+            # Could not spawn the thread (e.g. resource exhaustion). Release
+            # the guard so a later caller can try again; the cached token is
+            # still valid, so this caller is unaffected.
+            cls._refresh_lock.release()
+            logger.warning("Could not start the RDS IAM token refresh thread: %s", e)
 
     @classmethod
     def create_db_connection_url(cls, token: str | None = None) -> str:
@@ -282,3 +345,20 @@ def is_using_rds_proxy() -> bool:
         logger.warning("MWAA__DB__POSTGRES_SSLMODE not set in environment.")
         return False
     return ssl_mode == "require"
+
+
+def _reset_locks_after_fork() -> None:
+    """Recreate the provider's locks in a forked child.
+
+    Airflow forks (Celery prefork workers, DAG processors). If the parent
+    forks while a lock is held, the child inherits it locked with no thread
+    alive to release it, which would wedge every future refresh in that child.
+    The cached token itself is plain data and remains valid across the fork,
+    so only the locks are replaced.
+    """
+    RDSIAMCredentialProvider._lock = threading.Lock()
+    RDSIAMCredentialProvider._refresh_lock = threading.Lock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_locks_after_fork)

--- a/images/airflow/3.2.1/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.2.1/python/mwaa/config/rds_iam_credentials.py
@@ -9,14 +9,55 @@ import logging
 import os
 import threading
 import time
+import urllib.error
 import urllib.request
 from urllib.parse import quote_plus, urlparse
 
 import boto3
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
 
 DB_IAM_USERNAME = "airflow_user"
+
+# The ECS task credential endpoint is link-local (169.254.170.2), routed inside
+# the task's own network namespace, and normally answers in milliseconds. It can
+# still fail with a connect timeout, but per the Fargate Data Plane analysis in
+# P481207036 that is not the endpoint being unhealthy or throttling: breaching
+# the TMDS limit (80 req/s steady, 120 burst) returns HTTP 429 on a completed
+# connection, whereas a connect timeout means the *calling* process could not
+# complete connect() in time because it is resource starved. So the call must be
+# bounded and retried rather than left to block.
+#
+# Note botocore's AWS_METADATA_SERVICE_TIMEOUT / _NUM_ATTEMPTS do not apply here:
+# this fetch is plain urllib, not botocore, so the values have to be set
+# explicitly.
+_METADATA_TIMEOUT_SECONDS = float(
+    os.environ.get("MWAA__DB__IAM_METADATA_TIMEOUT", "5")
+)
+_METADATA_ATTEMPTS = int(os.environ.get("MWAA__DB__IAM_METADATA_ATTEMPTS", "3"))
+
+
+def _is_transient_metadata_error(exception: BaseException) -> bool:
+    """Return True for metadata failures that are worth retrying.
+
+    Retries connect/read timeouts and connection errors, plus HTTP 429 (the
+    documented TMDS throttle response) and 5xx. Deliberately does not retry
+    configuration mistakes such as a missing environment variable, or client
+    errors like 404, where retrying only delays the failure.
+    """
+    if isinstance(exception, urllib.error.HTTPError):
+        return exception.code == 429 or exception.code >= 500
+    # socket.timeout is an alias of TimeoutError on Python 3.10+.
+    return isinstance(exception, (urllib.error.URLError, TimeoutError, ConnectionError))
+
+
+_with_metadata_retry = retry(
+    stop=stop_after_attempt(_METADATA_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=1, max=4),
+    retry=retry_if_exception(_is_transient_metadata_error),
+    reraise=True,
+)
 
 
 class RDSIAMCredentialProvider:
@@ -31,11 +72,18 @@ class RDSIAMCredentialProvider:
     _expires_at: float = 0
 
     @staticmethod
+    @_with_metadata_retry
     def get_ecs_credentials() -> dict:
         """Get AWS credentials from ECS task metadata endpoint.
 
         Uses AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI for the credential path
         and ECS_CONTAINER_METADATA_URI for the base URL.
+
+        The request is bounded by MWAA__DB__IAM_METADATA_TIMEOUT and retried up
+        to MWAA__DB__IAM_METADATA_ATTEMPTS times on transient failures. Without
+        a timeout this call can block indefinitely, and it runs inside the
+        SQLAlchemy do_connect listener, so a hang would stall a metadata
+        database connection.
 
         :returns: AWS credentials dict with AccessKeyId, SecretAccessKey, Token.
         :raises ValueError: If required environment variables are not set.
@@ -56,7 +104,7 @@ class RDSIAMCredentialProvider:
         no_proxy_handler = urllib.request.ProxyHandler({})
         opener = urllib.request.build_opener(no_proxy_handler)
 
-        with opener.open(request) as response:
+        with opener.open(request, timeout=_METADATA_TIMEOUT_SECONDS) as response:
             credentials_data = json.loads(response.read().decode("utf-8"))
 
         return credentials_data
@@ -139,8 +187,19 @@ class RDSIAMCredentialProvider:
     def get_token(cls) -> str:
         """Get cached RDS IAM token, refreshing if expired or missing.
 
-        Uses thread-safe caching with 5-minute refresh buffer before
-        the 15-minute token expiration.
+        Tokens are valid for 15 minutes and refreshed at the 10-minute mark, so
+        a refresh failure still leaves roughly 5 minutes of usable token. In
+        that window the cached token is reused rather than failing the caller:
+        the endpoint this refresh depends on times out under process contention
+        (P481207036), and a transient blip should not break a metadata database
+        connection.
+
+        The refresh is deliberately performed while holding the lock. That
+        serialises concurrent refreshes into a single fetch, which is the
+        "shared credential provider" shape the Fargate Data Plane team
+        recommends to avoid multiplying connects to the endpoint. It is only
+        safe to hold the lock across the network call because that call is now
+        bounded by MWAA__DB__IAM_METADATA_TIMEOUT.
 
         :returns: Cached or freshly generated RDS auth token.
         """
@@ -150,8 +209,21 @@ class RDSIAMCredentialProvider:
         if cls._token is None or now > cls._expires_at - 300:
             with cls._lock:
                 if cls._token is None or now > cls._expires_at - 300:
-                    cls._token = cls.generate_credentials()
-                    cls._expires_at = now + 15 * 60  # 15 mins
+                    try:
+                        token = cls.generate_credentials()
+                    except Exception as e:
+                        if cls._token is not None and time.time() < cls._expires_at:
+                            logger.warning(
+                                "Could not refresh the RDS IAM token (%s); reusing "
+                                "the cached token, which is still valid.",
+                                e,
+                            )
+                            return cls._token
+                        raise
+                    cls._token = token
+                    # Timed from after the mint, not from before the lock wait,
+                    # so a slow refresh cannot overstate the token's lifetime.
+                    cls._expires_at = time.time() + 15 * 60  # 15 mins
 
         return cls._token
 

--- a/images/airflow/3.2.1/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.2.1/python/mwaa/config/rds_iam_credentials.py
@@ -231,14 +231,16 @@ class RDSIAMCredentialProvider:
     def create_db_connection_url(cls, token: str | None = None) -> str:
         """Create a PostgreSQL connection URL for RDS IAM authentication.
 
-        :param token: RDS IAM auth token. If None, generates a fresh token.
+        :param token: RDS IAM auth token. If None, the cached token from
+            ``get_token()`` is used.
         :returns: PostgreSQL connection URL with IAM authentication.
         """
         if token is None:
-            # NOTE: bypasses the get_token() cache, matching 2.x. No caller uses
-            # this default path today; the cache bypass is tracked for a
-            # cross-version follow-up rather than diverging from 2.x here.
-            token = cls.generate_credentials()
+            # Route through get_token() rather than generate_credentials() so
+            # the default path reuses the thread-safe cache. Calling
+            # generate_credentials() directly would mint a new token -- an ECS
+            # metadata fetch plus a signed boto3 call -- on every connection.
+            token = cls.get_token()
 
         auth_token = quote_plus(token)
         postgres_host = os.environ.get("MWAA__DB__POSTGRES_HOST", "localhost")

--- a/images/airflow/3.3.0/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.3.0/python/mwaa/config/rds_iam_credentials.py
@@ -20,6 +20,13 @@ logger = logging.getLogger(__name__)
 
 DB_IAM_USERNAME = "airflow_user"
 
+# Tokens are valid for 15 minutes; a refresh is attempted once fewer than 5
+# remain. The buffer exists so the refresh can happen off the critical path:
+# a caller is handed the still-valid cached token immediately while a
+# background thread mints the replacement.
+_TOKEN_LIFETIME_SECONDS = 15 * 60
+_TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60
+
 # The ECS task credential endpoint is link-local (169.254.170.2), routed inside
 # the task's own network namespace, and normally answers in milliseconds. It can
 # still fail with a connect timeout, but per the Fargate Data Plane analysis in
@@ -68,6 +75,13 @@ class RDSIAMCredentialProvider:
     """
 
     _lock = threading.Lock()
+    # Single-flight guard for the background refresh: acquired without
+    # blocking by whichever caller notices the token is due, released by the
+    # refresh thread when it finishes. (threading.Lock permits releasing from
+    # a thread other than the acquirer.)
+    _refresh_lock = threading.Lock()
+    # The last background refresh thread, kept for introspection and tests.
+    _refresh_thread: threading.Thread | None = None
     _token: str | None = None
     _expires_at: float = 0
 
@@ -185,47 +199,96 @@ class RDSIAMCredentialProvider:
 
     @classmethod
     def get_token(cls) -> str:
-        """Get cached RDS IAM token, refreshing if expired or missing.
+        """Get cached RDS IAM token, refreshing if due, expired or missing.
 
-        Tokens are valid for 15 minutes and refreshed at the 10-minute mark, so
-        a refresh failure still leaves roughly 5 minutes of usable token. In
-        that window the cached token is reused rather than failing the caller:
-        the endpoint this refresh depends on times out under process contention
-        (P481207036), and a transient blip should not break a metadata database
-        connection.
+        Tokens are valid for 15 minutes and become due for refresh once fewer
+        than 5 remain. A caller holding a usable token never pays for the
+        refresh: the cached token is returned immediately and the refresh runs
+        on a background thread (see ``_start_background_refresh``). This keeps
+        the ECS metadata fetch off the connection critical path -- the fetch
+        is most likely to be slow exactly when the process is busy
+        (P481207036), which is also when connections are most frequent.
 
-        The refresh is deliberately performed while holding the lock. That
-        serialises concurrent refreshes into a single fetch, which is the
-        "shared credential provider" shape the Fargate Data Plane team
-        recommends to avoid multiplying connects to the endpoint. It is only
-        safe to hold the lock across the network call because that call is now
-        bounded by MWAA__DB__IAM_METADATA_TIMEOUT.
+        Only when nothing usable is cached -- cold start, or a token that has
+        actually expired -- is the fetch performed synchronously on the
+        calling thread. That path holds the lock across the mint, which
+        serialises concurrent callers into a single fetch (the shared
+        credential provider shape the Fargate Data Plane team recommends to
+        avoid multiplying connects to the endpoint), and is only safe to hold
+        across the network call because the call is bounded by
+        MWAA__DB__IAM_METADATA_TIMEOUT.
 
         :returns: Cached or freshly generated RDS auth token.
         """
         now = time.time()
+        token = cls._token
 
-        # Refresh token in cache if missing or expires in 5 mins.
-        if cls._token is None or now > cls._expires_at - 300:
-            with cls._lock:
-                if cls._token is None or now > cls._expires_at - 300:
-                    try:
-                        token = cls.generate_credentials()
-                    except Exception as e:
-                        if cls._token is not None and time.time() < cls._expires_at:
-                            logger.warning(
-                                "Could not refresh the RDS IAM token (%s); reusing "
-                                "the cached token, which is still valid.",
-                                e,
-                            )
-                            return cls._token
-                        raise
-                    cls._token = token
-                    # Timed from after the mint, not from before the lock wait,
-                    # so a slow refresh cannot overstate the token's lifetime.
-                    cls._expires_at = time.time() + 15 * 60  # 15 mins
+        if token is not None and now < cls._expires_at:
+            # The cached token is usable. If it is due for refresh, hand the
+            # refresh to a background thread and serve the cached token
+            # immediately rather than making this caller -- typically a
+            # database connection inside the do_connect listener -- block on
+            # the fetch.
+            if now > cls._expires_at - _TOKEN_REFRESH_BUFFER_SECONDS:
+                cls._start_background_refresh()
+            return token
 
-        return cls._token
+        # Nothing usable: cold start, or the token has expired. Fetch
+        # synchronously; the double-check returns without a second fetch for
+        # the threads that queued behind the winner.
+        with cls._lock:
+            if cls._token is None or time.time() >= cls._expires_at:
+                token = cls.generate_credentials()
+                cls._token = token
+                # Timed from after the mint, not from before the lock wait,
+                # so a slow refresh cannot overstate the token's lifetime.
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            return cls._token
+
+    @classmethod
+    def _start_background_refresh(cls) -> None:
+        """Refresh the token on a background thread, single-flight.
+
+        The non-blocking acquire keeps the refresh single-flight, so
+        concurrent callers noticing a due token do not multiply connects to
+        the ECS credential endpoint -- multiplying connects under contention
+        is the amplification pattern identified in P481207036.
+
+        A refresh failure is logged and the still-valid cached token stays in
+        place: tokens become due at the 10-minute mark of their 15-minute
+        lifetime precisely so a failed attempt leaves a ~5 minute window in
+        which later callers re-trigger the refresh.
+        """
+        if not cls._refresh_lock.acquire(blocking=False):
+            # A refresh is already in flight.
+            return
+
+        def _refresh() -> None:
+            try:
+                token = cls.generate_credentials()
+                cls._token = token
+                cls._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+            except Exception as e:
+                logger.warning(
+                    "Could not refresh the RDS IAM token in the background "
+                    "(%s); keeping the cached token, which is still valid.",
+                    e,
+                )
+            finally:
+                cls._refresh_lock.release()
+
+        try:
+            thread = threading.Thread(
+                target=_refresh, name="mwaa-rds-iam-token-refresh", daemon=True
+            )
+            cls._refresh_thread = thread
+            thread.start()
+        except Exception as e:
+            # Could not spawn the thread (e.g. resource exhaustion). Release
+            # the guard so a later caller can try again; the cached token is
+            # still valid, so this caller is unaffected.
+            cls._refresh_lock.release()
+            logger.warning("Could not start the RDS IAM token refresh thread: %s", e)
 
     @classmethod
     def create_db_connection_url(cls, token: str | None = None) -> str:
@@ -282,3 +345,20 @@ def is_using_rds_proxy() -> bool:
         logger.warning("MWAA__DB__POSTGRES_SSLMODE not set in environment.")
         return False
     return ssl_mode == "require"
+
+
+def _reset_locks_after_fork() -> None:
+    """Recreate the provider's locks in a forked child.
+
+    Airflow forks (Celery prefork workers, DAG processors). If the parent
+    forks while a lock is held, the child inherits it locked with no thread
+    alive to release it, which would wedge every future refresh in that child.
+    The cached token itself is plain data and remains valid across the fork,
+    so only the locks are replaced.
+    """
+    RDSIAMCredentialProvider._lock = threading.Lock()
+    RDSIAMCredentialProvider._refresh_lock = threading.Lock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_locks_after_fork)

--- a/images/airflow/3.3.0/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.3.0/python/mwaa/config/rds_iam_credentials.py
@@ -9,14 +9,55 @@ import logging
 import os
 import threading
 import time
+import urllib.error
 import urllib.request
 from urllib.parse import quote_plus, urlparse
 
 import boto3
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
 
 DB_IAM_USERNAME = "airflow_user"
+
+# The ECS task credential endpoint is link-local (169.254.170.2), routed inside
+# the task's own network namespace, and normally answers in milliseconds. It can
+# still fail with a connect timeout, but per the Fargate Data Plane analysis in
+# P481207036 that is not the endpoint being unhealthy or throttling: breaching
+# the TMDS limit (80 req/s steady, 120 burst) returns HTTP 429 on a completed
+# connection, whereas a connect timeout means the *calling* process could not
+# complete connect() in time because it is resource starved. So the call must be
+# bounded and retried rather than left to block.
+#
+# Note botocore's AWS_METADATA_SERVICE_TIMEOUT / _NUM_ATTEMPTS do not apply here:
+# this fetch is plain urllib, not botocore, so the values have to be set
+# explicitly.
+_METADATA_TIMEOUT_SECONDS = float(
+    os.environ.get("MWAA__DB__IAM_METADATA_TIMEOUT", "5")
+)
+_METADATA_ATTEMPTS = int(os.environ.get("MWAA__DB__IAM_METADATA_ATTEMPTS", "3"))
+
+
+def _is_transient_metadata_error(exception: BaseException) -> bool:
+    """Return True for metadata failures that are worth retrying.
+
+    Retries connect/read timeouts and connection errors, plus HTTP 429 (the
+    documented TMDS throttle response) and 5xx. Deliberately does not retry
+    configuration mistakes such as a missing environment variable, or client
+    errors like 404, where retrying only delays the failure.
+    """
+    if isinstance(exception, urllib.error.HTTPError):
+        return exception.code == 429 or exception.code >= 500
+    # socket.timeout is an alias of TimeoutError on Python 3.10+.
+    return isinstance(exception, (urllib.error.URLError, TimeoutError, ConnectionError))
+
+
+_with_metadata_retry = retry(
+    stop=stop_after_attempt(_METADATA_ATTEMPTS),
+    wait=wait_exponential(multiplier=1, min=1, max=4),
+    retry=retry_if_exception(_is_transient_metadata_error),
+    reraise=True,
+)
 
 
 class RDSIAMCredentialProvider:
@@ -31,11 +72,18 @@ class RDSIAMCredentialProvider:
     _expires_at: float = 0
 
     @staticmethod
+    @_with_metadata_retry
     def get_ecs_credentials() -> dict:
         """Get AWS credentials from ECS task metadata endpoint.
 
         Uses AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI for the credential path
         and ECS_CONTAINER_METADATA_URI for the base URL.
+
+        The request is bounded by MWAA__DB__IAM_METADATA_TIMEOUT and retried up
+        to MWAA__DB__IAM_METADATA_ATTEMPTS times on transient failures. Without
+        a timeout this call can block indefinitely, and it runs inside the
+        SQLAlchemy do_connect listener, so a hang would stall a metadata
+        database connection.
 
         :returns: AWS credentials dict with AccessKeyId, SecretAccessKey, Token.
         :raises ValueError: If required environment variables are not set.
@@ -56,7 +104,7 @@ class RDSIAMCredentialProvider:
         no_proxy_handler = urllib.request.ProxyHandler({})
         opener = urllib.request.build_opener(no_proxy_handler)
 
-        with opener.open(request) as response:
+        with opener.open(request, timeout=_METADATA_TIMEOUT_SECONDS) as response:
             credentials_data = json.loads(response.read().decode("utf-8"))
 
         return credentials_data
@@ -139,8 +187,19 @@ class RDSIAMCredentialProvider:
     def get_token(cls) -> str:
         """Get cached RDS IAM token, refreshing if expired or missing.
 
-        Uses thread-safe caching with 5-minute refresh buffer before
-        the 15-minute token expiration.
+        Tokens are valid for 15 minutes and refreshed at the 10-minute mark, so
+        a refresh failure still leaves roughly 5 minutes of usable token. In
+        that window the cached token is reused rather than failing the caller:
+        the endpoint this refresh depends on times out under process contention
+        (P481207036), and a transient blip should not break a metadata database
+        connection.
+
+        The refresh is deliberately performed while holding the lock. That
+        serialises concurrent refreshes into a single fetch, which is the
+        "shared credential provider" shape the Fargate Data Plane team
+        recommends to avoid multiplying connects to the endpoint. It is only
+        safe to hold the lock across the network call because that call is now
+        bounded by MWAA__DB__IAM_METADATA_TIMEOUT.
 
         :returns: Cached or freshly generated RDS auth token.
         """
@@ -150,8 +209,21 @@ class RDSIAMCredentialProvider:
         if cls._token is None or now > cls._expires_at - 300:
             with cls._lock:
                 if cls._token is None or now > cls._expires_at - 300:
-                    cls._token = cls.generate_credentials()
-                    cls._expires_at = now + 15 * 60  # 15 mins
+                    try:
+                        token = cls.generate_credentials()
+                    except Exception as e:
+                        if cls._token is not None and time.time() < cls._expires_at:
+                            logger.warning(
+                                "Could not refresh the RDS IAM token (%s); reusing "
+                                "the cached token, which is still valid.",
+                                e,
+                            )
+                            return cls._token
+                        raise
+                    cls._token = token
+                    # Timed from after the mint, not from before the lock wait,
+                    # so a slow refresh cannot overstate the token's lifetime.
+                    cls._expires_at = time.time() + 15 * 60  # 15 mins
 
         return cls._token
 

--- a/images/airflow/3.3.0/python/mwaa/config/rds_iam_credentials.py
+++ b/images/airflow/3.3.0/python/mwaa/config/rds_iam_credentials.py
@@ -231,14 +231,16 @@ class RDSIAMCredentialProvider:
     def create_db_connection_url(cls, token: str | None = None) -> str:
         """Create a PostgreSQL connection URL for RDS IAM authentication.
 
-        :param token: RDS IAM auth token. If None, generates a fresh token.
+        :param token: RDS IAM auth token. If None, the cached token from
+            ``get_token()`` is used.
         :returns: PostgreSQL connection URL with IAM authentication.
         """
         if token is None:
-            # NOTE: bypasses the get_token() cache, matching 2.x. No caller uses
-            # this default path today; the cache bypass is tracked for a
-            # cross-version follow-up rather than diverging from 2.x here.
-            token = cls.generate_credentials()
+            # Route through get_token() rather than generate_credentials() so
+            # the default path reuses the thread-safe cache. Calling
+            # generate_credentials() directly would mint a new token -- an ECS
+            # metadata fetch plus a signed boto3 call -- on every connection.
+            token = cls.get_token()
 
         auth_token = quote_plus(token)
         postgres_host = os.environ.get("MWAA__DB__POSTGRES_HOST", "localhost")

--- a/tests/images/airflow/2.10.1/python/mwaa/utils/test_get_rds_iam_credentials_2_10_1.py
+++ b/tests/images/airflow/2.10.1/python/mwaa/utils/test_get_rds_iam_credentials_2_10_1.py
@@ -219,14 +219,19 @@ def test_generate_credentials_success():
 
 
 def test_generate_credentials_failure():
-    """Test credential generation failure"""
+    """A failed mint must raise rather than return None.
+
+    Regression test: returning None poisoned the cache -- get_token() stored
+    the None with a full 15-minute lifetime, so every caller in the process
+    was handed an unusable credential until the entry aged out.
+    """
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
     
     with patch.object(RDSIAMCredentialProvider, 'get_ecs_credentials', side_effect=Exception("ECS error")), \
          patch('mwaa.utils.get_rds_iam_credentials.logger') as mock_logger:
         
-        result = RDSIAMCredentialProvider.generate_credentials()
-        assert result is None
+        with pytest.raises(Exception, match="ECS error"):
+            RDSIAMCredentialProvider.generate_credentials()
         mock_logger.error.assert_called_with("Failed to update credentials: ECS error")
 
 
@@ -245,25 +250,492 @@ def test_create_db_connection_url():
 
 
 def test_create_db_connection_url_generate_token():
-    """Test database connection URL creation with token generation"""
+    """The default token path must go through the thread-safe cache.
+
+    Regression test: calling generate_credentials() directly bypassed
+    get_token(), minting a fresh token (ECS metadata fetch + signed boto3 call)
+    on every connection instead of reusing the cached one.
+    """
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
-    
+
+    # Start from a cold cache; other tests in this module mutate this state.
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
     with patch.dict('os.environ', {
         'POSTGRES_HOST': 'test.rds.amazonaws.com',
         'POSTGRES_PORT': '5432',
         'POSTGRES_DB': 'airflow',
         'SSL_MODE': 'require'
     }), \
-    patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value='generated_token'):
-        
-        result = RDSIAMCredentialProvider.create_db_connection_url()
-        assert 'postgresql+psycopg2://airflow_user:generated_token@test.rds.amazonaws.com:5432/airflow?sslmode=require' in result
+    patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value='generated_token') as mock_generate:
+        expected = (
+            'postgresql+psycopg2://airflow_user:generated_token'
+            '@test.rds.amazonaws.com:5432/airflow?sslmode=require'
+        )
+
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        # Second call must be served from the cache, not mint a new token.
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        assert mock_generate.call_count == 1
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
 
 
 def test_create_db_connection_url_generation_failure():
-    """Test database connection URL creation when token generation fails"""
+    """URL creation must surface a failed mint on the default token path."""
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
-    
-    with patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value=None):
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
+    with patch.object(
+        RDSIAMCredentialProvider,
+        'generate_credentials',
+        side_effect=Exception("Failed to generate RDS auth token"),
+    ):
         with pytest.raises(Exception, match="Failed to generate RDS auth token"):
             RDSIAMCredentialProvider.create_db_connection_url()
+
+# --- ECS metadata endpoint hardening (see P481207036) ---
+
+def test_get_token_does_not_cache_a_failed_mint():
+    """A failed cold-start mint must not populate the cache.
+
+    Regression test for the None-poisoning defect: generate_credentials()
+    used to swallow failures and return None, which get_token() cached with a
+    full 15-minute lifetime -- every caller in the process was then handed an
+    unusable credential until the entry aged out. A failure must propagate
+    and leave the cache empty so the next caller retries.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = None
+        RDSIAMCredentialProvider._expires_at = 0
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            'get_ecs_credentials',
+            side_effect=Exception("ECS error"),
+        ):
+            with pytest.raises(Exception, match="ECS error"):
+                RDSIAMCredentialProvider.get_token()
+
+        # The failure left the cache empty rather than caching a dud...
+        assert RDSIAMCredentialProvider._token is None
+        assert RDSIAMCredentialProvider._expires_at == 0
+        # ...so the very next caller retries and succeeds.
+        with patch.object(
+            RDSIAMCredentialProvider, 'generate_credentials', return_value='recovered'
+        ):
+            assert RDSIAMCredentialProvider.get_token() == 'recovered'
+    finally:
+        RDSIAMCredentialProvider._token = None
+        RDSIAMCredentialProvider._expires_at = 0
+
+
+
+_ECS_ENV = {
+    "AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/abc",
+    "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/containers/test",
+}
+_CREDS = {
+    "AccessKeyId": "k",
+    "SecretAccessKey": "s",
+    "Token": "t",
+}
+
+
+def _mock_opener(side_effect=None, payload=None):
+    """Build a mock urllib opener returning payload, or raising side_effect."""
+    opener = MagicMock()
+    if side_effect is not None:
+        opener.open.side_effect = side_effect
+    else:
+        response = MagicMock()
+        response.status = 200
+        response.read.return_value = json.dumps(payload or _CREDS).encode("utf-8")
+        opener.open.return_value.__enter__.return_value = response
+    return opener
+
+
+def _reset_token_cache():
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
+
+def _join_refresh_thread():
+    """Wait for the background refresh thread so assertions are deterministic."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    thread = RDSIAMCredentialProvider._refresh_thread
+    if thread is not None:
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "background refresh did not finish"
+
+
+def test_ecs_metadata_fetch_passes_a_timeout():
+    """The fetch must be bounded; without a timeout urllib blocks indefinitely.
+
+    It runs inside the SQLAlchemy do_connect listener, so an unbounded hang
+    would stall a metadata database connection.
+    """
+    from mwaa.utils import get_rds_iam_credentials
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    _, kwargs = opener.open.call_args
+    assert kwargs.get("timeout") == get_rds_iam_credentials._METADATA_TIMEOUT_SECONDS
+    assert kwargs["timeout"] > 0
+
+
+def test_ecs_metadata_fetch_retries_transient_failure_then_succeeds():
+    """A single connect timeout must not fail the caller."""
+    import urllib.error
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    response = MagicMock()
+    response.status = 200
+    response.read.return_value = json.dumps(_CREDS).encode("utf-8")
+    ok = MagicMock()
+    ok.__enter__ = MagicMock(return_value=response)
+    ok.__exit__ = MagicMock(return_value=False)
+
+    opener = MagicMock()
+    opener.open.side_effect = [urllib.error.URLError("timed out"), ok]
+
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ), patch("tenacity.nap.time.sleep"):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    assert opener.open.call_count == 2
+
+
+def test_ecs_metadata_fetch_does_not_retry_config_errors():
+    """A missing environment variable is not transient; fail immediately."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", {}, clear=True), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        with pytest.raises(ValueError):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+    opener.open.assert_not_called()
+
+
+def test_transient_error_classification():
+    """429 and 5xx are retryable; 4xx client errors are not."""
+    import urllib.error
+
+    from mwaa.utils.get_rds_iam_credentials import _is_transient_metadata_error
+
+    def http(code):
+        return urllib.error.HTTPError("u", code, "msg", None, None)
+
+    assert _is_transient_metadata_error(http(429)) is True
+    assert _is_transient_metadata_error(http(503)) is True
+    assert _is_transient_metadata_error(http(500)) is True
+    assert _is_transient_metadata_error(http(404)) is False
+    assert _is_transient_metadata_error(http(403)) is False
+    assert _is_transient_metadata_error(urllib.error.URLError("boom")) is True
+    assert _is_transient_metadata_error(TimeoutError()) is True
+    assert _is_transient_metadata_error(ConnectionResetError()) is True
+    assert _is_transient_metadata_error(ValueError("config")) is False
+
+
+def test_failed_refresh_reuses_a_still_valid_cached_token():
+    """A refresh failure inside the grace window must not fail the caller.
+
+    Tokens live 15 minutes and are refreshed at 10, so a blip during refresh
+    still leaves a usable token. The failure happens on the background thread
+    and is logged; the cached token stays in place, and the single-flight
+    guard is released so a later caller can retry the refresh.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "still_valid"
+        # Inside the refresh window (expires in 60s) but not yet expired.
+        expires_at = time.time() + 60
+        RDSIAMCredentialProvider._expires_at = expires_at
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "still_valid"
+            _join_refresh_thread()
+
+        # The failed refresh left the cache untouched...
+        assert RDSIAMCredentialProvider._token == "still_valid"
+        assert RDSIAMCredentialProvider._expires_at == expires_at
+        # ...and released the single-flight guard for the next attempt.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        _reset_token_cache()
+
+
+def test_failed_refresh_raises_once_the_token_has_expired():
+    """Past expiry there is nothing safe to reuse, so surface the failure."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            with pytest.raises(Exception, match="metadata endpoint timed out"):
+                RDSIAMCredentialProvider.get_token()
+    finally:
+        _reset_token_cache()
+
+
+def test_token_expiry_measured_after_the_mint():
+    """Expiry must be timed from after the fetch, not before the lock wait.
+
+    Uses a stepped clock so a slow mint is distinguishable: timing from before
+    would set expiry to 1000+900, from after to 2000+900. With a real (instant)
+    mint the two are indistinguishable, which is why the clock is stubbed.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    calls = {"n": 0}
+
+    def stepped_clock():
+        calls["n"] += 1
+        return 1000.0 if calls["n"] == 1 else 2000.0
+
+    try:
+        _reset_token_cache()
+        with patch(
+            "mwaa.utils.get_rds_iam_credentials.time.time", side_effect=stepped_clock
+        ), patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", return_value="fresh"
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert RDSIAMCredentialProvider._expires_at == 2000.0 + 15 * 60
+    finally:
+        _reset_token_cache()
+
+
+# --- Off-critical-path token refresh ---
+#
+# The 5-minute refresh buffer on the 15-minute token lifetime exists so the
+# refresh can happen without a caller paying for it. These tests pin that
+# property: a usable token is always served immediately, the refresh runs on a
+# background thread, and only a cold start or a genuinely expired token blocks
+# the caller.
+
+
+def test_due_token_is_served_immediately_and_refreshed_in_background():
+    """A caller holding a usable token must not pay for the refresh.
+
+    Regression test: get_token() used to perform the fetch on the calling
+    thread while holding the lock, so the connection that arrived at the
+    10-minute mark blocked on the ECS metadata endpoint and every other
+    caller in the process queued behind it.
+    """
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    caller = threading.current_thread()
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        # Due for refresh (fewer than 5 minutes left) but not expired.
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            # The caller is handed the cached token, not the refreshed one.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            _join_refresh_thread()
+
+        # The refresh ran on a different thread and updated the cache.
+        assert minting_thread["thread"] is not caller
+        assert RDSIAMCredentialProvider._token == "refreshed"
+        assert RDSIAMCredentialProvider._expires_at > time.time() + 14 * 60
+    finally:
+        _reset_token_cache()
+
+
+def test_background_refresh_is_single_flight():
+    """Concurrent callers noticing a due token must not multiply fetches.
+
+    Multiplying connects to the ECS credential endpoint under contention is
+    the amplification pattern identified in P481207036, so while one refresh
+    is in flight further callers must be served the cached token without
+    triggering another fetch.
+    """
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    release = threading.Event()
+    calls = []
+
+    def slow_mint():
+        calls.append(1)
+        assert release.wait(timeout=5), "test never released the mint"
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=slow_mint
+        ):
+            for _ in range(5):
+                assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            release.set()
+            _join_refresh_thread()
+
+        assert len(calls) == 1
+    finally:
+        release.set()
+        _reset_token_cache()
+
+
+def test_cold_start_fetches_synchronously():
+    """With nothing cached there is nothing to serve, so the caller waits."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        _reset_token_cache()
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_expired_token_fetches_synchronously():
+    """Past expiry the cached token is unusable, so the caller waits."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_locks_are_replaced_after_fork():
+    """A child forked while a lock is held must not inherit it locked.
+
+    Airflow forks (Celery prefork workers, DAG processors). A lock held at
+    fork time is inherited locked by the child with no thread alive to
+    release it, which would wedge every future refresh in that child.
+    """
+    from mwaa.utils import get_rds_iam_credentials as m
+
+    old_lock = m.RDSIAMCredentialProvider._lock
+    old_refresh_lock = m.RDSIAMCredentialProvider._refresh_lock
+    old_lock.acquire()
+    old_refresh_lock.acquire()
+    try:
+        m._reset_locks_after_fork()
+
+        assert m.RDSIAMCredentialProvider._lock is not old_lock
+        assert m.RDSIAMCredentialProvider._refresh_lock is not old_refresh_lock
+        # The replacements are usable.
+        assert m.RDSIAMCredentialProvider._lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._lock.release()
+        assert m.RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        old_lock.release()
+        old_refresh_lock.release()
+
+
+def test_fork_hook_is_registered_at_import():
+    """The at-fork reset must be wired up when the module is imported."""
+    import importlib
+
+    from mwaa.utils import get_rds_iam_credentials as m
+
+    try:
+        with patch("os.register_at_fork") as mock_register:
+            importlib.reload(m)
+        mock_register.assert_called_once()
+        hook = mock_register.call_args.kwargs["after_in_child"]
+        assert hook.__name__ == "_reset_locks_after_fork"
+    finally:
+        # Restore a clean module (the reload above replaced the class object).
+        importlib.reload(m)
+
+
+def test_failed_thread_start_releases_the_single_flight_guard():
+    """If the refresh thread cannot start, later callers must be able to retry."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            threading.Thread, "start", side_effect=RuntimeError("can't start new thread")
+        ):
+            # The caller is unaffected: it still gets the cached token.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+
+        # The guard was released, so the next caller can attempt the refresh.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        _reset_token_cache()

--- a/tests/images/airflow/2.10.3/python/mwaa/utils/test_get_rds_iam_credentials_2_10_3.py
+++ b/tests/images/airflow/2.10.3/python/mwaa/utils/test_get_rds_iam_credentials_2_10_3.py
@@ -219,14 +219,19 @@ def test_generate_credentials_success():
 
 
 def test_generate_credentials_failure():
-    """Test credential generation failure"""
+    """A failed mint must raise rather than return None.
+
+    Regression test: returning None poisoned the cache -- get_token() stored
+    the None with a full 15-minute lifetime, so every caller in the process
+    was handed an unusable credential until the entry aged out.
+    """
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
     
     with patch.object(RDSIAMCredentialProvider, 'get_ecs_credentials', side_effect=Exception("ECS error")), \
          patch('mwaa.utils.get_rds_iam_credentials.logger') as mock_logger:
         
-        result = RDSIAMCredentialProvider.generate_credentials()
-        assert result is None
+        with pytest.raises(Exception, match="ECS error"):
+            RDSIAMCredentialProvider.generate_credentials()
         mock_logger.error.assert_called_with("Failed to update credentials: ECS error")
 
 
@@ -245,25 +250,492 @@ def test_create_db_connection_url():
 
 
 def test_create_db_connection_url_generate_token():
-    """Test database connection URL creation with token generation"""
+    """The default token path must go through the thread-safe cache.
+
+    Regression test: calling generate_credentials() directly bypassed
+    get_token(), minting a fresh token (ECS metadata fetch + signed boto3 call)
+    on every connection instead of reusing the cached one.
+    """
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
-    
+
+    # Start from a cold cache; other tests in this module mutate this state.
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
     with patch.dict('os.environ', {
         'POSTGRES_HOST': 'test.rds.amazonaws.com',
         'POSTGRES_PORT': '5432',
         'POSTGRES_DB': 'airflow',
         'SSL_MODE': 'require'
     }), \
-    patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value='generated_token'):
-        
-        result = RDSIAMCredentialProvider.create_db_connection_url()
-        assert 'postgresql+psycopg2://airflow_user:generated_token@test.rds.amazonaws.com:5432/airflow?sslmode=require' in result
+    patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value='generated_token') as mock_generate:
+        expected = (
+            'postgresql+psycopg2://airflow_user:generated_token'
+            '@test.rds.amazonaws.com:5432/airflow?sslmode=require'
+        )
+
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        # Second call must be served from the cache, not mint a new token.
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        assert mock_generate.call_count == 1
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
 
 
 def test_create_db_connection_url_generation_failure():
-    """Test database connection URL creation when token generation fails"""
+    """URL creation must surface a failed mint on the default token path."""
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
-    
-    with patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value=None):
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
+    with patch.object(
+        RDSIAMCredentialProvider,
+        'generate_credentials',
+        side_effect=Exception("Failed to generate RDS auth token"),
+    ):
         with pytest.raises(Exception, match="Failed to generate RDS auth token"):
             RDSIAMCredentialProvider.create_db_connection_url()
+
+# --- ECS metadata endpoint hardening (see P481207036) ---
+
+def test_get_token_does_not_cache_a_failed_mint():
+    """A failed cold-start mint must not populate the cache.
+
+    Regression test for the None-poisoning defect: generate_credentials()
+    used to swallow failures and return None, which get_token() cached with a
+    full 15-minute lifetime -- every caller in the process was then handed an
+    unusable credential until the entry aged out. A failure must propagate
+    and leave the cache empty so the next caller retries.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = None
+        RDSIAMCredentialProvider._expires_at = 0
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            'get_ecs_credentials',
+            side_effect=Exception("ECS error"),
+        ):
+            with pytest.raises(Exception, match="ECS error"):
+                RDSIAMCredentialProvider.get_token()
+
+        # The failure left the cache empty rather than caching a dud...
+        assert RDSIAMCredentialProvider._token is None
+        assert RDSIAMCredentialProvider._expires_at == 0
+        # ...so the very next caller retries and succeeds.
+        with patch.object(
+            RDSIAMCredentialProvider, 'generate_credentials', return_value='recovered'
+        ):
+            assert RDSIAMCredentialProvider.get_token() == 'recovered'
+    finally:
+        RDSIAMCredentialProvider._token = None
+        RDSIAMCredentialProvider._expires_at = 0
+
+
+
+_ECS_ENV = {
+    "AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/abc",
+    "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/containers/test",
+}
+_CREDS = {
+    "AccessKeyId": "k",
+    "SecretAccessKey": "s",
+    "Token": "t",
+}
+
+
+def _mock_opener(side_effect=None, payload=None):
+    """Build a mock urllib opener returning payload, or raising side_effect."""
+    opener = MagicMock()
+    if side_effect is not None:
+        opener.open.side_effect = side_effect
+    else:
+        response = MagicMock()
+        response.status = 200
+        response.read.return_value = json.dumps(payload or _CREDS).encode("utf-8")
+        opener.open.return_value.__enter__.return_value = response
+    return opener
+
+
+def _reset_token_cache():
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
+
+def _join_refresh_thread():
+    """Wait for the background refresh thread so assertions are deterministic."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    thread = RDSIAMCredentialProvider._refresh_thread
+    if thread is not None:
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "background refresh did not finish"
+
+
+def test_ecs_metadata_fetch_passes_a_timeout():
+    """The fetch must be bounded; without a timeout urllib blocks indefinitely.
+
+    It runs inside the SQLAlchemy do_connect listener, so an unbounded hang
+    would stall a metadata database connection.
+    """
+    from mwaa.utils import get_rds_iam_credentials
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    _, kwargs = opener.open.call_args
+    assert kwargs.get("timeout") == get_rds_iam_credentials._METADATA_TIMEOUT_SECONDS
+    assert kwargs["timeout"] > 0
+
+
+def test_ecs_metadata_fetch_retries_transient_failure_then_succeeds():
+    """A single connect timeout must not fail the caller."""
+    import urllib.error
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    response = MagicMock()
+    response.status = 200
+    response.read.return_value = json.dumps(_CREDS).encode("utf-8")
+    ok = MagicMock()
+    ok.__enter__ = MagicMock(return_value=response)
+    ok.__exit__ = MagicMock(return_value=False)
+
+    opener = MagicMock()
+    opener.open.side_effect = [urllib.error.URLError("timed out"), ok]
+
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ), patch("tenacity.nap.time.sleep"):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    assert opener.open.call_count == 2
+
+
+def test_ecs_metadata_fetch_does_not_retry_config_errors():
+    """A missing environment variable is not transient; fail immediately."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", {}, clear=True), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        with pytest.raises(ValueError):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+    opener.open.assert_not_called()
+
+
+def test_transient_error_classification():
+    """429 and 5xx are retryable; 4xx client errors are not."""
+    import urllib.error
+
+    from mwaa.utils.get_rds_iam_credentials import _is_transient_metadata_error
+
+    def http(code):
+        return urllib.error.HTTPError("u", code, "msg", None, None)
+
+    assert _is_transient_metadata_error(http(429)) is True
+    assert _is_transient_metadata_error(http(503)) is True
+    assert _is_transient_metadata_error(http(500)) is True
+    assert _is_transient_metadata_error(http(404)) is False
+    assert _is_transient_metadata_error(http(403)) is False
+    assert _is_transient_metadata_error(urllib.error.URLError("boom")) is True
+    assert _is_transient_metadata_error(TimeoutError()) is True
+    assert _is_transient_metadata_error(ConnectionResetError()) is True
+    assert _is_transient_metadata_error(ValueError("config")) is False
+
+
+def test_failed_refresh_reuses_a_still_valid_cached_token():
+    """A refresh failure inside the grace window must not fail the caller.
+
+    Tokens live 15 minutes and are refreshed at 10, so a blip during refresh
+    still leaves a usable token. The failure happens on the background thread
+    and is logged; the cached token stays in place, and the single-flight
+    guard is released so a later caller can retry the refresh.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "still_valid"
+        # Inside the refresh window (expires in 60s) but not yet expired.
+        expires_at = time.time() + 60
+        RDSIAMCredentialProvider._expires_at = expires_at
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "still_valid"
+            _join_refresh_thread()
+
+        # The failed refresh left the cache untouched...
+        assert RDSIAMCredentialProvider._token == "still_valid"
+        assert RDSIAMCredentialProvider._expires_at == expires_at
+        # ...and released the single-flight guard for the next attempt.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        _reset_token_cache()
+
+
+def test_failed_refresh_raises_once_the_token_has_expired():
+    """Past expiry there is nothing safe to reuse, so surface the failure."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            with pytest.raises(Exception, match="metadata endpoint timed out"):
+                RDSIAMCredentialProvider.get_token()
+    finally:
+        _reset_token_cache()
+
+
+def test_token_expiry_measured_after_the_mint():
+    """Expiry must be timed from after the fetch, not before the lock wait.
+
+    Uses a stepped clock so a slow mint is distinguishable: timing from before
+    would set expiry to 1000+900, from after to 2000+900. With a real (instant)
+    mint the two are indistinguishable, which is why the clock is stubbed.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    calls = {"n": 0}
+
+    def stepped_clock():
+        calls["n"] += 1
+        return 1000.0 if calls["n"] == 1 else 2000.0
+
+    try:
+        _reset_token_cache()
+        with patch(
+            "mwaa.utils.get_rds_iam_credentials.time.time", side_effect=stepped_clock
+        ), patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", return_value="fresh"
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert RDSIAMCredentialProvider._expires_at == 2000.0 + 15 * 60
+    finally:
+        _reset_token_cache()
+
+
+# --- Off-critical-path token refresh ---
+#
+# The 5-minute refresh buffer on the 15-minute token lifetime exists so the
+# refresh can happen without a caller paying for it. These tests pin that
+# property: a usable token is always served immediately, the refresh runs on a
+# background thread, and only a cold start or a genuinely expired token blocks
+# the caller.
+
+
+def test_due_token_is_served_immediately_and_refreshed_in_background():
+    """A caller holding a usable token must not pay for the refresh.
+
+    Regression test: get_token() used to perform the fetch on the calling
+    thread while holding the lock, so the connection that arrived at the
+    10-minute mark blocked on the ECS metadata endpoint and every other
+    caller in the process queued behind it.
+    """
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    caller = threading.current_thread()
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        # Due for refresh (fewer than 5 minutes left) but not expired.
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            # The caller is handed the cached token, not the refreshed one.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            _join_refresh_thread()
+
+        # The refresh ran on a different thread and updated the cache.
+        assert minting_thread["thread"] is not caller
+        assert RDSIAMCredentialProvider._token == "refreshed"
+        assert RDSIAMCredentialProvider._expires_at > time.time() + 14 * 60
+    finally:
+        _reset_token_cache()
+
+
+def test_background_refresh_is_single_flight():
+    """Concurrent callers noticing a due token must not multiply fetches.
+
+    Multiplying connects to the ECS credential endpoint under contention is
+    the amplification pattern identified in P481207036, so while one refresh
+    is in flight further callers must be served the cached token without
+    triggering another fetch.
+    """
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    release = threading.Event()
+    calls = []
+
+    def slow_mint():
+        calls.append(1)
+        assert release.wait(timeout=5), "test never released the mint"
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=slow_mint
+        ):
+            for _ in range(5):
+                assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            release.set()
+            _join_refresh_thread()
+
+        assert len(calls) == 1
+    finally:
+        release.set()
+        _reset_token_cache()
+
+
+def test_cold_start_fetches_synchronously():
+    """With nothing cached there is nothing to serve, so the caller waits."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        _reset_token_cache()
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_expired_token_fetches_synchronously():
+    """Past expiry the cached token is unusable, so the caller waits."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_locks_are_replaced_after_fork():
+    """A child forked while a lock is held must not inherit it locked.
+
+    Airflow forks (Celery prefork workers, DAG processors). A lock held at
+    fork time is inherited locked by the child with no thread alive to
+    release it, which would wedge every future refresh in that child.
+    """
+    from mwaa.utils import get_rds_iam_credentials as m
+
+    old_lock = m.RDSIAMCredentialProvider._lock
+    old_refresh_lock = m.RDSIAMCredentialProvider._refresh_lock
+    old_lock.acquire()
+    old_refresh_lock.acquire()
+    try:
+        m._reset_locks_after_fork()
+
+        assert m.RDSIAMCredentialProvider._lock is not old_lock
+        assert m.RDSIAMCredentialProvider._refresh_lock is not old_refresh_lock
+        # The replacements are usable.
+        assert m.RDSIAMCredentialProvider._lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._lock.release()
+        assert m.RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        old_lock.release()
+        old_refresh_lock.release()
+
+
+def test_fork_hook_is_registered_at_import():
+    """The at-fork reset must be wired up when the module is imported."""
+    import importlib
+
+    from mwaa.utils import get_rds_iam_credentials as m
+
+    try:
+        with patch("os.register_at_fork") as mock_register:
+            importlib.reload(m)
+        mock_register.assert_called_once()
+        hook = mock_register.call_args.kwargs["after_in_child"]
+        assert hook.__name__ == "_reset_locks_after_fork"
+    finally:
+        # Restore a clean module (the reload above replaced the class object).
+        importlib.reload(m)
+
+
+def test_failed_thread_start_releases_the_single_flight_guard():
+    """If the refresh thread cannot start, later callers must be able to retry."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            threading.Thread, "start", side_effect=RuntimeError("can't start new thread")
+        ):
+            # The caller is unaffected: it still gets the cached token.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+
+        # The guard was released, so the next caller can attempt the refresh.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        _reset_token_cache()

--- a/tests/images/airflow/2.11.0/python/mwaa/utils/test_get_rds_iam_credentials_2_11_0.py
+++ b/tests/images/airflow/2.11.0/python/mwaa/utils/test_get_rds_iam_credentials_2_11_0.py
@@ -182,8 +182,9 @@ def test_get_token_cached():
     """Test cached token retrieval"""
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
     
+    # Set up cached token
     RDSIAMCredentialProvider._token = 'cached_token'
-    RDSIAMCredentialProvider._expires_at = time.time() + 600
+    RDSIAMCredentialProvider._expires_at = time.time() + 600  # 10 minutes from now
     
     result = RDSIAMCredentialProvider.get_token()
     assert result == 'cached_token'
@@ -193,8 +194,9 @@ def test_get_token_refresh_needed():
     """Test token refresh when expired"""
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
     
+    # Set up expired token
     RDSIAMCredentialProvider._token = 'old_token'
-    RDSIAMCredentialProvider._expires_at = time.time() - 100
+    RDSIAMCredentialProvider._expires_at = time.time() - 100  # Expired
     
     with patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value='new_token'):
         result = RDSIAMCredentialProvider.get_token()
@@ -217,14 +219,19 @@ def test_generate_credentials_success():
 
 
 def test_generate_credentials_failure():
-    """Test credential generation failure"""
+    """A failed mint must raise rather than return None.
+
+    Regression test: returning None poisoned the cache -- get_token() stored
+    the None with a full 15-minute lifetime, so every caller in the process
+    was handed an unusable credential until the entry aged out.
+    """
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
     
     with patch.object(RDSIAMCredentialProvider, 'get_ecs_credentials', side_effect=Exception("ECS error")), \
          patch('mwaa.utils.get_rds_iam_credentials.logger') as mock_logger:
         
-        result = RDSIAMCredentialProvider.generate_credentials()
-        assert result is None
+        with pytest.raises(Exception, match="ECS error"):
+            RDSIAMCredentialProvider.generate_credentials()
         mock_logger.error.assert_called_with("Failed to update credentials: ECS error")
 
 
@@ -243,25 +250,492 @@ def test_create_db_connection_url():
 
 
 def test_create_db_connection_url_generate_token():
-    """Test database connection URL creation with token generation"""
+    """The default token path must go through the thread-safe cache.
+
+    Regression test: calling generate_credentials() directly bypassed
+    get_token(), minting a fresh token (ECS metadata fetch + signed boto3 call)
+    on every connection instead of reusing the cached one.
+    """
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
-    
+
+    # Start from a cold cache; other tests in this module mutate this state.
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
     with patch.dict('os.environ', {
         'POSTGRES_HOST': 'test.rds.amazonaws.com',
         'POSTGRES_PORT': '5432',
         'POSTGRES_DB': 'airflow',
         'SSL_MODE': 'require'
     }), \
-    patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value='generated_token'):
-        
-        result = RDSIAMCredentialProvider.create_db_connection_url()
-        assert 'postgresql+psycopg2://airflow_user:generated_token@test.rds.amazonaws.com:5432/airflow?sslmode=require' in result
+    patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value='generated_token') as mock_generate:
+        expected = (
+            'postgresql+psycopg2://airflow_user:generated_token'
+            '@test.rds.amazonaws.com:5432/airflow?sslmode=require'
+        )
+
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        # Second call must be served from the cache, not mint a new token.
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        assert mock_generate.call_count == 1
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
 
 
 def test_create_db_connection_url_generation_failure():
-    """Test database connection URL creation when token generation fails"""
+    """URL creation must surface a failed mint on the default token path."""
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
-    
-    with patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value=None):
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
+    with patch.object(
+        RDSIAMCredentialProvider,
+        'generate_credentials',
+        side_effect=Exception("Failed to generate RDS auth token"),
+    ):
         with pytest.raises(Exception, match="Failed to generate RDS auth token"):
             RDSIAMCredentialProvider.create_db_connection_url()
+
+# --- ECS metadata endpoint hardening (see P481207036) ---
+
+def test_get_token_does_not_cache_a_failed_mint():
+    """A failed cold-start mint must not populate the cache.
+
+    Regression test for the None-poisoning defect: generate_credentials()
+    used to swallow failures and return None, which get_token() cached with a
+    full 15-minute lifetime -- every caller in the process was then handed an
+    unusable credential until the entry aged out. A failure must propagate
+    and leave the cache empty so the next caller retries.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = None
+        RDSIAMCredentialProvider._expires_at = 0
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            'get_ecs_credentials',
+            side_effect=Exception("ECS error"),
+        ):
+            with pytest.raises(Exception, match="ECS error"):
+                RDSIAMCredentialProvider.get_token()
+
+        # The failure left the cache empty rather than caching a dud...
+        assert RDSIAMCredentialProvider._token is None
+        assert RDSIAMCredentialProvider._expires_at == 0
+        # ...so the very next caller retries and succeeds.
+        with patch.object(
+            RDSIAMCredentialProvider, 'generate_credentials', return_value='recovered'
+        ):
+            assert RDSIAMCredentialProvider.get_token() == 'recovered'
+    finally:
+        RDSIAMCredentialProvider._token = None
+        RDSIAMCredentialProvider._expires_at = 0
+
+
+
+_ECS_ENV = {
+    "AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/abc",
+    "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/containers/test",
+}
+_CREDS = {
+    "AccessKeyId": "k",
+    "SecretAccessKey": "s",
+    "Token": "t",
+}
+
+
+def _mock_opener(side_effect=None, payload=None):
+    """Build a mock urllib opener returning payload, or raising side_effect."""
+    opener = MagicMock()
+    if side_effect is not None:
+        opener.open.side_effect = side_effect
+    else:
+        response = MagicMock()
+        response.status = 200
+        response.read.return_value = json.dumps(payload or _CREDS).encode("utf-8")
+        opener.open.return_value.__enter__.return_value = response
+    return opener
+
+
+def _reset_token_cache():
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
+
+def _join_refresh_thread():
+    """Wait for the background refresh thread so assertions are deterministic."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    thread = RDSIAMCredentialProvider._refresh_thread
+    if thread is not None:
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "background refresh did not finish"
+
+
+def test_ecs_metadata_fetch_passes_a_timeout():
+    """The fetch must be bounded; without a timeout urllib blocks indefinitely.
+
+    It runs inside the SQLAlchemy do_connect listener, so an unbounded hang
+    would stall a metadata database connection.
+    """
+    from mwaa.utils import get_rds_iam_credentials
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    _, kwargs = opener.open.call_args
+    assert kwargs.get("timeout") == get_rds_iam_credentials._METADATA_TIMEOUT_SECONDS
+    assert kwargs["timeout"] > 0
+
+
+def test_ecs_metadata_fetch_retries_transient_failure_then_succeeds():
+    """A single connect timeout must not fail the caller."""
+    import urllib.error
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    response = MagicMock()
+    response.status = 200
+    response.read.return_value = json.dumps(_CREDS).encode("utf-8")
+    ok = MagicMock()
+    ok.__enter__ = MagicMock(return_value=response)
+    ok.__exit__ = MagicMock(return_value=False)
+
+    opener = MagicMock()
+    opener.open.side_effect = [urllib.error.URLError("timed out"), ok]
+
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ), patch("tenacity.nap.time.sleep"):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    assert opener.open.call_count == 2
+
+
+def test_ecs_metadata_fetch_does_not_retry_config_errors():
+    """A missing environment variable is not transient; fail immediately."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", {}, clear=True), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        with pytest.raises(ValueError):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+    opener.open.assert_not_called()
+
+
+def test_transient_error_classification():
+    """429 and 5xx are retryable; 4xx client errors are not."""
+    import urllib.error
+
+    from mwaa.utils.get_rds_iam_credentials import _is_transient_metadata_error
+
+    def http(code):
+        return urllib.error.HTTPError("u", code, "msg", None, None)
+
+    assert _is_transient_metadata_error(http(429)) is True
+    assert _is_transient_metadata_error(http(503)) is True
+    assert _is_transient_metadata_error(http(500)) is True
+    assert _is_transient_metadata_error(http(404)) is False
+    assert _is_transient_metadata_error(http(403)) is False
+    assert _is_transient_metadata_error(urllib.error.URLError("boom")) is True
+    assert _is_transient_metadata_error(TimeoutError()) is True
+    assert _is_transient_metadata_error(ConnectionResetError()) is True
+    assert _is_transient_metadata_error(ValueError("config")) is False
+
+
+def test_failed_refresh_reuses_a_still_valid_cached_token():
+    """A refresh failure inside the grace window must not fail the caller.
+
+    Tokens live 15 minutes and are refreshed at 10, so a blip during refresh
+    still leaves a usable token. The failure happens on the background thread
+    and is logged; the cached token stays in place, and the single-flight
+    guard is released so a later caller can retry the refresh.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "still_valid"
+        # Inside the refresh window (expires in 60s) but not yet expired.
+        expires_at = time.time() + 60
+        RDSIAMCredentialProvider._expires_at = expires_at
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "still_valid"
+            _join_refresh_thread()
+
+        # The failed refresh left the cache untouched...
+        assert RDSIAMCredentialProvider._token == "still_valid"
+        assert RDSIAMCredentialProvider._expires_at == expires_at
+        # ...and released the single-flight guard for the next attempt.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        _reset_token_cache()
+
+
+def test_failed_refresh_raises_once_the_token_has_expired():
+    """Past expiry there is nothing safe to reuse, so surface the failure."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            with pytest.raises(Exception, match="metadata endpoint timed out"):
+                RDSIAMCredentialProvider.get_token()
+    finally:
+        _reset_token_cache()
+
+
+def test_token_expiry_measured_after_the_mint():
+    """Expiry must be timed from after the fetch, not before the lock wait.
+
+    Uses a stepped clock so a slow mint is distinguishable: timing from before
+    would set expiry to 1000+900, from after to 2000+900. With a real (instant)
+    mint the two are indistinguishable, which is why the clock is stubbed.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    calls = {"n": 0}
+
+    def stepped_clock():
+        calls["n"] += 1
+        return 1000.0 if calls["n"] == 1 else 2000.0
+
+    try:
+        _reset_token_cache()
+        with patch(
+            "mwaa.utils.get_rds_iam_credentials.time.time", side_effect=stepped_clock
+        ), patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", return_value="fresh"
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert RDSIAMCredentialProvider._expires_at == 2000.0 + 15 * 60
+    finally:
+        _reset_token_cache()
+
+
+# --- Off-critical-path token refresh ---
+#
+# The 5-minute refresh buffer on the 15-minute token lifetime exists so the
+# refresh can happen without a caller paying for it. These tests pin that
+# property: a usable token is always served immediately, the refresh runs on a
+# background thread, and only a cold start or a genuinely expired token blocks
+# the caller.
+
+
+def test_due_token_is_served_immediately_and_refreshed_in_background():
+    """A caller holding a usable token must not pay for the refresh.
+
+    Regression test: get_token() used to perform the fetch on the calling
+    thread while holding the lock, so the connection that arrived at the
+    10-minute mark blocked on the ECS metadata endpoint and every other
+    caller in the process queued behind it.
+    """
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    caller = threading.current_thread()
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        # Due for refresh (fewer than 5 minutes left) but not expired.
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            # The caller is handed the cached token, not the refreshed one.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            _join_refresh_thread()
+
+        # The refresh ran on a different thread and updated the cache.
+        assert minting_thread["thread"] is not caller
+        assert RDSIAMCredentialProvider._token == "refreshed"
+        assert RDSIAMCredentialProvider._expires_at > time.time() + 14 * 60
+    finally:
+        _reset_token_cache()
+
+
+def test_background_refresh_is_single_flight():
+    """Concurrent callers noticing a due token must not multiply fetches.
+
+    Multiplying connects to the ECS credential endpoint under contention is
+    the amplification pattern identified in P481207036, so while one refresh
+    is in flight further callers must be served the cached token without
+    triggering another fetch.
+    """
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    release = threading.Event()
+    calls = []
+
+    def slow_mint():
+        calls.append(1)
+        assert release.wait(timeout=5), "test never released the mint"
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=slow_mint
+        ):
+            for _ in range(5):
+                assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            release.set()
+            _join_refresh_thread()
+
+        assert len(calls) == 1
+    finally:
+        release.set()
+        _reset_token_cache()
+
+
+def test_cold_start_fetches_synchronously():
+    """With nothing cached there is nothing to serve, so the caller waits."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        _reset_token_cache()
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_expired_token_fetches_synchronously():
+    """Past expiry the cached token is unusable, so the caller waits."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_locks_are_replaced_after_fork():
+    """A child forked while a lock is held must not inherit it locked.
+
+    Airflow forks (Celery prefork workers, DAG processors). A lock held at
+    fork time is inherited locked by the child with no thread alive to
+    release it, which would wedge every future refresh in that child.
+    """
+    from mwaa.utils import get_rds_iam_credentials as m
+
+    old_lock = m.RDSIAMCredentialProvider._lock
+    old_refresh_lock = m.RDSIAMCredentialProvider._refresh_lock
+    old_lock.acquire()
+    old_refresh_lock.acquire()
+    try:
+        m._reset_locks_after_fork()
+
+        assert m.RDSIAMCredentialProvider._lock is not old_lock
+        assert m.RDSIAMCredentialProvider._refresh_lock is not old_refresh_lock
+        # The replacements are usable.
+        assert m.RDSIAMCredentialProvider._lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._lock.release()
+        assert m.RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        old_lock.release()
+        old_refresh_lock.release()
+
+
+def test_fork_hook_is_registered_at_import():
+    """The at-fork reset must be wired up when the module is imported."""
+    import importlib
+
+    from mwaa.utils import get_rds_iam_credentials as m
+
+    try:
+        with patch("os.register_at_fork") as mock_register:
+            importlib.reload(m)
+        mock_register.assert_called_once()
+        hook = mock_register.call_args.kwargs["after_in_child"]
+        assert hook.__name__ == "_reset_locks_after_fork"
+    finally:
+        # Restore a clean module (the reload above replaced the class object).
+        importlib.reload(m)
+
+
+def test_failed_thread_start_releases_the_single_flight_guard():
+    """If the refresh thread cannot start, later callers must be able to retry."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            threading.Thread, "start", side_effect=RuntimeError("can't start new thread")
+        ):
+            # The caller is unaffected: it still gets the cached token.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+
+        # The guard was released, so the next caller can attempt the refresh.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        _reset_token_cache()

--- a/tests/images/airflow/2.11.2/python/mwaa/utils/test_get_rds_iam_credentials_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/utils/test_get_rds_iam_credentials_2_11_2.py
@@ -182,8 +182,9 @@ def test_get_token_cached():
     """Test cached token retrieval"""
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
     
+    # Set up cached token
     RDSIAMCredentialProvider._token = 'cached_token'
-    RDSIAMCredentialProvider._expires_at = time.time() + 600
+    RDSIAMCredentialProvider._expires_at = time.time() + 600  # 10 minutes from now
     
     result = RDSIAMCredentialProvider.get_token()
     assert result == 'cached_token'
@@ -193,8 +194,9 @@ def test_get_token_refresh_needed():
     """Test token refresh when expired"""
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
     
+    # Set up expired token
     RDSIAMCredentialProvider._token = 'old_token'
-    RDSIAMCredentialProvider._expires_at = time.time() - 100
+    RDSIAMCredentialProvider._expires_at = time.time() - 100  # Expired
     
     with patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value='new_token'):
         result = RDSIAMCredentialProvider.get_token()
@@ -217,14 +219,19 @@ def test_generate_credentials_success():
 
 
 def test_generate_credentials_failure():
-    """Test credential generation failure"""
+    """A failed mint must raise rather than return None.
+
+    Regression test: returning None poisoned the cache -- get_token() stored
+    the None with a full 15-minute lifetime, so every caller in the process
+    was handed an unusable credential until the entry aged out.
+    """
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
     
     with patch.object(RDSIAMCredentialProvider, 'get_ecs_credentials', side_effect=Exception("ECS error")), \
          patch('mwaa.utils.get_rds_iam_credentials.logger') as mock_logger:
         
-        result = RDSIAMCredentialProvider.generate_credentials()
-        assert result is None
+        with pytest.raises(Exception, match="ECS error"):
+            RDSIAMCredentialProvider.generate_credentials()
         mock_logger.error.assert_called_with("Failed to update credentials: ECS error")
 
 
@@ -243,25 +250,492 @@ def test_create_db_connection_url():
 
 
 def test_create_db_connection_url_generate_token():
-    """Test database connection URL creation with token generation"""
+    """The default token path must go through the thread-safe cache.
+
+    Regression test: calling generate_credentials() directly bypassed
+    get_token(), minting a fresh token (ECS metadata fetch + signed boto3 call)
+    on every connection instead of reusing the cached one.
+    """
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
-    
+
+    # Start from a cold cache; other tests in this module mutate this state.
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
     with patch.dict('os.environ', {
         'POSTGRES_HOST': 'test.rds.amazonaws.com',
         'POSTGRES_PORT': '5432',
         'POSTGRES_DB': 'airflow',
         'SSL_MODE': 'require'
     }), \
-    patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value='generated_token'):
-        
-        result = RDSIAMCredentialProvider.create_db_connection_url()
-        assert 'postgresql+psycopg2://airflow_user:generated_token@test.rds.amazonaws.com:5432/airflow?sslmode=require' in result
+    patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value='generated_token') as mock_generate:
+        expected = (
+            'postgresql+psycopg2://airflow_user:generated_token'
+            '@test.rds.amazonaws.com:5432/airflow?sslmode=require'
+        )
+
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        # Second call must be served from the cache, not mint a new token.
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        assert mock_generate.call_count == 1
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
 
 
 def test_create_db_connection_url_generation_failure():
-    """Test database connection URL creation when token generation fails"""
+    """URL creation must surface a failed mint on the default token path."""
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
-    
-    with patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value=None):
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
+    with patch.object(
+        RDSIAMCredentialProvider,
+        'generate_credentials',
+        side_effect=Exception("Failed to generate RDS auth token"),
+    ):
         with pytest.raises(Exception, match="Failed to generate RDS auth token"):
             RDSIAMCredentialProvider.create_db_connection_url()
+
+# --- ECS metadata endpoint hardening (see P481207036) ---
+
+def test_get_token_does_not_cache_a_failed_mint():
+    """A failed cold-start mint must not populate the cache.
+
+    Regression test for the None-poisoning defect: generate_credentials()
+    used to swallow failures and return None, which get_token() cached with a
+    full 15-minute lifetime -- every caller in the process was then handed an
+    unusable credential until the entry aged out. A failure must propagate
+    and leave the cache empty so the next caller retries.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = None
+        RDSIAMCredentialProvider._expires_at = 0
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            'get_ecs_credentials',
+            side_effect=Exception("ECS error"),
+        ):
+            with pytest.raises(Exception, match="ECS error"):
+                RDSIAMCredentialProvider.get_token()
+
+        # The failure left the cache empty rather than caching a dud...
+        assert RDSIAMCredentialProvider._token is None
+        assert RDSIAMCredentialProvider._expires_at == 0
+        # ...so the very next caller retries and succeeds.
+        with patch.object(
+            RDSIAMCredentialProvider, 'generate_credentials', return_value='recovered'
+        ):
+            assert RDSIAMCredentialProvider.get_token() == 'recovered'
+    finally:
+        RDSIAMCredentialProvider._token = None
+        RDSIAMCredentialProvider._expires_at = 0
+
+
+
+_ECS_ENV = {
+    "AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/abc",
+    "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/containers/test",
+}
+_CREDS = {
+    "AccessKeyId": "k",
+    "SecretAccessKey": "s",
+    "Token": "t",
+}
+
+
+def _mock_opener(side_effect=None, payload=None):
+    """Build a mock urllib opener returning payload, or raising side_effect."""
+    opener = MagicMock()
+    if side_effect is not None:
+        opener.open.side_effect = side_effect
+    else:
+        response = MagicMock()
+        response.status = 200
+        response.read.return_value = json.dumps(payload or _CREDS).encode("utf-8")
+        opener.open.return_value.__enter__.return_value = response
+    return opener
+
+
+def _reset_token_cache():
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
+
+def _join_refresh_thread():
+    """Wait for the background refresh thread so assertions are deterministic."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    thread = RDSIAMCredentialProvider._refresh_thread
+    if thread is not None:
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "background refresh did not finish"
+
+
+def test_ecs_metadata_fetch_passes_a_timeout():
+    """The fetch must be bounded; without a timeout urllib blocks indefinitely.
+
+    It runs inside the SQLAlchemy do_connect listener, so an unbounded hang
+    would stall a metadata database connection.
+    """
+    from mwaa.utils import get_rds_iam_credentials
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    _, kwargs = opener.open.call_args
+    assert kwargs.get("timeout") == get_rds_iam_credentials._METADATA_TIMEOUT_SECONDS
+    assert kwargs["timeout"] > 0
+
+
+def test_ecs_metadata_fetch_retries_transient_failure_then_succeeds():
+    """A single connect timeout must not fail the caller."""
+    import urllib.error
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    response = MagicMock()
+    response.status = 200
+    response.read.return_value = json.dumps(_CREDS).encode("utf-8")
+    ok = MagicMock()
+    ok.__enter__ = MagicMock(return_value=response)
+    ok.__exit__ = MagicMock(return_value=False)
+
+    opener = MagicMock()
+    opener.open.side_effect = [urllib.error.URLError("timed out"), ok]
+
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ), patch("tenacity.nap.time.sleep"):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    assert opener.open.call_count == 2
+
+
+def test_ecs_metadata_fetch_does_not_retry_config_errors():
+    """A missing environment variable is not transient; fail immediately."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", {}, clear=True), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        with pytest.raises(ValueError):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+    opener.open.assert_not_called()
+
+
+def test_transient_error_classification():
+    """429 and 5xx are retryable; 4xx client errors are not."""
+    import urllib.error
+
+    from mwaa.utils.get_rds_iam_credentials import _is_transient_metadata_error
+
+    def http(code):
+        return urllib.error.HTTPError("u", code, "msg", None, None)
+
+    assert _is_transient_metadata_error(http(429)) is True
+    assert _is_transient_metadata_error(http(503)) is True
+    assert _is_transient_metadata_error(http(500)) is True
+    assert _is_transient_metadata_error(http(404)) is False
+    assert _is_transient_metadata_error(http(403)) is False
+    assert _is_transient_metadata_error(urllib.error.URLError("boom")) is True
+    assert _is_transient_metadata_error(TimeoutError()) is True
+    assert _is_transient_metadata_error(ConnectionResetError()) is True
+    assert _is_transient_metadata_error(ValueError("config")) is False
+
+
+def test_failed_refresh_reuses_a_still_valid_cached_token():
+    """A refresh failure inside the grace window must not fail the caller.
+
+    Tokens live 15 minutes and are refreshed at 10, so a blip during refresh
+    still leaves a usable token. The failure happens on the background thread
+    and is logged; the cached token stays in place, and the single-flight
+    guard is released so a later caller can retry the refresh.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "still_valid"
+        # Inside the refresh window (expires in 60s) but not yet expired.
+        expires_at = time.time() + 60
+        RDSIAMCredentialProvider._expires_at = expires_at
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "still_valid"
+            _join_refresh_thread()
+
+        # The failed refresh left the cache untouched...
+        assert RDSIAMCredentialProvider._token == "still_valid"
+        assert RDSIAMCredentialProvider._expires_at == expires_at
+        # ...and released the single-flight guard for the next attempt.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        _reset_token_cache()
+
+
+def test_failed_refresh_raises_once_the_token_has_expired():
+    """Past expiry there is nothing safe to reuse, so surface the failure."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            with pytest.raises(Exception, match="metadata endpoint timed out"):
+                RDSIAMCredentialProvider.get_token()
+    finally:
+        _reset_token_cache()
+
+
+def test_token_expiry_measured_after_the_mint():
+    """Expiry must be timed from after the fetch, not before the lock wait.
+
+    Uses a stepped clock so a slow mint is distinguishable: timing from before
+    would set expiry to 1000+900, from after to 2000+900. With a real (instant)
+    mint the two are indistinguishable, which is why the clock is stubbed.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    calls = {"n": 0}
+
+    def stepped_clock():
+        calls["n"] += 1
+        return 1000.0 if calls["n"] == 1 else 2000.0
+
+    try:
+        _reset_token_cache()
+        with patch(
+            "mwaa.utils.get_rds_iam_credentials.time.time", side_effect=stepped_clock
+        ), patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", return_value="fresh"
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert RDSIAMCredentialProvider._expires_at == 2000.0 + 15 * 60
+    finally:
+        _reset_token_cache()
+
+
+# --- Off-critical-path token refresh ---
+#
+# The 5-minute refresh buffer on the 15-minute token lifetime exists so the
+# refresh can happen without a caller paying for it. These tests pin that
+# property: a usable token is always served immediately, the refresh runs on a
+# background thread, and only a cold start or a genuinely expired token blocks
+# the caller.
+
+
+def test_due_token_is_served_immediately_and_refreshed_in_background():
+    """A caller holding a usable token must not pay for the refresh.
+
+    Regression test: get_token() used to perform the fetch on the calling
+    thread while holding the lock, so the connection that arrived at the
+    10-minute mark blocked on the ECS metadata endpoint and every other
+    caller in the process queued behind it.
+    """
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    caller = threading.current_thread()
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        # Due for refresh (fewer than 5 minutes left) but not expired.
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            # The caller is handed the cached token, not the refreshed one.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            _join_refresh_thread()
+
+        # The refresh ran on a different thread and updated the cache.
+        assert minting_thread["thread"] is not caller
+        assert RDSIAMCredentialProvider._token == "refreshed"
+        assert RDSIAMCredentialProvider._expires_at > time.time() + 14 * 60
+    finally:
+        _reset_token_cache()
+
+
+def test_background_refresh_is_single_flight():
+    """Concurrent callers noticing a due token must not multiply fetches.
+
+    Multiplying connects to the ECS credential endpoint under contention is
+    the amplification pattern identified in P481207036, so while one refresh
+    is in flight further callers must be served the cached token without
+    triggering another fetch.
+    """
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    release = threading.Event()
+    calls = []
+
+    def slow_mint():
+        calls.append(1)
+        assert release.wait(timeout=5), "test never released the mint"
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=slow_mint
+        ):
+            for _ in range(5):
+                assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            release.set()
+            _join_refresh_thread()
+
+        assert len(calls) == 1
+    finally:
+        release.set()
+        _reset_token_cache()
+
+
+def test_cold_start_fetches_synchronously():
+    """With nothing cached there is nothing to serve, so the caller waits."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        _reset_token_cache()
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_expired_token_fetches_synchronously():
+    """Past expiry the cached token is unusable, so the caller waits."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_locks_are_replaced_after_fork():
+    """A child forked while a lock is held must not inherit it locked.
+
+    Airflow forks (Celery prefork workers, DAG processors). A lock held at
+    fork time is inherited locked by the child with no thread alive to
+    release it, which would wedge every future refresh in that child.
+    """
+    from mwaa.utils import get_rds_iam_credentials as m
+
+    old_lock = m.RDSIAMCredentialProvider._lock
+    old_refresh_lock = m.RDSIAMCredentialProvider._refresh_lock
+    old_lock.acquire()
+    old_refresh_lock.acquire()
+    try:
+        m._reset_locks_after_fork()
+
+        assert m.RDSIAMCredentialProvider._lock is not old_lock
+        assert m.RDSIAMCredentialProvider._refresh_lock is not old_refresh_lock
+        # The replacements are usable.
+        assert m.RDSIAMCredentialProvider._lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._lock.release()
+        assert m.RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        old_lock.release()
+        old_refresh_lock.release()
+
+
+def test_fork_hook_is_registered_at_import():
+    """The at-fork reset must be wired up when the module is imported."""
+    import importlib
+
+    from mwaa.utils import get_rds_iam_credentials as m
+
+    try:
+        with patch("os.register_at_fork") as mock_register:
+            importlib.reload(m)
+        mock_register.assert_called_once()
+        hook = mock_register.call_args.kwargs["after_in_child"]
+        assert hook.__name__ == "_reset_locks_after_fork"
+    finally:
+        # Restore a clean module (the reload above replaced the class object).
+        importlib.reload(m)
+
+
+def test_failed_thread_start_releases_the_single_flight_guard():
+    """If the refresh thread cannot start, later callers must be able to retry."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            threading.Thread, "start", side_effect=RuntimeError("can't start new thread")
+        ):
+            # The caller is unaffected: it still gets the cached token.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+
+        # The guard was released, so the next caller can attempt the refresh.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        _reset_token_cache()

--- a/tests/images/airflow/2.9.2/python/mwaa/utils/test_get_rds_iam_credentials_2_9_2.py
+++ b/tests/images/airflow/2.9.2/python/mwaa/utils/test_get_rds_iam_credentials_2_9_2.py
@@ -219,14 +219,19 @@ def test_generate_credentials_success():
 
 
 def test_generate_credentials_failure():
-    """Test credential generation failure"""
+    """A failed mint must raise rather than return None.
+
+    Regression test: returning None poisoned the cache -- get_token() stored
+    the None with a full 15-minute lifetime, so every caller in the process
+    was handed an unusable credential until the entry aged out.
+    """
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
     
     with patch.object(RDSIAMCredentialProvider, 'get_ecs_credentials', side_effect=Exception("ECS error")), \
          patch('mwaa.utils.get_rds_iam_credentials.logger') as mock_logger:
         
-        result = RDSIAMCredentialProvider.generate_credentials()
-        assert result is None
+        with pytest.raises(Exception, match="ECS error"):
+            RDSIAMCredentialProvider.generate_credentials()
         mock_logger.error.assert_called_with("Failed to update credentials: ECS error")
 
 
@@ -245,25 +250,492 @@ def test_create_db_connection_url():
 
 
 def test_create_db_connection_url_generate_token():
-    """Test database connection URL creation with token generation"""
+    """The default token path must go through the thread-safe cache.
+
+    Regression test: calling generate_credentials() directly bypassed
+    get_token(), minting a fresh token (ECS metadata fetch + signed boto3 call)
+    on every connection instead of reusing the cached one.
+    """
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
-    
+
+    # Start from a cold cache; other tests in this module mutate this state.
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
     with patch.dict('os.environ', {
         'POSTGRES_HOST': 'test.rds.amazonaws.com',
         'POSTGRES_PORT': '5432',
         'POSTGRES_DB': 'airflow',
         'SSL_MODE': 'require'
     }), \
-    patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value='generated_token'):
-        
-        result = RDSIAMCredentialProvider.create_db_connection_url()
-        assert 'postgresql+psycopg2://airflow_user:generated_token@test.rds.amazonaws.com:5432/airflow?sslmode=require' in result
+    patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value='generated_token') as mock_generate:
+        expected = (
+            'postgresql+psycopg2://airflow_user:generated_token'
+            '@test.rds.amazonaws.com:5432/airflow?sslmode=require'
+        )
+
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        # Second call must be served from the cache, not mint a new token.
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        assert mock_generate.call_count == 1
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
 
 
 def test_create_db_connection_url_generation_failure():
-    """Test database connection URL creation when token generation fails"""
+    """URL creation must surface a failed mint on the default token path."""
     from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
-    
-    with patch.object(RDSIAMCredentialProvider, 'generate_credentials', return_value=None):
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
+    with patch.object(
+        RDSIAMCredentialProvider,
+        'generate_credentials',
+        side_effect=Exception("Failed to generate RDS auth token"),
+    ):
         with pytest.raises(Exception, match="Failed to generate RDS auth token"):
             RDSIAMCredentialProvider.create_db_connection_url()
+
+# --- ECS metadata endpoint hardening (see P481207036) ---
+
+def test_get_token_does_not_cache_a_failed_mint():
+    """A failed cold-start mint must not populate the cache.
+
+    Regression test for the None-poisoning defect: generate_credentials()
+    used to swallow failures and return None, which get_token() cached with a
+    full 15-minute lifetime -- every caller in the process was then handed an
+    unusable credential until the entry aged out. A failure must propagate
+    and leave the cache empty so the next caller retries.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = None
+        RDSIAMCredentialProvider._expires_at = 0
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            'get_ecs_credentials',
+            side_effect=Exception("ECS error"),
+        ):
+            with pytest.raises(Exception, match="ECS error"):
+                RDSIAMCredentialProvider.get_token()
+
+        # The failure left the cache empty rather than caching a dud...
+        assert RDSIAMCredentialProvider._token is None
+        assert RDSIAMCredentialProvider._expires_at == 0
+        # ...so the very next caller retries and succeeds.
+        with patch.object(
+            RDSIAMCredentialProvider, 'generate_credentials', return_value='recovered'
+        ):
+            assert RDSIAMCredentialProvider.get_token() == 'recovered'
+    finally:
+        RDSIAMCredentialProvider._token = None
+        RDSIAMCredentialProvider._expires_at = 0
+
+
+
+_ECS_ENV = {
+    "AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/abc",
+    "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/containers/test",
+}
+_CREDS = {
+    "AccessKeyId": "k",
+    "SecretAccessKey": "s",
+    "Token": "t",
+}
+
+
+def _mock_opener(side_effect=None, payload=None):
+    """Build a mock urllib opener returning payload, or raising side_effect."""
+    opener = MagicMock()
+    if side_effect is not None:
+        opener.open.side_effect = side_effect
+    else:
+        response = MagicMock()
+        response.status = 200
+        response.read.return_value = json.dumps(payload or _CREDS).encode("utf-8")
+        opener.open.return_value.__enter__.return_value = response
+    return opener
+
+
+def _reset_token_cache():
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
+
+def _join_refresh_thread():
+    """Wait for the background refresh thread so assertions are deterministic."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    thread = RDSIAMCredentialProvider._refresh_thread
+    if thread is not None:
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "background refresh did not finish"
+
+
+def test_ecs_metadata_fetch_passes_a_timeout():
+    """The fetch must be bounded; without a timeout urllib blocks indefinitely.
+
+    It runs inside the SQLAlchemy do_connect listener, so an unbounded hang
+    would stall a metadata database connection.
+    """
+    from mwaa.utils import get_rds_iam_credentials
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    _, kwargs = opener.open.call_args
+    assert kwargs.get("timeout") == get_rds_iam_credentials._METADATA_TIMEOUT_SECONDS
+    assert kwargs["timeout"] > 0
+
+
+def test_ecs_metadata_fetch_retries_transient_failure_then_succeeds():
+    """A single connect timeout must not fail the caller."""
+    import urllib.error
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    response = MagicMock()
+    response.status = 200
+    response.read.return_value = json.dumps(_CREDS).encode("utf-8")
+    ok = MagicMock()
+    ok.__enter__ = MagicMock(return_value=response)
+    ok.__exit__ = MagicMock(return_value=False)
+
+    opener = MagicMock()
+    opener.open.side_effect = [urllib.error.URLError("timed out"), ok]
+
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ), patch("tenacity.nap.time.sleep"):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    assert opener.open.call_count == 2
+
+
+def test_ecs_metadata_fetch_does_not_retry_config_errors():
+    """A missing environment variable is not transient; fail immediately."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", {}, clear=True), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        with pytest.raises(ValueError):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+    opener.open.assert_not_called()
+
+
+def test_transient_error_classification():
+    """429 and 5xx are retryable; 4xx client errors are not."""
+    import urllib.error
+
+    from mwaa.utils.get_rds_iam_credentials import _is_transient_metadata_error
+
+    def http(code):
+        return urllib.error.HTTPError("u", code, "msg", None, None)
+
+    assert _is_transient_metadata_error(http(429)) is True
+    assert _is_transient_metadata_error(http(503)) is True
+    assert _is_transient_metadata_error(http(500)) is True
+    assert _is_transient_metadata_error(http(404)) is False
+    assert _is_transient_metadata_error(http(403)) is False
+    assert _is_transient_metadata_error(urllib.error.URLError("boom")) is True
+    assert _is_transient_metadata_error(TimeoutError()) is True
+    assert _is_transient_metadata_error(ConnectionResetError()) is True
+    assert _is_transient_metadata_error(ValueError("config")) is False
+
+
+def test_failed_refresh_reuses_a_still_valid_cached_token():
+    """A refresh failure inside the grace window must not fail the caller.
+
+    Tokens live 15 minutes and are refreshed at 10, so a blip during refresh
+    still leaves a usable token. The failure happens on the background thread
+    and is logged; the cached token stays in place, and the single-flight
+    guard is released so a later caller can retry the refresh.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "still_valid"
+        # Inside the refresh window (expires in 60s) but not yet expired.
+        expires_at = time.time() + 60
+        RDSIAMCredentialProvider._expires_at = expires_at
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "still_valid"
+            _join_refresh_thread()
+
+        # The failed refresh left the cache untouched...
+        assert RDSIAMCredentialProvider._token == "still_valid"
+        assert RDSIAMCredentialProvider._expires_at == expires_at
+        # ...and released the single-flight guard for the next attempt.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        _reset_token_cache()
+
+
+def test_failed_refresh_raises_once_the_token_has_expired():
+    """Past expiry there is nothing safe to reuse, so surface the failure."""
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            with pytest.raises(Exception, match="metadata endpoint timed out"):
+                RDSIAMCredentialProvider.get_token()
+    finally:
+        _reset_token_cache()
+
+
+def test_token_expiry_measured_after_the_mint():
+    """Expiry must be timed from after the fetch, not before the lock wait.
+
+    Uses a stepped clock so a slow mint is distinguishable: timing from before
+    would set expiry to 1000+900, from after to 2000+900. With a real (instant)
+    mint the two are indistinguishable, which is why the clock is stubbed.
+    """
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    calls = {"n": 0}
+
+    def stepped_clock():
+        calls["n"] += 1
+        return 1000.0 if calls["n"] == 1 else 2000.0
+
+    try:
+        _reset_token_cache()
+        with patch(
+            "mwaa.utils.get_rds_iam_credentials.time.time", side_effect=stepped_clock
+        ), patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", return_value="fresh"
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert RDSIAMCredentialProvider._expires_at == 2000.0 + 15 * 60
+    finally:
+        _reset_token_cache()
+
+
+# --- Off-critical-path token refresh ---
+#
+# The 5-minute refresh buffer on the 15-minute token lifetime exists so the
+# refresh can happen without a caller paying for it. These tests pin that
+# property: a usable token is always served immediately, the refresh runs on a
+# background thread, and only a cold start or a genuinely expired token blocks
+# the caller.
+
+
+def test_due_token_is_served_immediately_and_refreshed_in_background():
+    """A caller holding a usable token must not pay for the refresh.
+
+    Regression test: get_token() used to perform the fetch on the calling
+    thread while holding the lock, so the connection that arrived at the
+    10-minute mark blocked on the ECS metadata endpoint and every other
+    caller in the process queued behind it.
+    """
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    caller = threading.current_thread()
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        # Due for refresh (fewer than 5 minutes left) but not expired.
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            # The caller is handed the cached token, not the refreshed one.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            _join_refresh_thread()
+
+        # The refresh ran on a different thread and updated the cache.
+        assert minting_thread["thread"] is not caller
+        assert RDSIAMCredentialProvider._token == "refreshed"
+        assert RDSIAMCredentialProvider._expires_at > time.time() + 14 * 60
+    finally:
+        _reset_token_cache()
+
+
+def test_background_refresh_is_single_flight():
+    """Concurrent callers noticing a due token must not multiply fetches.
+
+    Multiplying connects to the ECS credential endpoint under contention is
+    the amplification pattern identified in P481207036, so while one refresh
+    is in flight further callers must be served the cached token without
+    triggering another fetch.
+    """
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    release = threading.Event()
+    calls = []
+
+    def slow_mint():
+        calls.append(1)
+        assert release.wait(timeout=5), "test never released the mint"
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=slow_mint
+        ):
+            for _ in range(5):
+                assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            release.set()
+            _join_refresh_thread()
+
+        assert len(calls) == 1
+    finally:
+        release.set()
+        _reset_token_cache()
+
+
+def test_cold_start_fetches_synchronously():
+    """With nothing cached there is nothing to serve, so the caller waits."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        _reset_token_cache()
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_expired_token_fetches_synchronously():
+    """Past expiry the cached token is unusable, so the caller waits."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_locks_are_replaced_after_fork():
+    """A child forked while a lock is held must not inherit it locked.
+
+    Airflow forks (Celery prefork workers, DAG processors). A lock held at
+    fork time is inherited locked by the child with no thread alive to
+    release it, which would wedge every future refresh in that child.
+    """
+    from mwaa.utils import get_rds_iam_credentials as m
+
+    old_lock = m.RDSIAMCredentialProvider._lock
+    old_refresh_lock = m.RDSIAMCredentialProvider._refresh_lock
+    old_lock.acquire()
+    old_refresh_lock.acquire()
+    try:
+        m._reset_locks_after_fork()
+
+        assert m.RDSIAMCredentialProvider._lock is not old_lock
+        assert m.RDSIAMCredentialProvider._refresh_lock is not old_refresh_lock
+        # The replacements are usable.
+        assert m.RDSIAMCredentialProvider._lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._lock.release()
+        assert m.RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        old_lock.release()
+        old_refresh_lock.release()
+
+
+def test_fork_hook_is_registered_at_import():
+    """The at-fork reset must be wired up when the module is imported."""
+    import importlib
+
+    from mwaa.utils import get_rds_iam_credentials as m
+
+    try:
+        with patch("os.register_at_fork") as mock_register:
+            importlib.reload(m)
+        mock_register.assert_called_once()
+        hook = mock_register.call_args.kwargs["after_in_child"]
+        assert hook.__name__ == "_reset_locks_after_fork"
+    finally:
+        # Restore a clean module (the reload above replaced the class object).
+        importlib.reload(m)
+
+
+def test_failed_thread_start_releases_the_single_flight_guard():
+    """If the refresh thread cannot start, later callers must be able to retry."""
+    import threading
+
+    from mwaa.utils.get_rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            threading.Thread, "start", side_effect=RuntimeError("can't start new thread")
+        ):
+            # The caller is unaffected: it still gets the cached token.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+
+        # The guard was released, so the next caller can attempt the refresh.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        _reset_token_cache()

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_credentials_3_0_6.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_credentials_3_0_6.py
@@ -338,6 +338,16 @@ def _reset_token_cache():
     RDSIAMCredentialProvider._expires_at = 0
 
 
+def _join_refresh_thread():
+    """Wait for the background refresh thread so assertions are deterministic."""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    thread = RDSIAMCredentialProvider._refresh_thread
+    if thread is not None:
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "background refresh did not finish"
+
+
 def test_ecs_metadata_fetch_passes_a_timeout():
     """The fetch must be bounded; without a timeout urllib blocks indefinitely.
 
@@ -418,14 +428,17 @@ def test_failed_refresh_reuses_a_still_valid_cached_token():
     """A refresh failure inside the grace window must not fail the caller.
 
     Tokens live 15 minutes and are refreshed at 10, so a blip during refresh
-    still leaves a usable token.
+    still leaves a usable token. The failure happens on the background thread
+    and is logged; the cached token stays in place, and the single-flight
+    guard is released so a later caller can retry the refresh.
     """
     from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
 
     try:
         RDSIAMCredentialProvider._token = "still_valid"
         # Inside the refresh window (expires in 60s) but not yet expired.
-        RDSIAMCredentialProvider._expires_at = time.time() + 60
+        expires_at = time.time() + 60
+        RDSIAMCredentialProvider._expires_at = expires_at
 
         with patch.object(
             RDSIAMCredentialProvider,
@@ -433,6 +446,14 @@ def test_failed_refresh_reuses_a_still_valid_cached_token():
             side_effect=Exception("metadata endpoint timed out"),
         ):
             assert RDSIAMCredentialProvider.get_token() == "still_valid"
+            _join_refresh_thread()
+
+        # The failed refresh left the cache untouched...
+        assert RDSIAMCredentialProvider._token == "still_valid"
+        assert RDSIAMCredentialProvider._expires_at == expires_at
+        # ...and released the single-flight guard for the next attempt.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
     finally:
         _reset_token_cache()
 
@@ -481,5 +502,209 @@ def test_token_expiry_measured_after_the_mint():
             assert RDSIAMCredentialProvider.get_token() == "fresh"
 
         assert RDSIAMCredentialProvider._expires_at == 2000.0 + 15 * 60
+    finally:
+        _reset_token_cache()
+
+
+# --- Off-critical-path token refresh ---
+#
+# The 5-minute refresh buffer on the 15-minute token lifetime exists so the
+# refresh can happen without a caller paying for it. These tests pin that
+# property: a usable token is always served immediately, the refresh runs on a
+# background thread, and only a cold start or a genuinely expired token blocks
+# the caller.
+
+
+def test_due_token_is_served_immediately_and_refreshed_in_background():
+    """A caller holding a usable token must not pay for the refresh.
+
+    Regression test: get_token() used to perform the fetch on the calling
+    thread while holding the lock, so the connection that arrived at the
+    10-minute mark blocked on the ECS metadata endpoint and every other
+    caller in the process queued behind it.
+    """
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    caller = threading.current_thread()
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        # Due for refresh (fewer than 5 minutes left) but not expired.
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            # The caller is handed the cached token, not the refreshed one.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            _join_refresh_thread()
+
+        # The refresh ran on a different thread and updated the cache.
+        assert minting_thread["thread"] is not caller
+        assert RDSIAMCredentialProvider._token == "refreshed"
+        assert RDSIAMCredentialProvider._expires_at > time.time() + 14 * 60
+    finally:
+        _reset_token_cache()
+
+
+def test_background_refresh_is_single_flight():
+    """Concurrent callers noticing a due token must not multiply fetches.
+
+    Multiplying connects to the ECS credential endpoint under contention is
+    the amplification pattern identified in P481207036, so while one refresh
+    is in flight further callers must be served the cached token without
+    triggering another fetch.
+    """
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    release = threading.Event()
+    calls = []
+
+    def slow_mint():
+        calls.append(1)
+        assert release.wait(timeout=5), "test never released the mint"
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=slow_mint
+        ):
+            for _ in range(5):
+                assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            release.set()
+            _join_refresh_thread()
+
+        assert len(calls) == 1
+    finally:
+        release.set()
+        _reset_token_cache()
+
+
+def test_cold_start_fetches_synchronously():
+    """With nothing cached there is nothing to serve, so the caller waits."""
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        _reset_token_cache()
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_expired_token_fetches_synchronously():
+    """Past expiry the cached token is unusable, so the caller waits."""
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_locks_are_replaced_after_fork():
+    """A child forked while a lock is held must not inherit it locked.
+
+    Airflow forks (Celery prefork workers, DAG processors). A lock held at
+    fork time is inherited locked by the child with no thread alive to
+    release it, which would wedge every future refresh in that child.
+    """
+    from mwaa.config import rds_iam_credentials as m
+
+    old_lock = m.RDSIAMCredentialProvider._lock
+    old_refresh_lock = m.RDSIAMCredentialProvider._refresh_lock
+    old_lock.acquire()
+    old_refresh_lock.acquire()
+    try:
+        m._reset_locks_after_fork()
+
+        assert m.RDSIAMCredentialProvider._lock is not old_lock
+        assert m.RDSIAMCredentialProvider._refresh_lock is not old_refresh_lock
+        # The replacements are usable.
+        assert m.RDSIAMCredentialProvider._lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._lock.release()
+        assert m.RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        old_lock.release()
+        old_refresh_lock.release()
+
+
+def test_fork_hook_is_registered_at_import():
+    """The at-fork reset must be wired up when the module is imported."""
+    import importlib
+
+    from mwaa.config import rds_iam_credentials as m
+
+    try:
+        with patch("os.register_at_fork") as mock_register:
+            importlib.reload(m)
+        mock_register.assert_called_once()
+        hook = mock_register.call_args.kwargs["after_in_child"]
+        assert hook.__name__ == "_reset_locks_after_fork"
+    finally:
+        # Restore a clean module (the reload above replaced the class object).
+        importlib.reload(m)
+
+
+def test_failed_thread_start_releases_the_single_flight_guard():
+    """If the refresh thread cannot start, later callers must be able to retry."""
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            threading.Thread, "start", side_effect=RuntimeError("can't start new thread")
+        ):
+            # The caller is unaffected: it still gets the cached token.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+
+        # The guard was released, so the next caller can attempt the refresh.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
     finally:
         _reset_token_cache()

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_credentials_3_0_6.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_credentials_3_0_6.py
@@ -288,3 +288,182 @@ def test_is_using_rds_proxy():
 
     with patch.dict("os.environ", {}, clear=True):
         assert is_using_rds_proxy() is False
+
+
+# --- ECS metadata endpoint hardening (see P481207036) ---
+
+_ECS_ENV = {
+    "AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/abc",
+    "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/containers/test",
+}
+_CREDS = {
+    "AccessKeyId": "k",
+    "SecretAccessKey": "s",
+    "Token": "t",
+}
+
+
+def _mock_opener(side_effect=None, payload=None):
+    """Build a mock urllib opener returning payload, or raising side_effect."""
+    opener = MagicMock()
+    if side_effect is not None:
+        opener.open.side_effect = side_effect
+    else:
+        response = MagicMock()
+        response.read.return_value = json.dumps(payload or _CREDS).encode("utf-8")
+        opener.open.return_value.__enter__.return_value = response
+    return opener
+
+
+def _reset_token_cache():
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
+
+def test_ecs_metadata_fetch_passes_a_timeout():
+    """The fetch must be bounded; without a timeout urllib blocks indefinitely.
+
+    It runs inside the SQLAlchemy do_connect listener, so an unbounded hang
+    would stall a metadata database connection.
+    """
+    from mwaa.config import rds_iam_credentials
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    _, kwargs = opener.open.call_args
+    assert kwargs.get("timeout") == rds_iam_credentials._METADATA_TIMEOUT_SECONDS
+    assert kwargs["timeout"] > 0
+
+
+def test_ecs_metadata_fetch_retries_transient_failure_then_succeeds():
+    """A single connect timeout must not fail the caller."""
+    import urllib.error
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    response = MagicMock()
+    response.read.return_value = json.dumps(_CREDS).encode("utf-8")
+    ok = MagicMock()
+    ok.__enter__ = MagicMock(return_value=response)
+    ok.__exit__ = MagicMock(return_value=False)
+
+    opener = MagicMock()
+    opener.open.side_effect = [urllib.error.URLError("timed out"), ok]
+
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ), patch("tenacity.nap.time.sleep"):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    assert opener.open.call_count == 2
+
+
+def test_ecs_metadata_fetch_does_not_retry_config_errors():
+    """A missing environment variable is not transient; fail immediately."""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", {}, clear=True), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        with pytest.raises(ValueError):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+    opener.open.assert_not_called()
+
+
+def test_transient_error_classification():
+    """429 and 5xx are retryable; 4xx client errors are not."""
+    import urllib.error
+
+    from mwaa.config.rds_iam_credentials import _is_transient_metadata_error
+
+    def http(code):
+        return urllib.error.HTTPError("u", code, "msg", None, None)
+
+    assert _is_transient_metadata_error(http(429)) is True
+    assert _is_transient_metadata_error(http(503)) is True
+    assert _is_transient_metadata_error(http(500)) is True
+    assert _is_transient_metadata_error(http(404)) is False
+    assert _is_transient_metadata_error(http(403)) is False
+    assert _is_transient_metadata_error(urllib.error.URLError("boom")) is True
+    assert _is_transient_metadata_error(TimeoutError()) is True
+    assert _is_transient_metadata_error(ConnectionResetError()) is True
+    assert _is_transient_metadata_error(ValueError("config")) is False
+
+
+def test_failed_refresh_reuses_a_still_valid_cached_token():
+    """A refresh failure inside the grace window must not fail the caller.
+
+    Tokens live 15 minutes and are refreshed at 10, so a blip during refresh
+    still leaves a usable token.
+    """
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "still_valid"
+        # Inside the refresh window (expires in 60s) but not yet expired.
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "still_valid"
+    finally:
+        _reset_token_cache()
+
+
+def test_failed_refresh_raises_once_the_token_has_expired():
+    """Past expiry there is nothing safe to reuse, so surface the failure."""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            with pytest.raises(Exception, match="metadata endpoint timed out"):
+                RDSIAMCredentialProvider.get_token()
+    finally:
+        _reset_token_cache()
+
+
+def test_token_expiry_measured_after_the_mint():
+    """Expiry must be timed from after the fetch, not before the lock wait.
+
+    Uses a stepped clock so a slow mint is distinguishable: timing from before
+    would set expiry to 1000+900, from after to 2000+900. With a real (instant)
+    mint the two are indistinguishable, which is why the clock is stubbed.
+    """
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    calls = {"n": 0}
+
+    def stepped_clock():
+        calls["n"] += 1
+        return 1000.0 if calls["n"] == 1 else 2000.0
+
+    try:
+        _reset_token_cache()
+        with patch(
+            "mwaa.config.rds_iam_credentials.time.time", side_effect=stepped_clock
+        ), patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", return_value="fresh"
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert RDSIAMCredentialProvider._expires_at == 2000.0 + 15 * 60
+    finally:
+        _reset_token_cache()

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_credentials_3_0_6.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_credentials_3_0_6.py
@@ -241,8 +241,17 @@ def test_create_db_connection_url():
 
 
 def test_create_db_connection_url_generate_token():
-    """Test database connection URL creation with token generation"""
+    """The default token path must go through the thread-safe cache.
+
+    Regression test: calling generate_credentials() directly bypassed
+    get_token(), minting a fresh token (ECS metadata fetch + signed boto3 call)
+    on every connection instead of reusing the cached one.
+    """
     from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    # Start from a cold cache; other tests in this module mutate this state.
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
 
     with patch.dict(
         "os.environ",
@@ -254,12 +263,19 @@ def test_create_db_connection_url_generate_token():
         },
     ), patch.object(
         RDSIAMCredentialProvider, "generate_credentials", return_value="generated_token"
-    ):
-        result = RDSIAMCredentialProvider.create_db_connection_url()
-        assert (
+    ) as mock_generate:
+        expected = (
             "postgresql+psycopg2://airflow_user:generated_token"
-            "@test.rds.amazonaws.com:5432/airflow?sslmode=require" in result
+            "@test.rds.amazonaws.com:5432/airflow?sslmode=require"
         )
+
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        # Second call must be served from the cache, not mint a new token.
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        assert mock_generate.call_count == 1
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
 
 
 def test_use_iam_credentials():

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_credentials_3_2_1.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_credentials_3_2_1.py
@@ -338,6 +338,16 @@ def _reset_token_cache():
     RDSIAMCredentialProvider._expires_at = 0
 
 
+def _join_refresh_thread():
+    """Wait for the background refresh thread so assertions are deterministic."""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    thread = RDSIAMCredentialProvider._refresh_thread
+    if thread is not None:
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "background refresh did not finish"
+
+
 def test_ecs_metadata_fetch_passes_a_timeout():
     """The fetch must be bounded; without a timeout urllib blocks indefinitely.
 
@@ -418,14 +428,17 @@ def test_failed_refresh_reuses_a_still_valid_cached_token():
     """A refresh failure inside the grace window must not fail the caller.
 
     Tokens live 15 minutes and are refreshed at 10, so a blip during refresh
-    still leaves a usable token.
+    still leaves a usable token. The failure happens on the background thread
+    and is logged; the cached token stays in place, and the single-flight
+    guard is released so a later caller can retry the refresh.
     """
     from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
 
     try:
         RDSIAMCredentialProvider._token = "still_valid"
         # Inside the refresh window (expires in 60s) but not yet expired.
-        RDSIAMCredentialProvider._expires_at = time.time() + 60
+        expires_at = time.time() + 60
+        RDSIAMCredentialProvider._expires_at = expires_at
 
         with patch.object(
             RDSIAMCredentialProvider,
@@ -433,6 +446,14 @@ def test_failed_refresh_reuses_a_still_valid_cached_token():
             side_effect=Exception("metadata endpoint timed out"),
         ):
             assert RDSIAMCredentialProvider.get_token() == "still_valid"
+            _join_refresh_thread()
+
+        # The failed refresh left the cache untouched...
+        assert RDSIAMCredentialProvider._token == "still_valid"
+        assert RDSIAMCredentialProvider._expires_at == expires_at
+        # ...and released the single-flight guard for the next attempt.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
     finally:
         _reset_token_cache()
 
@@ -481,5 +502,209 @@ def test_token_expiry_measured_after_the_mint():
             assert RDSIAMCredentialProvider.get_token() == "fresh"
 
         assert RDSIAMCredentialProvider._expires_at == 2000.0 + 15 * 60
+    finally:
+        _reset_token_cache()
+
+
+# --- Off-critical-path token refresh ---
+#
+# The 5-minute refresh buffer on the 15-minute token lifetime exists so the
+# refresh can happen without a caller paying for it. These tests pin that
+# property: a usable token is always served immediately, the refresh runs on a
+# background thread, and only a cold start or a genuinely expired token blocks
+# the caller.
+
+
+def test_due_token_is_served_immediately_and_refreshed_in_background():
+    """A caller holding a usable token must not pay for the refresh.
+
+    Regression test: get_token() used to perform the fetch on the calling
+    thread while holding the lock, so the connection that arrived at the
+    10-minute mark blocked on the ECS metadata endpoint and every other
+    caller in the process queued behind it.
+    """
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    caller = threading.current_thread()
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        # Due for refresh (fewer than 5 minutes left) but not expired.
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            # The caller is handed the cached token, not the refreshed one.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            _join_refresh_thread()
+
+        # The refresh ran on a different thread and updated the cache.
+        assert minting_thread["thread"] is not caller
+        assert RDSIAMCredentialProvider._token == "refreshed"
+        assert RDSIAMCredentialProvider._expires_at > time.time() + 14 * 60
+    finally:
+        _reset_token_cache()
+
+
+def test_background_refresh_is_single_flight():
+    """Concurrent callers noticing a due token must not multiply fetches.
+
+    Multiplying connects to the ECS credential endpoint under contention is
+    the amplification pattern identified in P481207036, so while one refresh
+    is in flight further callers must be served the cached token without
+    triggering another fetch.
+    """
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    release = threading.Event()
+    calls = []
+
+    def slow_mint():
+        calls.append(1)
+        assert release.wait(timeout=5), "test never released the mint"
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=slow_mint
+        ):
+            for _ in range(5):
+                assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            release.set()
+            _join_refresh_thread()
+
+        assert len(calls) == 1
+    finally:
+        release.set()
+        _reset_token_cache()
+
+
+def test_cold_start_fetches_synchronously():
+    """With nothing cached there is nothing to serve, so the caller waits."""
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        _reset_token_cache()
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_expired_token_fetches_synchronously():
+    """Past expiry the cached token is unusable, so the caller waits."""
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_locks_are_replaced_after_fork():
+    """A child forked while a lock is held must not inherit it locked.
+
+    Airflow forks (Celery prefork workers, DAG processors). A lock held at
+    fork time is inherited locked by the child with no thread alive to
+    release it, which would wedge every future refresh in that child.
+    """
+    from mwaa.config import rds_iam_credentials as m
+
+    old_lock = m.RDSIAMCredentialProvider._lock
+    old_refresh_lock = m.RDSIAMCredentialProvider._refresh_lock
+    old_lock.acquire()
+    old_refresh_lock.acquire()
+    try:
+        m._reset_locks_after_fork()
+
+        assert m.RDSIAMCredentialProvider._lock is not old_lock
+        assert m.RDSIAMCredentialProvider._refresh_lock is not old_refresh_lock
+        # The replacements are usable.
+        assert m.RDSIAMCredentialProvider._lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._lock.release()
+        assert m.RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        old_lock.release()
+        old_refresh_lock.release()
+
+
+def test_fork_hook_is_registered_at_import():
+    """The at-fork reset must be wired up when the module is imported."""
+    import importlib
+
+    from mwaa.config import rds_iam_credentials as m
+
+    try:
+        with patch("os.register_at_fork") as mock_register:
+            importlib.reload(m)
+        mock_register.assert_called_once()
+        hook = mock_register.call_args.kwargs["after_in_child"]
+        assert hook.__name__ == "_reset_locks_after_fork"
+    finally:
+        # Restore a clean module (the reload above replaced the class object).
+        importlib.reload(m)
+
+
+def test_failed_thread_start_releases_the_single_flight_guard():
+    """If the refresh thread cannot start, later callers must be able to retry."""
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            threading.Thread, "start", side_effect=RuntimeError("can't start new thread")
+        ):
+            # The caller is unaffected: it still gets the cached token.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+
+        # The guard was released, so the next caller can attempt the refresh.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
     finally:
         _reset_token_cache()

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_credentials_3_2_1.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_credentials_3_2_1.py
@@ -288,3 +288,182 @@ def test_is_using_rds_proxy():
 
     with patch.dict("os.environ", {}, clear=True):
         assert is_using_rds_proxy() is False
+
+
+# --- ECS metadata endpoint hardening (see P481207036) ---
+
+_ECS_ENV = {
+    "AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/abc",
+    "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/containers/test",
+}
+_CREDS = {
+    "AccessKeyId": "k",
+    "SecretAccessKey": "s",
+    "Token": "t",
+}
+
+
+def _mock_opener(side_effect=None, payload=None):
+    """Build a mock urllib opener returning payload, or raising side_effect."""
+    opener = MagicMock()
+    if side_effect is not None:
+        opener.open.side_effect = side_effect
+    else:
+        response = MagicMock()
+        response.read.return_value = json.dumps(payload or _CREDS).encode("utf-8")
+        opener.open.return_value.__enter__.return_value = response
+    return opener
+
+
+def _reset_token_cache():
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
+
+def test_ecs_metadata_fetch_passes_a_timeout():
+    """The fetch must be bounded; without a timeout urllib blocks indefinitely.
+
+    It runs inside the SQLAlchemy do_connect listener, so an unbounded hang
+    would stall a metadata database connection.
+    """
+    from mwaa.config import rds_iam_credentials
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    _, kwargs = opener.open.call_args
+    assert kwargs.get("timeout") == rds_iam_credentials._METADATA_TIMEOUT_SECONDS
+    assert kwargs["timeout"] > 0
+
+
+def test_ecs_metadata_fetch_retries_transient_failure_then_succeeds():
+    """A single connect timeout must not fail the caller."""
+    import urllib.error
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    response = MagicMock()
+    response.read.return_value = json.dumps(_CREDS).encode("utf-8")
+    ok = MagicMock()
+    ok.__enter__ = MagicMock(return_value=response)
+    ok.__exit__ = MagicMock(return_value=False)
+
+    opener = MagicMock()
+    opener.open.side_effect = [urllib.error.URLError("timed out"), ok]
+
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ), patch("tenacity.nap.time.sleep"):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    assert opener.open.call_count == 2
+
+
+def test_ecs_metadata_fetch_does_not_retry_config_errors():
+    """A missing environment variable is not transient; fail immediately."""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", {}, clear=True), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        with pytest.raises(ValueError):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+    opener.open.assert_not_called()
+
+
+def test_transient_error_classification():
+    """429 and 5xx are retryable; 4xx client errors are not."""
+    import urllib.error
+
+    from mwaa.config.rds_iam_credentials import _is_transient_metadata_error
+
+    def http(code):
+        return urllib.error.HTTPError("u", code, "msg", None, None)
+
+    assert _is_transient_metadata_error(http(429)) is True
+    assert _is_transient_metadata_error(http(503)) is True
+    assert _is_transient_metadata_error(http(500)) is True
+    assert _is_transient_metadata_error(http(404)) is False
+    assert _is_transient_metadata_error(http(403)) is False
+    assert _is_transient_metadata_error(urllib.error.URLError("boom")) is True
+    assert _is_transient_metadata_error(TimeoutError()) is True
+    assert _is_transient_metadata_error(ConnectionResetError()) is True
+    assert _is_transient_metadata_error(ValueError("config")) is False
+
+
+def test_failed_refresh_reuses_a_still_valid_cached_token():
+    """A refresh failure inside the grace window must not fail the caller.
+
+    Tokens live 15 minutes and are refreshed at 10, so a blip during refresh
+    still leaves a usable token.
+    """
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "still_valid"
+        # Inside the refresh window (expires in 60s) but not yet expired.
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "still_valid"
+    finally:
+        _reset_token_cache()
+
+
+def test_failed_refresh_raises_once_the_token_has_expired():
+    """Past expiry there is nothing safe to reuse, so surface the failure."""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            with pytest.raises(Exception, match="metadata endpoint timed out"):
+                RDSIAMCredentialProvider.get_token()
+    finally:
+        _reset_token_cache()
+
+
+def test_token_expiry_measured_after_the_mint():
+    """Expiry must be timed from after the fetch, not before the lock wait.
+
+    Uses a stepped clock so a slow mint is distinguishable: timing from before
+    would set expiry to 1000+900, from after to 2000+900. With a real (instant)
+    mint the two are indistinguishable, which is why the clock is stubbed.
+    """
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    calls = {"n": 0}
+
+    def stepped_clock():
+        calls["n"] += 1
+        return 1000.0 if calls["n"] == 1 else 2000.0
+
+    try:
+        _reset_token_cache()
+        with patch(
+            "mwaa.config.rds_iam_credentials.time.time", side_effect=stepped_clock
+        ), patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", return_value="fresh"
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert RDSIAMCredentialProvider._expires_at == 2000.0 + 15 * 60
+    finally:
+        _reset_token_cache()

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_credentials_3_2_1.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_credentials_3_2_1.py
@@ -241,8 +241,17 @@ def test_create_db_connection_url():
 
 
 def test_create_db_connection_url_generate_token():
-    """Test database connection URL creation with token generation"""
+    """The default token path must go through the thread-safe cache.
+
+    Regression test: calling generate_credentials() directly bypassed
+    get_token(), minting a fresh token (ECS metadata fetch + signed boto3 call)
+    on every connection instead of reusing the cached one.
+    """
     from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    # Start from a cold cache; other tests in this module mutate this state.
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
 
     with patch.dict(
         "os.environ",
@@ -254,12 +263,19 @@ def test_create_db_connection_url_generate_token():
         },
     ), patch.object(
         RDSIAMCredentialProvider, "generate_credentials", return_value="generated_token"
-    ):
-        result = RDSIAMCredentialProvider.create_db_connection_url()
-        assert (
+    ) as mock_generate:
+        expected = (
             "postgresql+psycopg2://airflow_user:generated_token"
-            "@test.rds.amazonaws.com:5432/airflow?sslmode=require" in result
+            "@test.rds.amazonaws.com:5432/airflow?sslmode=require"
         )
+
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        # Second call must be served from the cache, not mint a new token.
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        assert mock_generate.call_count == 1
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
 
 
 def test_use_iam_credentials():

--- a/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_credentials_3_3_0.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_credentials_3_3_0.py
@@ -338,6 +338,16 @@ def _reset_token_cache():
     RDSIAMCredentialProvider._expires_at = 0
 
 
+def _join_refresh_thread():
+    """Wait for the background refresh thread so assertions are deterministic."""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    thread = RDSIAMCredentialProvider._refresh_thread
+    if thread is not None:
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "background refresh did not finish"
+
+
 def test_ecs_metadata_fetch_passes_a_timeout():
     """The fetch must be bounded; without a timeout urllib blocks indefinitely.
 
@@ -418,14 +428,17 @@ def test_failed_refresh_reuses_a_still_valid_cached_token():
     """A refresh failure inside the grace window must not fail the caller.
 
     Tokens live 15 minutes and are refreshed at 10, so a blip during refresh
-    still leaves a usable token.
+    still leaves a usable token. The failure happens on the background thread
+    and is logged; the cached token stays in place, and the single-flight
+    guard is released so a later caller can retry the refresh.
     """
     from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
 
     try:
         RDSIAMCredentialProvider._token = "still_valid"
         # Inside the refresh window (expires in 60s) but not yet expired.
-        RDSIAMCredentialProvider._expires_at = time.time() + 60
+        expires_at = time.time() + 60
+        RDSIAMCredentialProvider._expires_at = expires_at
 
         with patch.object(
             RDSIAMCredentialProvider,
@@ -433,6 +446,14 @@ def test_failed_refresh_reuses_a_still_valid_cached_token():
             side_effect=Exception("metadata endpoint timed out"),
         ):
             assert RDSIAMCredentialProvider.get_token() == "still_valid"
+            _join_refresh_thread()
+
+        # The failed refresh left the cache untouched...
+        assert RDSIAMCredentialProvider._token == "still_valid"
+        assert RDSIAMCredentialProvider._expires_at == expires_at
+        # ...and released the single-flight guard for the next attempt.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
     finally:
         _reset_token_cache()
 
@@ -481,5 +502,209 @@ def test_token_expiry_measured_after_the_mint():
             assert RDSIAMCredentialProvider.get_token() == "fresh"
 
         assert RDSIAMCredentialProvider._expires_at == 2000.0 + 15 * 60
+    finally:
+        _reset_token_cache()
+
+
+# --- Off-critical-path token refresh ---
+#
+# The 5-minute refresh buffer on the 15-minute token lifetime exists so the
+# refresh can happen without a caller paying for it. These tests pin that
+# property: a usable token is always served immediately, the refresh runs on a
+# background thread, and only a cold start or a genuinely expired token blocks
+# the caller.
+
+
+def test_due_token_is_served_immediately_and_refreshed_in_background():
+    """A caller holding a usable token must not pay for the refresh.
+
+    Regression test: get_token() used to perform the fetch on the calling
+    thread while holding the lock, so the connection that arrived at the
+    10-minute mark blocked on the ECS metadata endpoint and every other
+    caller in the process queued behind it.
+    """
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    caller = threading.current_thread()
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        # Due for refresh (fewer than 5 minutes left) but not expired.
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            # The caller is handed the cached token, not the refreshed one.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            _join_refresh_thread()
+
+        # The refresh ran on a different thread and updated the cache.
+        assert minting_thread["thread"] is not caller
+        assert RDSIAMCredentialProvider._token == "refreshed"
+        assert RDSIAMCredentialProvider._expires_at > time.time() + 14 * 60
+    finally:
+        _reset_token_cache()
+
+
+def test_background_refresh_is_single_flight():
+    """Concurrent callers noticing a due token must not multiply fetches.
+
+    Multiplying connects to the ECS credential endpoint under contention is
+    the amplification pattern identified in P481207036, so while one refresh
+    is in flight further callers must be served the cached token without
+    triggering another fetch.
+    """
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    release = threading.Event()
+    calls = []
+
+    def slow_mint():
+        calls.append(1)
+        assert release.wait(timeout=5), "test never released the mint"
+        return "refreshed"
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=slow_mint
+        ):
+            for _ in range(5):
+                assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+            release.set()
+            _join_refresh_thread()
+
+        assert len(calls) == 1
+    finally:
+        release.set()
+        _reset_token_cache()
+
+
+def test_cold_start_fetches_synchronously():
+    """With nothing cached there is nothing to serve, so the caller waits."""
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        _reset_token_cache()
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_expired_token_fetches_synchronously():
+    """Past expiry the cached token is unusable, so the caller waits."""
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    minting_thread = {}
+
+    def record_thread():
+        minting_thread["thread"] = threading.current_thread()
+        return "fresh"
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", side_effect=record_thread
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert minting_thread["thread"] is threading.current_thread()
+    finally:
+        _reset_token_cache()
+
+
+def test_locks_are_replaced_after_fork():
+    """A child forked while a lock is held must not inherit it locked.
+
+    Airflow forks (Celery prefork workers, DAG processors). A lock held at
+    fork time is inherited locked by the child with no thread alive to
+    release it, which would wedge every future refresh in that child.
+    """
+    from mwaa.config import rds_iam_credentials as m
+
+    old_lock = m.RDSIAMCredentialProvider._lock
+    old_refresh_lock = m.RDSIAMCredentialProvider._refresh_lock
+    old_lock.acquire()
+    old_refresh_lock.acquire()
+    try:
+        m._reset_locks_after_fork()
+
+        assert m.RDSIAMCredentialProvider._lock is not old_lock
+        assert m.RDSIAMCredentialProvider._refresh_lock is not old_refresh_lock
+        # The replacements are usable.
+        assert m.RDSIAMCredentialProvider._lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._lock.release()
+        assert m.RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        m.RDSIAMCredentialProvider._refresh_lock.release()
+    finally:
+        old_lock.release()
+        old_refresh_lock.release()
+
+
+def test_fork_hook_is_registered_at_import():
+    """The at-fork reset must be wired up when the module is imported."""
+    import importlib
+
+    from mwaa.config import rds_iam_credentials as m
+
+    try:
+        with patch("os.register_at_fork") as mock_register:
+            importlib.reload(m)
+        mock_register.assert_called_once()
+        hook = mock_register.call_args.kwargs["after_in_child"]
+        assert hook.__name__ == "_reset_locks_after_fork"
+    finally:
+        # Restore a clean module (the reload above replaced the class object).
+        importlib.reload(m)
+
+
+def test_failed_thread_start_releases_the_single_flight_guard():
+    """If the refresh thread cannot start, later callers must be able to retry."""
+    import threading
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "due_but_valid"
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            threading.Thread, "start", side_effect=RuntimeError("can't start new thread")
+        ):
+            # The caller is unaffected: it still gets the cached token.
+            assert RDSIAMCredentialProvider.get_token() == "due_but_valid"
+
+        # The guard was released, so the next caller can attempt the refresh.
+        assert RDSIAMCredentialProvider._refresh_lock.acquire(blocking=False)
+        RDSIAMCredentialProvider._refresh_lock.release()
     finally:
         _reset_token_cache()

--- a/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_credentials_3_3_0.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_credentials_3_3_0.py
@@ -288,3 +288,182 @@ def test_is_using_rds_proxy():
 
     with patch.dict("os.environ", {}, clear=True):
         assert is_using_rds_proxy() is False
+
+
+# --- ECS metadata endpoint hardening (see P481207036) ---
+
+_ECS_ENV = {
+    "AWS_TASK_EXEC_CREDENTIALS_RELATIVE_URI": "/v2/credentials/abc",
+    "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/containers/test",
+}
+_CREDS = {
+    "AccessKeyId": "k",
+    "SecretAccessKey": "s",
+    "Token": "t",
+}
+
+
+def _mock_opener(side_effect=None, payload=None):
+    """Build a mock urllib opener returning payload, or raising side_effect."""
+    opener = MagicMock()
+    if side_effect is not None:
+        opener.open.side_effect = side_effect
+    else:
+        response = MagicMock()
+        response.read.return_value = json.dumps(payload or _CREDS).encode("utf-8")
+        opener.open.return_value.__enter__.return_value = response
+    return opener
+
+
+def _reset_token_cache():
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
+
+
+def test_ecs_metadata_fetch_passes_a_timeout():
+    """The fetch must be bounded; without a timeout urllib blocks indefinitely.
+
+    It runs inside the SQLAlchemy do_connect listener, so an unbounded hang
+    would stall a metadata database connection.
+    """
+    from mwaa.config import rds_iam_credentials
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    _, kwargs = opener.open.call_args
+    assert kwargs.get("timeout") == rds_iam_credentials._METADATA_TIMEOUT_SECONDS
+    assert kwargs["timeout"] > 0
+
+
+def test_ecs_metadata_fetch_retries_transient_failure_then_succeeds():
+    """A single connect timeout must not fail the caller."""
+    import urllib.error
+
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    response = MagicMock()
+    response.read.return_value = json.dumps(_CREDS).encode("utf-8")
+    ok = MagicMock()
+    ok.__enter__ = MagicMock(return_value=response)
+    ok.__exit__ = MagicMock(return_value=False)
+
+    opener = MagicMock()
+    opener.open.side_effect = [urllib.error.URLError("timed out"), ok]
+
+    with patch.dict("os.environ", _ECS_ENV), patch(
+        "urllib.request.build_opener", return_value=opener
+    ), patch("tenacity.nap.time.sleep"):
+        assert RDSIAMCredentialProvider.get_ecs_credentials() == _CREDS
+
+    assert opener.open.call_count == 2
+
+
+def test_ecs_metadata_fetch_does_not_retry_config_errors():
+    """A missing environment variable is not transient; fail immediately."""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    opener = _mock_opener()
+    with patch.dict("os.environ", {}, clear=True), patch(
+        "urllib.request.build_opener", return_value=opener
+    ):
+        with pytest.raises(ValueError):
+            RDSIAMCredentialProvider.get_ecs_credentials()
+    opener.open.assert_not_called()
+
+
+def test_transient_error_classification():
+    """429 and 5xx are retryable; 4xx client errors are not."""
+    import urllib.error
+
+    from mwaa.config.rds_iam_credentials import _is_transient_metadata_error
+
+    def http(code):
+        return urllib.error.HTTPError("u", code, "msg", None, None)
+
+    assert _is_transient_metadata_error(http(429)) is True
+    assert _is_transient_metadata_error(http(503)) is True
+    assert _is_transient_metadata_error(http(500)) is True
+    assert _is_transient_metadata_error(http(404)) is False
+    assert _is_transient_metadata_error(http(403)) is False
+    assert _is_transient_metadata_error(urllib.error.URLError("boom")) is True
+    assert _is_transient_metadata_error(TimeoutError()) is True
+    assert _is_transient_metadata_error(ConnectionResetError()) is True
+    assert _is_transient_metadata_error(ValueError("config")) is False
+
+
+def test_failed_refresh_reuses_a_still_valid_cached_token():
+    """A refresh failure inside the grace window must not fail the caller.
+
+    Tokens live 15 minutes and are refreshed at 10, so a blip during refresh
+    still leaves a usable token.
+    """
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "still_valid"
+        # Inside the refresh window (expires in 60s) but not yet expired.
+        RDSIAMCredentialProvider._expires_at = time.time() + 60
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "still_valid"
+    finally:
+        _reset_token_cache()
+
+
+def test_failed_refresh_raises_once_the_token_has_expired():
+    """Past expiry there is nothing safe to reuse, so surface the failure."""
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    try:
+        RDSIAMCredentialProvider._token = "expired"
+        RDSIAMCredentialProvider._expires_at = time.time() - 1
+
+        with patch.object(
+            RDSIAMCredentialProvider,
+            "generate_credentials",
+            side_effect=Exception("metadata endpoint timed out"),
+        ):
+            with pytest.raises(Exception, match="metadata endpoint timed out"):
+                RDSIAMCredentialProvider.get_token()
+    finally:
+        _reset_token_cache()
+
+
+def test_token_expiry_measured_after_the_mint():
+    """Expiry must be timed from after the fetch, not before the lock wait.
+
+    Uses a stepped clock so a slow mint is distinguishable: timing from before
+    would set expiry to 1000+900, from after to 2000+900. With a real (instant)
+    mint the two are indistinguishable, which is why the clock is stubbed.
+    """
+    from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    calls = {"n": 0}
+
+    def stepped_clock():
+        calls["n"] += 1
+        return 1000.0 if calls["n"] == 1 else 2000.0
+
+    try:
+        _reset_token_cache()
+        with patch(
+            "mwaa.config.rds_iam_credentials.time.time", side_effect=stepped_clock
+        ), patch.object(
+            RDSIAMCredentialProvider, "generate_credentials", return_value="fresh"
+        ):
+            assert RDSIAMCredentialProvider.get_token() == "fresh"
+
+        assert RDSIAMCredentialProvider._expires_at == 2000.0 + 15 * 60
+    finally:
+        _reset_token_cache()

--- a/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_credentials_3_3_0.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_credentials_3_3_0.py
@@ -241,8 +241,17 @@ def test_create_db_connection_url():
 
 
 def test_create_db_connection_url_generate_token():
-    """Test database connection URL creation with token generation"""
+    """The default token path must go through the thread-safe cache.
+
+    Regression test: calling generate_credentials() directly bypassed
+    get_token(), minting a fresh token (ECS metadata fetch + signed boto3 call)
+    on every connection instead of reusing the cached one.
+    """
     from mwaa.config.rds_iam_credentials import RDSIAMCredentialProvider
+
+    # Start from a cold cache; other tests in this module mutate this state.
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
 
     with patch.dict(
         "os.environ",
@@ -254,12 +263,19 @@ def test_create_db_connection_url_generate_token():
         },
     ), patch.object(
         RDSIAMCredentialProvider, "generate_credentials", return_value="generated_token"
-    ):
-        result = RDSIAMCredentialProvider.create_db_connection_url()
-        assert (
+    ) as mock_generate:
+        expected = (
             "postgresql+psycopg2://airflow_user:generated_token"
-            "@test.rds.amazonaws.com:5432/airflow?sslmode=require" in result
+            "@test.rds.amazonaws.com:5432/airflow?sslmode=require"
         )
+
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        # Second call must be served from the cache, not mint a new token.
+        assert expected in RDSIAMCredentialProvider.create_db_connection_url()
+        assert mock_generate.call_count == 1
+
+    RDSIAMCredentialProvider._token = None
+    RDSIAMCredentialProvider._expires_at = 0
 
 
 def test_use_iam_credentials():


### PR DESCRIPTION
## Summary

Hardens the RDS IAM token path across all eight images that ship the feature (2.9.2, 2.10.1, 2.10.3, 2.11.0, 2.11.2, 3.0.6, 3.2.1, 3.3.0). Fixes three of the cross-version defects deliberately deferred from #574 so they could land uniformly rather than only in 3.x. The remaining deferred item (customer local settings re-export) is kept separate and will follow in its own PR.

### 1. The ECS task credential fetch was unbounded and unretried

`get_ecs_credentials()` called `urllib` with no `timeout`, and `socket.getdefaulttimeout()` is `None` in the images, so the call could block indefinitely — inside the SQLAlchemy `do_connect` listener, stalling a metadata DB connection in whichever Airflow process hit it. There was no retry, and `with_db_retry` does not cover socket errors.

This happens in production: customers see daily `Connect timeout on endpoint URL: http://169.254.170.2/v2/credentials/<uuid>`. Per the Fargate Data Plane team's source-level analysis (P481207036), a TMDS throttle breach returns HTTP 429 on a *completed* connection, and the address is link-local with no remote hop — so a connect timeout means the calling process is resource-starved, and the mitigation is client-side timeouts and retries.

The fetch is now bounded by `MWAA__DB__IAM_METADATA_TIMEOUT` (default 5s) and retried up to `MWAA__DB__IAM_METADATA_ATTEMPTS` times (default 3) with exponential backoff. Retries are classified, not blanket: connect/read timeouts, connection errors, HTTP 429 and 5xx retry; configuration errors and other 4xx fail immediately (`HTTPError` subclasses `URLError`, so a naive predicate would retry 404s). Note botocore's `AWS_METADATA_SERVICE_TIMEOUT`/`_NUM_ATTEMPTS` do **not** apply to this path — it is plain `urllib` — so a fleet-wide botocore mitigation would leave it unprotected.

### 2. The token refresh sat on the connection critical path

Tokens live 15 minutes and become due for refresh at 10 — that buffer exists precisely so a refresh can happen off the critical path. But `get_token()` fetched on the calling thread while holding the lock, so the connection arriving at the 10-minute mark blocked on the fetch and every other caller queued behind it. The fetch is most likely to be slow exactly when the process is busy, which is when connections are most frequent.

Now a caller holding a usable token is served the cached token immediately and the refresh runs on a background daemon thread, single-flight via a non-blocking lock acquire so concurrent callers cannot multiply connects to the endpoint (the amplification named as the root cause in P481207036). A background failure is logged and the still-valid token stays in place for later callers to re-trigger. Only a cold start or a genuinely expired token fetches synchronously, holding the lock across the now-bounded mint. Locks are recreated in forked children via `os.register_at_fork` — Airflow forks (Celery prefork, DAG processors), and a lock held at fork time would be inherited locked with no thread alive to release it. This also keeps the Triggerer's event loop unblocked, the Fargate team's third recommendation.

### 3. `create_db_connection_url()` bypassed the token cache

The default `token=None` path called `generate_credentials()` directly, minting a fresh token (ECS fetch + signed boto3 call) per call. Latent — all call sites pass an explicit token today — but anything adopting the default path would turn one fetch per process per ten minutes into one fetch per DB connection: the same refresh-amplification pattern as above. It now routes through `get_token()`. No recursion: `get_token()` → `generate_credentials()`, which does not call back.

### 2.x-specific fix the port depends on

2.x's `generate_credentials()` swallowed failures and returned `None`, which `get_token()` cached with a full 15-minute lifetime — every caller in the process was handed an unusable credential until the entry aged out. It now raises, matching 3.x: the retry classification and the cached-token fallback both need the underlying exception. The failure surface for callers is unchanged (a failed mint was already fatal downstream), just earlier and with the real cause.

## Testing

- Full suites pass on all eight versions: 231/231/232/210/231 (2.x) and 379/398/397 (3.x) — 2,319 total.
- New/updated tests per version cover: the timeout being passed, transient-retry-then-success, no-retry on config errors, the 429/5xx-vs-4xx classification, cache fallback inside the grace window, hard failure past expiry, expiry timed after the mint, background refresh serving the caller immediately, single-flight under a blocked mint, synchronous cold-start/expiry paths, at-fork lock replacement, fork-hook registration, thread-start failure releasing the guard, the cache-default path, and (2.x) the None-poisoning regression.
- Regression tests were confirmed to fail against the pre-fix code: 5 on 3.x (the off-critical-path set) and 13 on 2.x, individually per behaviour.
- `ruff check .` clean as CI runs it; diff-coverage gate at 100% on all eight changed credential files.

## Compatibility

No behaviour change with the feature flag off. With it on: token minting semantics are unchanged on the hot path (cached token served); the refresh moves to a background thread; failure modes are strictly narrower (bounded instead of indefinite blocking, transient failures retried, refresh blips absorbed by the grace window). The two new environment variables have safe defaults and need no deployment changes.

## References

- Deferred-from: #574
- Fargate Data Plane analysis: P481207036; customer ticket: D498796039
