### PR TITLE
Guard base_log_folder from local task log cleanup

### DIFF
--- a/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
@@ -703,6 +703,13 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
                 )
                 return
             parent = local_path.parent
+            if parent == base:
+                # Refuse to delete base_log_folder itself; only remove a task
+                # subdirectory. The relative_to check above passes even when the
+                # log resolves directly under base, in which case rmtree(parent)
+                # would wipe every task's local logs on this worker.
+                print(f"[upload] Refusing to delete base_log_folder itself: {parent}")
+                return
             if parent.exists():
                 shutil.rmtree(parent, ignore_errors=True)
                 if parent.exists():

--- a/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -555,6 +555,13 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
                 )
                 return
             parent = local_path.parent
+            if parent == base:
+                # Refuse to delete base_log_folder itself; only remove a task
+                # subdirectory. The relative_to check above passes even when the
+                # log resolves directly under base, in which case rmtree(parent)
+                # would wipe every task's local logs on this worker.
+                print(f"[upload] Refusing to delete base_log_folder itself: {parent}")
+                return
             if parent.exists():
                 shutil.rmtree(parent, ignore_errors=True)
                 if parent.exists():

--- a/images/airflow/3.3.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.3.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -555,6 +555,13 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
                 )
                 return
             parent = local_path.parent
+            if parent == base:
+                # Refuse to delete base_log_folder itself; only remove a task
+                # subdirectory. The relative_to check above passes even when the
+                # log resolves directly under base, in which case rmtree(parent)
+                # would wipe every task's local logs on this worker.
+                print(f"[upload] Refusing to delete base_log_folder itself: {parent}")
+                return
             if parent.exists():
                 shutil.rmtree(parent, ignore_errors=True)
                 if parent.exists():

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -379,6 +379,39 @@ def test_cloudwatch_remote_task_logger_upload_skips_path_outside_base(tmp_path):
     assert os.path.exists(outside)
 
 
+def test_cloudwatch_remote_task_logger_upload_refuses_to_delete_base(tmp_path):
+    """A log resolving directly under base_log_folder must NOT delete base itself.
+
+    parent == base would otherwise rmtree every task's local logs on the worker.
+    The relative_to guard passes in this case (the file IS inside base), so this
+    equality check is the last line of defense against wiping base_log_folder.
+    """
+    base = str(tmp_path)
+    # A sibling file standing in for another task's logs under base; must survive.
+    sentinel = os.path.join(base, "other_task.log")
+    with open(sentinel, "w") as f:
+        f.write("do not delete\n")
+    # Target log resolves directly under base -> parent == base.
+    log_file = os.path.join(base, "attempt=1.log")
+    with open(log_file, "w") as f:
+        f.write("log\n")
+
+    logger = _make_task_logger(enabled=True)
+    logger.stats = Mock()
+    ti = MagicMock()
+
+    with patch('mwaa.logging.cloudwatch_handlers.conf') as mock_conf:
+        mock_conf.get.return_value = base
+        result = logger.upload("attempt=1.log", ti)
+
+    assert result is None
+    # base and the sibling task's logs are untouched (catastrophe prevented).
+    assert os.path.isdir(base)
+    assert os.path.exists(sentinel)
+    # A clean refusal, not an error path: the error metric must not fire.
+    logger.stats.incr.assert_not_called()
+
+
 def test_cloudwatch_remote_task_logger_upload_handles_absolute_path(tmp_path):
     """An absolute path under the base is resolved and its parent deleted.
 

--- a/tests/images/airflow/3.2.1/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/logging/test_cloudwatch_handler.py
@@ -374,6 +374,39 @@ def test_cloudwatch_remote_task_logger_upload_skips_path_outside_base(tmp_path):
     assert os.path.exists(outside)
 
 
+def test_cloudwatch_remote_task_logger_upload_refuses_to_delete_base(tmp_path):
+    """A log resolving directly under base_log_folder must NOT delete base itself.
+
+    parent == base would otherwise rmtree every task's local logs on the worker.
+    The relative_to guard passes in this case (the file IS inside base), so this
+    equality check is the last line of defense against wiping base_log_folder.
+    """
+    base = str(tmp_path)
+    # A sibling file standing in for another task's logs under base; must survive.
+    sentinel = os.path.join(base, "other_task.log")
+    with open(sentinel, "w") as f:
+        f.write("do not delete\n")
+    # Target log resolves directly under base -> parent == base.
+    log_file = os.path.join(base, "attempt=1.log")
+    with open(log_file, "w") as f:
+        f.write("log\n")
+
+    logger = _make_task_logger(enabled=True)
+    logger.stats = Mock()
+    ti = MagicMock()
+
+    with patch('mwaa.logging.cloudwatch_handlers.conf') as mock_conf:
+        mock_conf.get.return_value = base
+        result = logger.upload("attempt=1.log", ti)
+
+    assert result is None
+    # base and the sibling task's logs are untouched (catastrophe prevented).
+    assert os.path.isdir(base)
+    assert os.path.exists(sentinel)
+    # A clean refusal, not an error path: the error metric must not fire.
+    logger.stats.incr.assert_not_called()
+
+
 def test_cloudwatch_remote_task_logger_upload_handles_absolute_path(tmp_path):
     """An absolute path under the base is resolved and its parent deleted.
 

--- a/tests/images/airflow/3.3.1/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.3.1/python/mwaa/logging/test_cloudwatch_handler.py
@@ -374,6 +374,39 @@ def test_cloudwatch_remote_task_logger_upload_skips_path_outside_base(tmp_path):
     assert os.path.exists(outside)
 
 
+def test_cloudwatch_remote_task_logger_upload_refuses_to_delete_base(tmp_path):
+    """A log resolving directly under base_log_folder must NOT delete base itself.
+
+    parent == base would otherwise rmtree every task's local logs on the worker.
+    The relative_to guard passes in this case (the file IS inside base), so this
+    equality check is the last line of defense against wiping base_log_folder.
+    """
+    base = str(tmp_path)
+    # A sibling file standing in for another task's logs under base; must survive.
+    sentinel = os.path.join(base, "other_task.log")
+    with open(sentinel, "w") as f:
+        f.write("do not delete\n")
+    # Target log resolves directly under base -> parent == base.
+    log_file = os.path.join(base, "attempt=1.log")
+    with open(log_file, "w") as f:
+        f.write("log\n")
+
+    logger = _make_task_logger(enabled=True)
+    logger.stats = Mock()
+    ti = MagicMock()
+
+    with patch('mwaa.logging.cloudwatch_handlers.conf') as mock_conf:
+        mock_conf.get.return_value = base
+        result = logger.upload("attempt=1.log", ti)
+
+    assert result is None
+    # base and the sibling task's logs are untouched (catastrophe prevented).
+    assert os.path.isdir(base)
+    assert os.path.exists(sentinel)
+    # A clean refusal, not an error path: the error metric must not fire.
+    logger.stats.incr.assert_not_called()
+
+
 def test_cloudwatch_remote_task_logger_upload_handles_absolute_path(tmp_path):
     """An absolute path under the base is resolved and its parent deleted.
 


### PR DESCRIPTION
Follow-up to #609 (now merged), addressing a hardening item AutoSDE flagged on that PR after it merged.

The local-log cleanup added in #609 checks that the resolved log file is inside base_log_folder, but not that its parent is strictly below base. If a log ever resolved directly under base, parent == base and rmtree(parent) would remove the entire base_log_folder. This adds an explicit refusal when parent == base, plus a test, across 3.0.6, 3.2.1, and 3.3.1.

In practice this is very unlikely: AF3 task logs are always deeply nested (base/dag_id=.../run_id=.../task_id=.../attempt=N.log), so parent never equals base. The guard is arguably unnecessary today, but the downside if it ever did trigger (wiping every task's local logs on the worker) is severe and the check is trivial, so it is worth adding as a safeguard.

Unit tests pass on all three images.