### PR TITLE
fix(images): Match 2.x logging in the RDS IAM patch

### DIFF
--- a/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
@@ -129,7 +129,7 @@ def install_rds_iam_patch() -> None:
     if is_local_runner():
         return
 
-    # Resolve here rather than on the first connection, as 2.x did: it keeps
+    # Resolve here rather than on the first connection to keep
     # get_db_connection_string()'s INFO record out of MWAA CLI stdout.
     _get_metadata_url()
 

--- a/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py
@@ -115,24 +115,23 @@ def install_rds_iam_patch() -> None:
     global _patch_installed
 
     if _patch_installed:
-        logger.debug("RDS IAM patch already installed in this process.")
         return
 
     if not use_iam_credentials():
-        logger.info("RDS IAM patch not installed: USE_IAM_CREDENTIALS is not true.")
         return
 
     if not is_using_rds_proxy():
-        logger.info("RDS IAM patch not installed: not using RDS Proxy.")
         return
 
     if _is_from_migrate_db():
-        logger.info("RDS IAM patch not installed: running in migrate-db process.")
         return
 
     if is_local_runner():
-        logger.info("RDS IAM patch not installed: running in local runner mode.")
         return
+
+    # Resolve here rather than on the first connection, as 2.x did: it keeps
+    # get_db_connection_string()'s INFO record out of MWAA CLI stdout.
+    _get_metadata_url()
 
     from sqlalchemy import event
     from sqlalchemy.engine import Engine

--- a/images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py
@@ -125,7 +125,7 @@ def install_rds_iam_patch() -> None:
     if is_local_runner():
         return
 
-    # Resolve here rather than on the first connection, as 2.x did: it keeps
+    # Resolve here rather than on the first connection to keep
     # get_db_connection_string()'s INFO record out of MWAA CLI stdout.
     _get_metadata_url()
 

--- a/images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py
@@ -111,24 +111,23 @@ def install_rds_iam_patch() -> None:
     global _patch_installed
 
     if _patch_installed:
-        logger.debug("RDS IAM patch already installed in this process.")
         return
 
     if not use_iam_credentials():
-        logger.info("RDS IAM patch not installed: USE_IAM_CREDENTIALS is not true.")
         return
 
     if not is_using_rds_proxy():
-        logger.info("RDS IAM patch not installed: not using RDS Proxy.")
         return
 
     if _is_from_migrate_db():
-        logger.info("RDS IAM patch not installed: running in migrate-db process.")
         return
 
     if is_local_runner():
-        logger.info("RDS IAM patch not installed: running in local runner mode.")
         return
+
+    # Resolve here rather than on the first connection, as 2.x did: it keeps
+    # get_db_connection_string()'s INFO record out of MWAA CLI stdout.
+    _get_metadata_url()
 
     from sqlalchemy import event
     from sqlalchemy.engine import Engine

--- a/images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py
@@ -125,7 +125,7 @@ def install_rds_iam_patch() -> None:
     if is_local_runner():
         return
 
-    # Resolve here rather than on the first connection, as 2.x did: it keeps
+    # Resolve here rather than on the first connection to keep
     # get_db_connection_string()'s INFO record out of MWAA CLI stdout.
     _get_metadata_url()
 

--- a/images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py
+++ b/images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py
@@ -111,24 +111,23 @@ def install_rds_iam_patch() -> None:
     global _patch_installed
 
     if _patch_installed:
-        logger.debug("RDS IAM patch already installed in this process.")
         return
 
     if not use_iam_credentials():
-        logger.info("RDS IAM patch not installed: USE_IAM_CREDENTIALS is not true.")
         return
 
     if not is_using_rds_proxy():
-        logger.info("RDS IAM patch not installed: not using RDS Proxy.")
         return
 
     if _is_from_migrate_db():
-        logger.info("RDS IAM patch not installed: running in migrate-db process.")
         return
 
     if is_local_runner():
-        logger.info("RDS IAM patch not installed: running in local runner mode.")
         return
+
+    # Resolve here rather than on the first connection, as 2.x did: it keeps
+    # get_db_connection_string()'s INFO record out of MWAA CLI stdout.
+    _get_metadata_url()
 
     from sqlalchemy import event
     from sqlalchemy.engine import Engine

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py
@@ -208,7 +208,7 @@ def _clear_metadata_url_cache(module=None):
     getattr(module._get_metadata_url, "cache_clear", lambda: None)()
 
 
-# --- Regression tests for the aspects restored from the 2.x implementation ---
+# --- Regression tests for patch installation and metadata URL resolution ---
 
 # Environment describing a metadata DB reachable through an RDS Proxy. Note the
 # deliberate absence of AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: that variable is

--- a/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py
@@ -578,3 +578,35 @@ def test_dblock_connect_uses_static_credentials_when_disabled():
         dblock._connect_with_retry()
 
     assert create_engine.call_args.args[0] == "postgresql://static"
+
+
+def test_install_resolves_metadata_url_eagerly():
+    """The metadata URL is resolved at install time, not on the first connection."""
+    from mwaa.config import rds_iam_patch
+
+    conn_string = (
+        "postgresql+psycopg2://airflow_user:pw@test.rds.amazonaws.com:5432"
+        "/AirflowMetadata?sslmode=require"
+    )
+
+    with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
+        _reset_patch_state()
+        with patch.object(
+            rds_iam_patch, "get_db_connection_string", return_value=conn_string
+        ) as mock_conn_string, patch("sqlalchemy.event.listen"):
+            rds_iam_patch.install_rds_iam_patch()
+
+            mock_conn_string.assert_called_once()
+
+            # A later connection must reuse the cached URL, not resolve again.
+            rds_iam_patch._is_accessing_metadata_db(
+                None,
+                (),
+                {
+                    "host": "test.rds.amazonaws.com",
+                    "dbname": "AirflowMetadata",
+                    "port": 5432,
+                    "user": "airflow_user",
+                },
+            )
+            mock_conn_string.assert_called_once()

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py
@@ -208,7 +208,7 @@ def _clear_metadata_url_cache(module=None):
     getattr(module._get_metadata_url, "cache_clear", lambda: None)()
 
 
-# --- Regression tests for the aspects restored from the 2.x implementation ---
+# --- Regression tests for patch installation and metadata URL resolution ---
 
 # Environment describing a metadata DB reachable through an RDS Proxy. Note the
 # deliberate absence of AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: that variable is

--- a/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py
@@ -578,3 +578,35 @@ def test_dblock_connect_uses_static_credentials_when_disabled():
         dblock._connect_with_retry()
 
     assert create_engine.call_args.args[0] == "postgresql://static"
+
+
+def test_install_resolves_metadata_url_eagerly():
+    """The metadata URL is resolved at install time, not on the first connection."""
+    from mwaa.config import rds_iam_patch
+
+    conn_string = (
+        "postgresql+psycopg2://airflow_user:pw@test.rds.amazonaws.com:5432"
+        "/AirflowMetadata?sslmode=require"
+    )
+
+    with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
+        _reset_patch_state()
+        with patch.object(
+            rds_iam_patch, "get_db_connection_string", return_value=conn_string
+        ) as mock_conn_string, patch("sqlalchemy.event.listen"):
+            rds_iam_patch.install_rds_iam_patch()
+
+            mock_conn_string.assert_called_once()
+
+            # A later connection must reuse the cached URL, not resolve again.
+            rds_iam_patch._is_accessing_metadata_db(
+                None,
+                (),
+                {
+                    "host": "test.rds.amazonaws.com",
+                    "dbname": "AirflowMetadata",
+                    "port": 5432,
+                    "user": "airflow_user",
+                },
+            )
+            mock_conn_string.assert_called_once()

--- a/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py
@@ -208,7 +208,7 @@ def _clear_metadata_url_cache(module=None):
     getattr(module._get_metadata_url, "cache_clear", lambda: None)()
 
 
-# --- Regression tests for the aspects restored from the 2.x implementation ---
+# --- Regression tests for patch installation and metadata URL resolution ---
 
 # Environment describing a metadata DB reachable through an RDS Proxy. Note the
 # deliberate absence of AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: that variable is

--- a/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py
+++ b/tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py
@@ -578,3 +578,35 @@ def test_dblock_connect_uses_static_credentials_when_disabled():
         dblock._connect_with_retry()
 
     assert create_engine.call_args.args[0] == "postgresql://static"
+
+
+def test_install_resolves_metadata_url_eagerly():
+    """The metadata URL is resolved at install time, not on the first connection."""
+    from mwaa.config import rds_iam_patch
+
+    conn_string = (
+        "postgresql+psycopg2://airflow_user:pw@test.rds.amazonaws.com:5432"
+        "/AirflowMetadata?sslmode=require"
+    )
+
+    with patch.dict("os.environ", _RDS_PROXY_ENV, clear=True):
+        _reset_patch_state()
+        with patch.object(
+            rds_iam_patch, "get_db_connection_string", return_value=conn_string
+        ) as mock_conn_string, patch("sqlalchemy.event.listen"):
+            rds_iam_patch.install_rds_iam_patch()
+
+            mock_conn_string.assert_called_once()
+
+            # A later connection must reuse the cached URL, not resolve again.
+            rds_iam_patch._is_accessing_metadata_db(
+                None,
+                (),
+                {
+                    "host": "test.rds.amazonaws.com",
+                    "dbname": "AirflowMetadata",
+                    "port": 5432,
+                    "user": "airflow_user",
+                },
+            )
+            mock_conn_string.assert_called_once()


### PR DESCRIPTION
## Summary

Restores the 2.x logging behaviour of the RDS IAM patch in two parts:

1. **Resolve the metadata database URL at patch-install time** instead of on the first database connection. This stops an internal INFO record from being prepended to MWAA CLI stdout, which breaks JSON parsing for CLI callers.

2. **Remove the five log records** that report the patch was not installed or was already installed. 2.x logs nothing on either path, and these records go to customer log groups.

## Changes

- `images/airflow/3.0.6/python/mwaa/config/rds_iam_patch.py`
- `images/airflow/3.2.1/python/mwaa/config/rds_iam_patch.py`
- `images/airflow/3.3.0/python/mwaa/config/rds_iam_patch.py`
- `tests/images/airflow/3.0.6/python/mwaa/config/test_rds_iam_patch_3_0_6.py`
- `tests/images/airflow/3.2.1/python/mwaa/config/test_rds_iam_patch_3_2_1.py`
- `tests/images/airflow/3.3.0/python/mwaa/config/test_rds_iam_patch_3_3_0.py`

## Testing

- Added `test_install_resolves_metadata_url_eagerly` to all three version test files.
- The test asserts `get_db_connection_string()` is called exactly once during `install_rds_iam_patch()` (at install time, not lazily on first connection) and is not called again by a later `_is_accessing_metadata_db()` check.

Port of internal CR-296267560.