### PR TITLE
Tolerate ProcessLookupError when sending SIGKILL after SIGTERM timeou…

### DIFF
--- a/images/airflow/2.11.2/python/mwaa/subprocess/subprocess.py
+++ b/images/airflow/2.11.2/python/mwaa/subprocess/subprocess.py
@@ -334,7 +334,13 @@ class Subprocess:
                 f"respond to SIGTERM after {sigterm_patience_interval_secs} "
                 "seconds. Sending SIGKILL..."
             )
-            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            try:
+                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                module_logger.info(
+                    f"Process group for {self} not found when sending SIGKILL. "
+                    "The process has already exited; skipping the kill."
+                )
             action_taken = "killed"
 
         module_logger.info(

--- a/tests/images/airflow/2.11.2/python/mwaa/subprocess/test_subprocess_shutdown_2_11_2.py
+++ b/tests/images/airflow/2.11.2/python/mwaa/subprocess/test_subprocess_shutdown_2_11_2.py
@@ -1,0 +1,68 @@
+"""Tests for the shutdown logic in mwaa.subprocess.subprocess."""
+import signal
+import subprocess as py_subprocess
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from mwaa.subprocess.subprocess import Subprocess
+
+
+def _make_subprocess_under_test():
+    sp = Subprocess.__new__(Subprocess)
+    sp.cmd = ["airflow", "celery", "worker"]
+    sp.friendly_name = "worker"
+    sp.name = 'Process "worker" (PID 12345)'
+    sp.sigterm_patience_interval = timedelta(seconds=0.01)
+    sp.process_logger = MagicMock()
+    return sp
+
+
+def _make_fake_process():
+    process = MagicMock()
+    process.pid = 12345
+    process.poll.return_value = None
+    process.returncode = None
+    process.communicate.side_effect = py_subprocess.TimeoutExpired(
+        cmd=["airflow", "celery", "worker"], timeout=0.01
+    )
+    return process
+
+
+def test_sigkill_fallback_tolerates_process_lookup_error():
+    """SIGKILL fallback must not raise when the process group is already gone."""
+    sp = _make_subprocess_under_test()
+    process = _make_fake_process()
+    sp.process = process
+
+    killpg_calls = []
+
+    def fake_killpg(pgid, sig):
+        killpg_calls.append(sig)
+        if sig == signal.SIGKILL:
+            raise ProcessLookupError(3, "No such process")
+
+    with patch("os.getpgid", return_value=12345), patch(
+        "os.killpg", side_effect=fake_killpg
+    ):
+        sp._shutdown_python_subprocess(process)
+
+    assert killpg_calls == [signal.SIGTERM, signal.SIGKILL]
+
+
+def test_sigkill_fallback_still_kills_live_process_group():
+    """SIGKILL fallback must still be issued when the process group is alive."""
+    sp = _make_subprocess_under_test()
+    process = _make_fake_process()
+    sp.process = process
+
+    killpg_calls = []
+
+    def fake_killpg(pgid, sig):
+        killpg_calls.append(sig)
+
+    with patch("os.getpgid", return_value=12345), patch(
+        "os.killpg", side_effect=fake_killpg
+    ):
+        sp._shutdown_python_subprocess(process)
+
+    assert killpg_calls == [signal.SIGTERM, signal.SIGKILL]


### PR DESCRIPTION
*Issue #, if available:*
+ When a worker with in-flight tasks is forcefully replaced, the tracked process can exit while orphaned child processes keep the stdout pipe open, causing communicate() to time out. The `SIGKILL` fallback then hits `ProcessLookupError` on the already-gone process group, which propagates up and makes the entrypoint exit non-zero, counting a successful shutdown as an ECS `TaskUnexpectedStop`. Since the goal of `SIGKILL` is to ensure termination, a missing process group means the goal is already achieved; log and skip instead of raising.

+ The issue is only affecting 2.11.2, so only making the change in this specific version.

+ **More details** about the issue and testing are documented in this doc: https://chorus.aws.dev/doc/fBbA5acyx0oY

*Description of changes:*
Do nothing when got `ProcessLookupError`.

*Testing*
+ Deployed to local, run active DAG during environment update, see the same `ProcessLookupError`, but no exit with non-zero status and no ECS `TaskUnexpectedStop` produced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
