### PR TITLE
Sync Dockerfile.base with the Monaco bootstrap Step

### DIFF
--- a/images/airflow/3.2.1/Dockerfiles/Dockerfile.base
+++ b/images/airflow/3.2.1/Dockerfiles/Dockerfile.base
@@ -95,6 +95,12 @@ RUN chmod +x /bootstrap/02-airflow/001-install-required-pip-packages.sh
 USER airflow
 RUN /bootstrap/02-airflow/001-install-required-pip-packages.sh
 
+USER root
+COPY ./bootstrap/02-airflow/002-vendor-monaco-editor.sh /bootstrap/02-airflow/002-vendor-monaco-editor.sh
+RUN chmod +x /bootstrap/02-airflow/002-vendor-monaco-editor.sh
+USER airflow
+RUN /bootstrap/02-airflow/002-vendor-monaco-editor.sh
+
 # Revert the PATH and user.
 ENV PATH=${PATH_DEFAULT}
 USER root


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Follow-up to [the Monaco vendoring backport](https://github.com/aws/amazon-mwaa-docker-images/pull/540), which committed the `002-vendor-monaco-editor.sh` bootstrap script but not the regenerated Dockerfile. This adds that generated `Dockerfile.base` change. 

**This has no build-time effect**. `build.sh` runs `generate-dockerfiles.py` before every build, so the step already ships. This only keeps the committed Dockerfile in sync so `generate-dockerfiles.py` no longer leaves a dirty working tree when run locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
