### PR TITLE
Suppress Dependabot version and security PRs for pinned Airflow dirs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
   - package-ecosystem: "pip"
     directories:
       - "/images/airflow/*"
+      - "/tests/images/airflow/*"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
*Issue # (if available):* N/A

*Description of changes:*

`.github/dependabot.yml` was supposed to stop Dependabot PRs for the version-pinned Airflow directories (added in #556), but it relied solely on `open-pull-requests-limit: 0`. That option applies to **version updates only** — per the [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-): "*Security update* pull requests are not subject to this limit and do not count toward it. There is no limit on the number of open pull requests for security updates."

Every PR that got through (#593–#601) is a **security** update, so the limit never applied. They carry the security-update markers: opened by `dependabot[bot]` "on behalf of github", a footer linking the Security Alerts page, and no `update-type: version-update:semver-*` trailer in the commit message.

Two changes, both scoped to the pinned-directories block:

1. **`ignore: - dependency-name: "*"`** — `ignore` is the only `dependabot.yml` option that applies to security-update PRs as well as version-update PRs, so this is what actually stops the flood. Note this newly suppresses security PRs for `/images/airflow/*` as well, which previously did receive them.
2. **`/tests/images/airflow/*` added to `directories`** — this path was not covered by any block, so nothing was suppressed there. Half the open PRs (#593, #595, #598, #600, #558) are under it.

The root `/` block is deliberately left untouched: `ruff`, `pytest`, `pip` and other dev dependencies continue to receive both version and security updates (e.g. #461, #545).

**Why this is safe**

- The Airflow pins in these directories are intentional — each directory *is* a specific Airflow version, so a bump is meaningless by construction. Dependabot proposing `2.9.2 → 3.3.0` inside `images/airflow/2.9.2` can never be merged.
- This suppresses *pull requests*, not *alerts*. Dependabot alerts continue to fire and remain visible on the Security tab, so CVE visibility for these dependencies is unchanged. Remediation for the published images continues to run through the image build's vulnerability scan and allowlist process, which is the actual gate.

**Verification**

- YAML parses. Glob scope confirmed against the existing PRs: the Dependabot branch names (for example `dependabot/pip/images/airflow/2.11.2/gitpython-3.1.58`) place every affected manifest exactly one level below `images/airflow` and `tests/images/airflow`, so the single-segment `*` matches all of them.
- After merge, Insights → Dependency graph → Dependabot should show the config parsed with no errors — a malformed `dependabot.yml` fails silently rather than failing a PR check.

**Follow-up after merge**

The 10 open Dependabot PRs against the pinned directories (#593–#601 and #558) need to be closed manually **after** this merges. Closing them beforehand just gets them recreated on the next Dependabot run. #461 and #545 target the root directory and are unaffected by this change.

*List any breaking changes for*
* *The Environment runtime*: None. This is a GitHub repository configuration file and is not shipped in any image.
* *The local development experience*: None.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
