### PR TITLE
Restrict local task log deletion to subdirectories of base_log_folder

### DIFF
--- a/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.0.6/python/mwaa/logging/cloudwatch_handlers.py
@@ -703,12 +703,14 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
                 )
                 return
             parent = local_path.parent
-            if parent == base:
-                # Refuse to delete base_log_folder itself; only remove a task
-                # subdirectory. The relative_to check above passes even when the
-                # log resolves directly under base, in which case rmtree(parent)
-                # would wipe every task's local logs on this worker.
-                print(f"[upload] Refusing to delete base_log_folder itself: {parent}")
+            if base not in parent.parents:
+                # Only delete a proper subdirectory of base_log_folder. This
+                # rejects a log that resolves to base itself (parent would be
+                # base.parent) and a log directly under base (parent == base), so
+                # rmtree can never touch base_log_folder or any directory above
+                # it. relative_to() above only proves local_path is inside base,
+                # not that its parent is strictly below base.
+                print(f"[upload] Refusing to delete non-subdirectory of base_log_folder: {parent}")
                 return
             if parent.exists():
                 shutil.rmtree(parent, ignore_errors=True)

--- a/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.2.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -555,12 +555,14 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
                 )
                 return
             parent = local_path.parent
-            if parent == base:
-                # Refuse to delete base_log_folder itself; only remove a task
-                # subdirectory. The relative_to check above passes even when the
-                # log resolves directly under base, in which case rmtree(parent)
-                # would wipe every task's local logs on this worker.
-                print(f"[upload] Refusing to delete base_log_folder itself: {parent}")
+            if base not in parent.parents:
+                # Only delete a proper subdirectory of base_log_folder. This
+                # rejects a log that resolves to base itself (parent would be
+                # base.parent) and a log directly under base (parent == base), so
+                # rmtree can never touch base_log_folder or any directory above
+                # it. relative_to() above only proves local_path is inside base,
+                # not that its parent is strictly below base.
+                print(f"[upload] Refusing to delete non-subdirectory of base_log_folder: {parent}")
                 return
             if parent.exists():
                 shutil.rmtree(parent, ignore_errors=True)

--- a/images/airflow/3.3.1/python/mwaa/logging/cloudwatch_handlers.py
+++ b/images/airflow/3.3.1/python/mwaa/logging/cloudwatch_handlers.py
@@ -555,12 +555,14 @@ class CloudWatchRemoteTaskLogger(BaseLogHandler, LoggingMixin):
                 )
                 return
             parent = local_path.parent
-            if parent == base:
-                # Refuse to delete base_log_folder itself; only remove a task
-                # subdirectory. The relative_to check above passes even when the
-                # log resolves directly under base, in which case rmtree(parent)
-                # would wipe every task's local logs on this worker.
-                print(f"[upload] Refusing to delete base_log_folder itself: {parent}")
+            if base not in parent.parents:
+                # Only delete a proper subdirectory of base_log_folder. This
+                # rejects a log that resolves to base itself (parent would be
+                # base.parent) and a log directly under base (parent == base), so
+                # rmtree can never touch base_log_folder or any directory above
+                # it. relative_to() above only proves local_path is inside base,
+                # not that its parent is strictly below base.
+                print(f"[upload] Refusing to delete non-subdirectory of base_log_folder: {parent}")
                 return
             if parent.exists():
                 shutil.rmtree(parent, ignore_errors=True)

--- a/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.0.6/python/mwaa/logging/test_cloudwatch_handler.py
@@ -379,22 +379,33 @@ def test_cloudwatch_remote_task_logger_upload_skips_path_outside_base(tmp_path):
     assert os.path.exists(outside)
 
 
-def test_cloudwatch_remote_task_logger_upload_refuses_to_delete_base(tmp_path):
-    """A log resolving directly under base_log_folder must NOT delete base itself.
+@pytest.mark.parametrize(
+    "path_arg",
+    [
+        "attempt=1.log",  # resolves to base/attempt=1.log -> parent == base
+        ".",              # resolves to base itself         -> parent == base.parent
+    ],
+    ids=["parent_is_base", "resolves_to_base"],
+)
+def test_cloudwatch_remote_task_logger_upload_refuses_non_subdirectory_of_base(
+    tmp_path, path_arg
+):
+    """upload() only deletes a proper subdirectory of base_log_folder.
 
-    parent == base would otherwise rmtree every task's local logs on the worker.
-    The relative_to guard passes in this case (the file IS inside base), so this
-    equality check is the last line of defense against wiping base_log_folder.
+    Two inputs reach the subdirectory guard: a log directly under base
+    (parent == base) and a path that resolves to base itself (parent ==
+    base.parent). In both cases rmtree must not run, or it would wipe
+    base_log_folder or its parent directory. relative_to() alone catches
+    neither.
     """
-    base = str(tmp_path)
-    # A sibling file standing in for another task's logs under base; must survive.
-    sentinel = os.path.join(base, "other_task.log")
-    with open(sentinel, "w") as f:
-        f.write("do not delete\n")
-    # Target log resolves directly under base -> parent == base.
-    log_file = os.path.join(base, "attempt=1.log")
-    with open(log_file, "w") as f:
-        f.write("log\n")
+    base = os.path.join(str(tmp_path), "logs")
+    os.makedirs(base, exist_ok=True)
+    # Sentinels that must survive: one inside base, one at the base.parent level.
+    inside = os.path.join(base, "other_task.log")
+    outside = os.path.join(str(tmp_path), "keep_me.txt")
+    for p in (inside, outside):
+        with open(p, "w") as f:
+            f.write("do not delete\n")
 
     logger = _make_task_logger(enabled=True)
     logger.stats = Mock()
@@ -402,14 +413,13 @@ def test_cloudwatch_remote_task_logger_upload_refuses_to_delete_base(tmp_path):
 
     with patch('mwaa.logging.cloudwatch_handlers.conf') as mock_conf:
         mock_conf.get.return_value = base
-        result = logger.upload("attempt=1.log", ti)
+        result = logger.upload(path_arg, ti)
 
     assert result is None
-    # base and the sibling task's logs are untouched (catastrophe prevented).
-    assert os.path.isdir(base)
-    assert os.path.exists(sentinel)
-    # A clean refusal, not an error path: the error metric must not fire.
-    logger.stats.incr.assert_not_called()
+    assert os.path.isdir(base)             # base_log_folder untouched
+    assert os.path.exists(inside)          # contents of base untouched
+    assert os.path.exists(outside)         # base.parent untouched
+    logger.stats.incr.assert_not_called()  # clean refusal, not an error
 
 
 def test_cloudwatch_remote_task_logger_upload_handles_absolute_path(tmp_path):

--- a/tests/images/airflow/3.2.1/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.2.1/python/mwaa/logging/test_cloudwatch_handler.py
@@ -374,22 +374,33 @@ def test_cloudwatch_remote_task_logger_upload_skips_path_outside_base(tmp_path):
     assert os.path.exists(outside)
 
 
-def test_cloudwatch_remote_task_logger_upload_refuses_to_delete_base(tmp_path):
-    """A log resolving directly under base_log_folder must NOT delete base itself.
+@pytest.mark.parametrize(
+    "path_arg",
+    [
+        "attempt=1.log",  # resolves to base/attempt=1.log -> parent == base
+        ".",              # resolves to base itself         -> parent == base.parent
+    ],
+    ids=["parent_is_base", "resolves_to_base"],
+)
+def test_cloudwatch_remote_task_logger_upload_refuses_non_subdirectory_of_base(
+    tmp_path, path_arg
+):
+    """upload() only deletes a proper subdirectory of base_log_folder.
 
-    parent == base would otherwise rmtree every task's local logs on the worker.
-    The relative_to guard passes in this case (the file IS inside base), so this
-    equality check is the last line of defense against wiping base_log_folder.
+    Two inputs reach the subdirectory guard: a log directly under base
+    (parent == base) and a path that resolves to base itself (parent ==
+    base.parent). In both cases rmtree must not run, or it would wipe
+    base_log_folder or its parent directory. relative_to() alone catches
+    neither.
     """
-    base = str(tmp_path)
-    # A sibling file standing in for another task's logs under base; must survive.
-    sentinel = os.path.join(base, "other_task.log")
-    with open(sentinel, "w") as f:
-        f.write("do not delete\n")
-    # Target log resolves directly under base -> parent == base.
-    log_file = os.path.join(base, "attempt=1.log")
-    with open(log_file, "w") as f:
-        f.write("log\n")
+    base = os.path.join(str(tmp_path), "logs")
+    os.makedirs(base, exist_ok=True)
+    # Sentinels that must survive: one inside base, one at the base.parent level.
+    inside = os.path.join(base, "other_task.log")
+    outside = os.path.join(str(tmp_path), "keep_me.txt")
+    for p in (inside, outside):
+        with open(p, "w") as f:
+            f.write("do not delete\n")
 
     logger = _make_task_logger(enabled=True)
     logger.stats = Mock()
@@ -397,14 +408,13 @@ def test_cloudwatch_remote_task_logger_upload_refuses_to_delete_base(tmp_path):
 
     with patch('mwaa.logging.cloudwatch_handlers.conf') as mock_conf:
         mock_conf.get.return_value = base
-        result = logger.upload("attempt=1.log", ti)
+        result = logger.upload(path_arg, ti)
 
     assert result is None
-    # base and the sibling task's logs are untouched (catastrophe prevented).
-    assert os.path.isdir(base)
-    assert os.path.exists(sentinel)
-    # A clean refusal, not an error path: the error metric must not fire.
-    logger.stats.incr.assert_not_called()
+    assert os.path.isdir(base)             # base_log_folder untouched
+    assert os.path.exists(inside)          # contents of base untouched
+    assert os.path.exists(outside)         # base.parent untouched
+    logger.stats.incr.assert_not_called()  # clean refusal, not an error
 
 
 def test_cloudwatch_remote_task_logger_upload_handles_absolute_path(tmp_path):

--- a/tests/images/airflow/3.3.1/python/mwaa/logging/test_cloudwatch_handler.py
+++ b/tests/images/airflow/3.3.1/python/mwaa/logging/test_cloudwatch_handler.py
@@ -374,22 +374,33 @@ def test_cloudwatch_remote_task_logger_upload_skips_path_outside_base(tmp_path):
     assert os.path.exists(outside)
 
 
-def test_cloudwatch_remote_task_logger_upload_refuses_to_delete_base(tmp_path):
-    """A log resolving directly under base_log_folder must NOT delete base itself.
+@pytest.mark.parametrize(
+    "path_arg",
+    [
+        "attempt=1.log",  # resolves to base/attempt=1.log -> parent == base
+        ".",              # resolves to base itself         -> parent == base.parent
+    ],
+    ids=["parent_is_base", "resolves_to_base"],
+)
+def test_cloudwatch_remote_task_logger_upload_refuses_non_subdirectory_of_base(
+    tmp_path, path_arg
+):
+    """upload() only deletes a proper subdirectory of base_log_folder.
 
-    parent == base would otherwise rmtree every task's local logs on the worker.
-    The relative_to guard passes in this case (the file IS inside base), so this
-    equality check is the last line of defense against wiping base_log_folder.
+    Two inputs reach the subdirectory guard: a log directly under base
+    (parent == base) and a path that resolves to base itself (parent ==
+    base.parent). In both cases rmtree must not run, or it would wipe
+    base_log_folder or its parent directory. relative_to() alone catches
+    neither.
     """
-    base = str(tmp_path)
-    # A sibling file standing in for another task's logs under base; must survive.
-    sentinel = os.path.join(base, "other_task.log")
-    with open(sentinel, "w") as f:
-        f.write("do not delete\n")
-    # Target log resolves directly under base -> parent == base.
-    log_file = os.path.join(base, "attempt=1.log")
-    with open(log_file, "w") as f:
-        f.write("log\n")
+    base = os.path.join(str(tmp_path), "logs")
+    os.makedirs(base, exist_ok=True)
+    # Sentinels that must survive: one inside base, one at the base.parent level.
+    inside = os.path.join(base, "other_task.log")
+    outside = os.path.join(str(tmp_path), "keep_me.txt")
+    for p in (inside, outside):
+        with open(p, "w") as f:
+            f.write("do not delete\n")
 
     logger = _make_task_logger(enabled=True)
     logger.stats = Mock()
@@ -397,14 +408,13 @@ def test_cloudwatch_remote_task_logger_upload_refuses_to_delete_base(tmp_path):
 
     with patch('mwaa.logging.cloudwatch_handlers.conf') as mock_conf:
         mock_conf.get.return_value = base
-        result = logger.upload("attempt=1.log", ti)
+        result = logger.upload(path_arg, ti)
 
     assert result is None
-    # base and the sibling task's logs are untouched (catastrophe prevented).
-    assert os.path.isdir(base)
-    assert os.path.exists(sentinel)
-    # A clean refusal, not an error path: the error metric must not fire.
-    logger.stats.incr.assert_not_called()
+    assert os.path.isdir(base)             # base_log_folder untouched
+    assert os.path.exists(inside)          # contents of base untouched
+    assert os.path.exists(outside)         # base.parent untouched
+    logger.stats.incr.assert_not_called()  # clean refusal, not an error
 
 
 def test_cloudwatch_remote_task_logger_upload_handles_absolute_path(tmp_path):


### PR DESCRIPTION
Follow-up to #610, addressing another case AutoSDE flagged: the guard added in #610 (`parent == base`) does not cover a path that resolves to `base_log_folder` itself (an empty or `.` path). In that case `parent` is `base.parent`, the `parent == base` check is False, and `rmtree` would remove `base_log_folder` and its parent directory.

This replaces the equality check with a single invariant: only delete `parent` when it is a proper subdirectory of `base_log_folder` (`base in parent.parents`). That covers both the direct-child case (`parent == base`) and the base-resolving case (`parent == base.parent`) at once, so `rmtree` can never touch `base_log_folder` or any directory above it.

As with #610, this is a very unlikely scenario in practice: real AF3 task log paths are always deeply nested, so `parent` is never `base` or above. The guard is arguably unnecessary today, but the downside if it ever triggered (wiping the log folder or its parent on the worker) is severe and the check is trivial, so it is worth keeping. Applied to 3.0.6, 3.2.1, and 3.3.1.

Testing: unit tests pass on all three images. **The change was also run against AutoSDE with no findings before raising this PR.**
