### PR TITLE
Bump apache-airflow-providers-openlineage to 2.16.0 in AF3.2.1 constraints

### DIFF
--- a/images/airflow/3.2.1/etc/airflow_constraints.txt
+++ b/images/airflow/3.2.1/etc/airflow_constraints.txt
@@ -161,7 +161,9 @@ apache-airflow-providers-neo4j==3.11.5
 apache-airflow-providers-odbc==4.12.2
 apache-airflow-providers-openai==1.7.4
 apache-airflow-providers-openfaas==3.9.4
-apache-airflow-providers-openlineage==2.14.0
+# default 'openlineage' v2.14.0 has fork() bug leading to 'SSL error: decryption failed or bad record mac'
+# fix: https://github.com/apache/airflow/pull/65677
+apache-airflow-providers-openlineage==2.16.0
 apache-airflow-providers-opensearch==1.9.0
 apache-airflow-providers-opsgenie==5.10.3
 apache-airflow-providers-oracle==4.5.3


### PR DESCRIPTION
Bump apache-airflow-providers-openlineage to 2.16.0 in AF3.2.1 constraints.

The default apache-airflow-providers-openlineage==2.14.0 has a known
fork() bug that leads to "SSL error: decryption failed or bad record mac"
due to inherited DB connection socket that's being used by two
processes. Version 2.16.0 contains fix: https://github.com/apache/airflow/pull/65677

* *The local development experience*:
Package install succeeds: `[INFO] - Successfully installed apache-airflow-providers-openlineage-2.16.0 openlineage-integration-common-1.46.0 openlineage-python-1.46.0 openlineage-sql-1.46.0`. 
It's not installed by default - only if user requests it `requirements.txt`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.